### PR TITLE
feat(#2): State drift correction + open vents on cycle termination

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -352,7 +352,8 @@ async def create_thermostat(request: web.Request) -> web.Response:
     # Load defaults then apply body fields
     tc = await db.get_thermostat_config(conn, body["thermostat_entity_id"])
     for field in ("name", "default_temp", "min_setpoint", "max_setpoint", "deadband",
-                  "max_vent_closed_min", "min_open_vents", "overshoot_delta", "cycle_timeout_hours"):
+                  "max_vent_closed_min", "min_open_vents", "overshoot_delta", "cycle_timeout_hours",
+                  "reconciliation_interval_min"):
         if field in body:
             setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -372,6 +373,7 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "name", "default_temp",
         "min_setpoint", "max_setpoint", "deadband", "max_vent_closed_min",
         "min_open_vents", "overshoot_delta", "cycle_timeout_hours",
+        "reconciliation_interval_min",
     ):
         if field in body:
             setattr(tc, field, body[field])

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -157,6 +157,7 @@ _MIGRATIONS = [
     "ALTER TABLE rooms ADD COLUMN temp_offset REAL NOT NULL DEFAULT 0.0",
     "ALTER TABLE thermostat_configs ADD COLUMN name TEXT NOT NULL DEFAULT ''",
     "ALTER TABLE thermostat_configs ADD COLUMN default_temp REAL",
+    "ALTER TABLE thermostat_configs ADD COLUMN reconciliation_interval_min INTEGER NOT NULL DEFAULT 0",
 ]
 
 
@@ -391,6 +392,7 @@ def _row_to_tc(row) -> ThermostatConfig:
         min_open_vents=row["min_open_vents"],
         overshoot_delta=row["overshoot_delta"],
         cycle_timeout_hours=row["cycle_timeout_hours"],
+        reconciliation_interval_min=int(row["reconciliation_interval_min"] or 0),
     )
 
 
@@ -398,8 +400,9 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
     await conn.execute(
         """INSERT INTO thermostat_configs
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
-            max_vent_closed_min,min_open_vents,overshoot_delta,cycle_timeout_hours)
-           VALUES(?,?,?,?,?,?,?,?,?,?)
+            max_vent_closed_min,min_open_vents,overshoot_delta,cycle_timeout_hours,
+            reconciliation_interval_min)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -409,12 +412,14 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              max_vent_closed_min=excluded.max_vent_closed_min,
              min_open_vents=excluded.min_open_vents,
              overshoot_delta=excluded.overshoot_delta,
-             cycle_timeout_hours=excluded.cycle_timeout_hours
+             cycle_timeout_hours=excluded.cycle_timeout_hours,
+             reconciliation_interval_min=excluded.reconciliation_interval_min
         """,
         (
             tc.thermostat_entity_id, tc.name, tc.default_temp,
             tc.min_setpoint, tc.max_setpoint, tc.deadband,
             tc.max_vent_closed_min, tc.min_open_vents, tc.overshoot_delta, tc.cycle_timeout_hours,
+            tc.reconciliation_interval_min,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -72,6 +72,12 @@ class CycleEngine:
         self._room_vents: dict[str, list[RoomVent]] = {}  # room_id → vents
         self._lock = asyncio.Lock()
 
+        # Last setpoint value successfully sent to HA; used by reconciliation to
+        # detect external changes to the thermostat setpoint.
+        self._last_setpoint_sent: Optional[float] = None
+        # Timestamp of the last reconciliation run; None = never reconciled.
+        self._last_reconciled_at: Optional[datetime] = None
+
     # ------------------------------------------------------------------
     # Public
     # ------------------------------------------------------------------
@@ -150,6 +156,10 @@ class CycleEngine:
         if not new_active_map:
             if self._state != CycleState.IDLE:
                 await self._abort_cycle(conn, reason="no active rooms")
+            # IDLE reconciliation: ensure all zone vents are open even when no
+            # rooms are scheduled. Only runs when system is enabled.
+            if self._get_enabled is None or self._get_enabled():
+                await self._maybe_reconcile(conn)
             return
 
         # Check thermostat availability (safety check always runs, even when disabled)
@@ -204,6 +214,7 @@ class CycleEngine:
                     )
                 await self._terminate_cycle(conn)
 
+        await self._maybe_reconcile(conn)
         await self._maybe_broadcast()
 
     async def _start_or_update_cycle(
@@ -389,6 +400,7 @@ class CycleEngine:
                     await self._ha.set_thermostat_temperature(
                         self.thermostat_entity_id, clamped
                     )
+                    self._last_setpoint_sent = clamped
                     if self._logger:
                         await self._logger.log(
                             "info", "engine",
@@ -402,11 +414,26 @@ class CycleEngine:
         if self._cycle_log:
             await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
 
+        # Capture all zone vents before clearing state so we can re-open them.
+        # Vents are closed as rooms hit target during the cycle; on termination
+        # they should all return to open (idle state = vents open).
+        all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
+
         self._state = CycleState.IDLE
         self._cycle_log = None
         self._active_rooms = {}
         self._room_cycle_states = {}
         self._room_vents = {}
+
+        if all_zone_vents:
+            log.info("Cycle complete — re-opening all zone vents for %s", self.thermostat_entity_id)
+            await self._vent.open_room_vents(all_zone_vents)
+            if self._logger:
+                await self._logger.log(
+                    "info", "engine",
+                    f"Cycle complete for {self.thermostat_entity_id} — all zone vents re-opened",
+                    {"thermostat": self.thermostat_entity_id},
+                )
 
     async def _abort_cycle(
         self,
@@ -506,6 +533,8 @@ class CycleEngine:
         clamped = max(tc.min_setpoint, min(tc.max_setpoint, setpoint))
         try:
             await self._ha.set_thermostat_temperature(self.thermostat_entity_id, clamped)
+            # Track what we last commanded so reconciliation can detect external drift.
+            self._last_setpoint_sent = clamped
             if self._logger:
                 await self._logger.log(
                     "info", "engine",
@@ -515,6 +544,125 @@ class CycleEngine:
                 )
         except Exception as exc:
             log.error("Failed to set thermostat setpoint: %s", exc)
+
+    async def _maybe_reconcile(self, conn: aiosqlite.Connection) -> None:
+        """Check whether it is time to reconcile and, if so, call _reconcile_state."""
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+        if tc.reconciliation_interval_min <= 0:
+            return
+        now = datetime.utcnow()
+        interval_secs = tc.reconciliation_interval_min * 60
+        if (
+            self._last_reconciled_at is None
+            or (now - self._last_reconciled_at).total_seconds() >= interval_secs
+        ):
+            await self._reconcile_state(conn, tc)
+            self._last_reconciled_at = now
+
+    async def _reconcile_state(
+        self, conn: aiosqlite.Connection, tc: "ThermostatConfig"
+    ) -> None:
+        """
+        Verify actual vent and thermostat state matches engine intent; correct any drift.
+
+        RUNNING: each active room's vents should be open when vent_closed_at is None,
+                 closed when vent_closed_at is set. Thermostat setpoint is checked
+                 against _last_setpoint_sent.
+        IDLE:    all zone vents should be open — no active cycle means nothing should
+                 be closed. Loads vents fresh from DB since _room_vents is cleared.
+
+        All corrections are logged as 'warning' under category 'reconcile'.
+        """
+        if self._state == CycleState.RUNNING:
+            all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
+            for room_id, ar in self._active_rooms.items():
+                rcs = self._room_cycle_states.get(room_id)
+                vents = self._room_vents.get(room_id, [])
+                if not vents or rcs is None:
+                    continue
+                should_be_closed = rcs.vent_closed_at is not None
+                for vent in vents:
+                    actual_open = self._vent._is_open(vent.entity_id)
+                    if should_be_closed and actual_open:
+                        # External actor opened a vent that the engine closed — re-close.
+                        closed = await self._vent.close_room_vents(
+                            [vent], all_zone_vents, tc, self._room_cycle_states
+                        )
+                        if closed:
+                            log.warning(
+                                "Reconcile: vent %s should be closed — re-closing (external change detected)",
+                                vent.entity_id,
+                            )
+                            if self._logger:
+                                await self._logger.log(
+                                    "warning", "reconcile",
+                                    f"Drift: vent {vent.entity_id} found open but should be closed — re-closed",
+                                    {"entity_id": vent.entity_id, "room_id": room_id,
+                                     "thermostat": self.thermostat_entity_id},
+                                )
+                    elif not should_be_closed and not actual_open:
+                        # External actor closed a vent that the engine opened — re-open.
+                        await self._vent.open_room_vents([vent])
+                        log.warning(
+                            "Reconcile: vent %s should be open — re-opening (external change detected)",
+                            vent.entity_id,
+                        )
+                        if self._logger:
+                            await self._logger.log(
+                                "warning", "reconcile",
+                                f"Drift: vent {vent.entity_id} found closed but should be open — re-opened",
+                                {"entity_id": vent.entity_id, "room_id": room_id,
+                                 "thermostat": self.thermostat_entity_id},
+                            )
+
+            # Check thermostat setpoint drift.
+            if self._last_setpoint_sent is not None:
+                thermo_state = self._ha.get_state(self.thermostat_entity_id)
+                if thermo_state:
+                    current_sp = thermo_state.get("attributes", {}).get("temperature")
+                    if current_sp is not None:
+                        drift = abs(float(current_sp) - self._last_setpoint_sent)
+                        if drift > 0.1:  # tolerance for float rounding in HA
+                            log.warning(
+                                "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
+                                self.thermostat_entity_id, current_sp, self._last_setpoint_sent,
+                            )
+                            if self._logger:
+                                await self._logger.log(
+                                    "warning", "reconcile",
+                                    f"Drift: thermostat {self.thermostat_entity_id} setpoint changed "
+                                    f"from {self._last_setpoint_sent:.1f}°F to {float(current_sp):.1f}°F "
+                                    f"— re-asserting",
+                                    {"entity_id": self.thermostat_entity_id,
+                                     "expected": self._last_setpoint_sent,
+                                     "actual": float(current_sp)},
+                                )
+                            try:
+                                await self._ha.set_thermostat_temperature(
+                                    self.thermostat_entity_id, self._last_setpoint_sent
+                                )
+                            except Exception as exc:
+                                log.error("Reconcile: failed to re-assert setpoint: %s", exc)
+
+        else:
+            # IDLE — all zone vents should be open; load fresh from DB.
+            rooms = await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id)
+            for room in rooms:
+                vents = await db.get_room_vents(conn, room.id)
+                for vent in vents:
+                    if not self._vent._is_open(vent.entity_id):
+                        await self._vent.open_room_vents([vent])
+                        log.warning(
+                            "Reconcile (idle): vent %s found closed while system idle — re-opening",
+                            vent.entity_id,
+                        )
+                        if self._logger:
+                            await self._logger.log(
+                                "warning", "reconcile",
+                                f"Drift (idle): vent {vent.entity_id} found closed while zone is idle — re-opened",
+                                {"entity_id": vent.entity_id, "room_id": room.id,
+                                 "thermostat": self.thermostat_entity_id},
+                            )
 
     async def _maybe_broadcast(self) -> None:
         if self._broadcast:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -107,6 +107,10 @@ class ThermostatConfig:
     min_open_vents: int = 1
     overshoot_delta: float = 2.0
     cycle_timeout_hours: float = 3.0
+    # How often (minutes) the engine re-checks actual vent/thermostat state against its
+    # intended state and corrects external changes (e.g. Flair app, manual HA overrides).
+    # 0 = disabled. Should not exceed cycle_timeout_hours * 60.
+    reconciliation_interval_min: int = 0
 
 
 @dataclass

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -41,6 +41,9 @@ export interface ThermostatConfig {
   min_open_vents: number;
   overshoot_delta: number;
   cycle_timeout_hours: number;
+  // 0 = disabled. How often (minutes) the engine re-checks vent/thermostat state
+  // against actual HA state and corrects external changes.
+  reconciliation_interval_min: number;
 }
 
 export interface ZoneStatus {

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -116,7 +116,7 @@ const LEVEL_COLORS: Record<string, string> = {
   error: "var(--red)",
 };
 
-const CATEGORIES = ["all", "system", "api", "engine", "presence", "ha"];
+const CATEGORIES = ["all", "system", "api", "engine", "presence", "ha", "dev", "reconcile"];
 
 function EventEntry({ entry }: { entry: EventLogEntry }) {
   const [expanded, setExpanded] = useState(false);

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -210,6 +210,35 @@ function ThermostatCard({
         ))}
       </div>
 
+      <hr className="divider" />
+
+      {/* Drift correction — rendered separately because max depends on cycle_timeout_hours */}
+      <div className="text-sm" style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}>
+        Drift correction
+      </div>
+      <div className="form-group" style={{ maxWidth: 280 }}>
+        <label className="form-label">Drift correction interval (min)</label>
+        <input
+          className="form-control"
+          type="number"
+          step="1"
+          min="0"
+          max={Math.floor(form.cycle_timeout_hours * 60)}
+          value={form.reconciliation_interval_min ?? 0}
+          onChange={e => {
+            const val = parseInt(e.target.value) || 0;
+            const maxVal = Math.floor(form.cycle_timeout_hours * 60);
+            setForm(f => ({ ...f, reconciliation_interval_min: Math.min(val, maxVal) }));
+          }}
+        />
+        <div className="form-hint">
+          How often (in minutes) the engine re-checks actual vent and thermostat state in Home
+          Assistant and corrects any external changes (e.g. from the Flair app or manual HA
+          overrides). Set to <strong>0</strong> to disable. Cannot exceed the cycle timeout
+          ({Math.floor(form.cycle_timeout_hours * 60)} min).
+        </div>
+      </div>
+
       <div style={{ marginTop: "1.25rem", display: "flex", alignItems: "center", gap: ".75rem" }}>
         <button className="btn btn-primary" onClick={save} disabled={saving}>
           {saving ? "Saving…" : "Save changes"}


### PR DESCRIPTION
## Summary
- Fixes vents staying closed after a cycle completes — they now re-open on termination
- Adds periodic drift correction: the engine re-checks actual HA state against its intent and corrects any external changes (Flair app, manual HA overrides)
- New `reconciliation_interval_min` thermostat setting with UI field and helper text
- `"reconcile"` and `"dev"` categories added to Live Feed filter

## Changes

### Backend
- **`_terminate_cycle`**: captures all zone vents before clearing state, re-opens them all after the cycle closes. Idle state = vents open.
- **`CycleEngine.__init__`**: adds `_last_setpoint_sent` (tracks last value sent to HA) and `_last_reconciled_at` (interval gating).
- **`_set_thermostat_setpoint`**: sets `_last_setpoint_sent` after every successful HA call.
- **`_maybe_reconcile`**: loads `tc`, checks interval, calls `_reconcile_state` and updates `_last_reconciled_at`.
- **`_reconcile_state`**: 
  - `RUNNING` — corrects drifted vent positions (respects `min_open_vents`) and re-asserts thermostat setpoint if HA reports a different value. Logs corrections as `warning/reconcile`.
  - `IDLE` — opens any zone vent found closed while no cycle is active.
- **`_do_tick`**: calls `_maybe_reconcile` at end of active path and in the no-active-rooms idle path.
- **`models.py`**: `ThermostatConfig.reconciliation_interval_min: int = 0`
- **`db.py`**: migration + read/write for new column
- **`routes.py`**: `reconciliation_interval_min` accepted in create and update thermostat handlers

### Frontend
- **`Thermostats.tsx`**: new "Drift correction interval" number input; max dynamically clamped to `cycle_timeout_hours * 60`; enforced client-side on change.
- **`api.ts`**: `ThermostatConfig` interface updated with `reconciliation_interval_min`
- **`Logs.tsx`**: `CATEGORIES` array gains `"dev"` and `"reconcile"`

## Test plan
- [ ] Manually close a vent in HA while a cycle is running — verify engine re-opens it after the configured interval (check `reconcile` category in Live Feed)
- [ ] Manually change thermostat setpoint in HA during a cycle — verify engine re-asserts original value
- [ ] Let a cycle complete naturally — verify all vents are open afterwards
- [ ] Set `reconciliation_interval_min = 0` — verify no reconcile log entries appear
- [ ] Confirm Thermostat Settings UI enforces the max = cycle_timeout * 60

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)