### PR TITLE
feat(#3): logging retention, time-window filtering, level filter, load more, clear logs

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -531,7 +531,10 @@ async def ha_entities(request: web.Request) -> web.Response:
 async def get_logs(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     limit = int(request.rel_url.query.get("limit", 50))
-    logs = await db.get_cycle_logs(conn, limit=limit)
+    offset = int(request.rel_url.query.get("offset", 0))
+    since = request.rel_url.query.get("since") or None
+    until = request.rel_url.query.get("until") or None
+    logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
     return json_response([
         {
             "id": l.id,
@@ -548,10 +551,55 @@ async def get_logs(request: web.Request) -> web.Response:
 @routes.get("/api/logs/events")
 async def get_event_logs(request: web.Request) -> web.Response:
     conn = await get_conn(request)
-    limit = int(request.rel_url.query.get("limit", 200))
+    limit = int(request.rel_url.query.get("limit", 100))
+    offset = int(request.rel_url.query.get("offset", 0))
     category = request.rel_url.query.get("category") or None
-    logs = await db.get_event_logs(conn, limit=limit, category=category)
+    since = request.rel_url.query.get("since") or None
+    until = request.rel_url.query.get("until") or None
+    level_param = request.rel_url.query.get("level") or None
+    levels = [lv.strip() for lv in level_param.split(",") if lv.strip()] if level_param else None
+    logs = await db.get_event_logs(
+        conn, limit=limit, offset=offset, category=category,
+        since=since, until=until, levels=levels,
+    )
     return json_response(logs)
+
+
+@routes.delete("/api/logs/events")
+async def clear_event_logs(request: web.Request) -> web.Response:
+    conn = await get_conn(request)
+    await db.clear_event_logs(conn)
+    await emit(request, "info", "system", "Event logs cleared by user")
+    return json_response({"cleared": True})
+
+
+@routes.get("/api/settings/log-retention")
+async def get_log_retention(request: web.Request) -> web.Response:
+    conn = await get_conn(request)
+    event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
+    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
+    return json_response({
+        "event_log_retention_days": event_days,
+        "cycle_log_retention_days": cycle_days,
+    })
+
+
+@routes.post("/api/settings/log-retention")
+async def set_log_retention(request: web.Request) -> web.Response:
+    conn = await get_conn(request)
+    body = await request.json()
+    if "event_log_retention_days" in body:
+        days = max(1, int(body["event_log_retention_days"]))
+        await db.set_system_setting(conn, "event_log_retention_days", str(days))
+    if "cycle_log_retention_days" in body:
+        days = max(1, int(body["cycle_log_retention_days"]))
+        await db.set_system_setting(conn, "cycle_log_retention_days", str(days))
+    event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
+    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
+    return json_response({
+        "event_log_retention_days": event_days,
+        "cycle_log_retention_days": cycle_days,
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from typing import Optional
 
 import aiosqlite
@@ -547,10 +547,25 @@ async def close_cycle_log(conn: aiosqlite.Connection, cycle_id: str, ended_at: d
 
 
 async def get_cycle_logs(
-    conn: aiosqlite.Connection, limit: int = 50
+    conn: aiosqlite.Connection,
+    limit: int = 50,
+    offset: int = 0,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
 ) -> list[CycleLog]:
+    conditions: list[str] = []
+    params: list = []
+    if since:
+        conditions.append("started_at >= ?")
+        params.append(since)
+    if until:
+        conditions.append("started_at <= ?")
+        params.append(until)
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params += [limit, offset]
     async with conn.execute(
-        "SELECT * FROM cycle_logs ORDER BY started_at DESC LIMIT ?", (limit,)
+        f"SELECT * FROM cycle_logs {where} ORDER BY started_at DESC LIMIT ? OFFSET ?",
+        params,
     ) as cur:
         rows = await cur.fetchall()
     return [
@@ -564,6 +579,17 @@ async def get_cycle_logs(
         )
         for r in rows
     ]
+
+
+async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
+    """Delete cycle logs older than N days. Returns number of rows deleted."""
+    cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+    async with conn.execute(
+        "DELETE FROM cycle_logs WHERE started_at < ?", (cutoff,)
+    ) as cur:
+        count = cur.rowcount or 0
+    await conn.commit()
+    return count
 
 
 async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleState) -> None:
@@ -663,15 +689,33 @@ async def insert_event_log(
 async def get_event_logs(
     conn: aiosqlite.Connection,
     limit: int = 200,
+    offset: int = 0,
     category: Optional[str] = None,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    levels: Optional[list[str]] = None,
 ) -> list[dict]:
+    conditions: list[str] = []
+    params: list = []
     if category:
-        sql = "SELECT * FROM event_log WHERE category=? ORDER BY id DESC LIMIT ?"
-        params = (category, limit)
-    else:
-        sql = "SELECT * FROM event_log ORDER BY id DESC LIMIT ?"
-        params = (limit,)
-    async with conn.execute(sql, params) as cur:
+        conditions.append("category=?")
+        params.append(category)
+    if since:
+        conditions.append("timestamp >= ?")
+        params.append(since)
+    if until:
+        conditions.append("timestamp <= ?")
+        params.append(until)
+    if levels:
+        placeholders = ",".join("?" * len(levels))
+        conditions.append(f"level IN ({placeholders})")
+        params.extend(levels)
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params += [limit, offset]
+    async with conn.execute(
+        f"SELECT * FROM event_log {where} ORDER BY id DESC LIMIT ? OFFSET ?",
+        params,
+    ) as cur:
         rows = await cur.fetchall()
     return [
         {
@@ -684,3 +728,20 @@ async def get_event_logs(
         }
         for r in rows
     ]
+
+
+async def purge_event_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
+    """Delete event logs older than N days. Returns number of rows deleted."""
+    cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+    async with conn.execute(
+        "DELETE FROM event_log WHERE timestamp < ?", (cutoff,)
+    ) as cur:
+        count = cur.rowcount or 0
+    await conn.commit()
+    return count
+
+
+async def clear_event_logs(conn: aiosqlite.Connection) -> None:
+    """Delete all event log rows (manual user-initiated clear)."""
+    await conn.execute("DELETE FROM event_log")
+    await conn.commit()

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -89,7 +89,19 @@ class Scheduler:
             max_instances=1,
             coalesce=True,
         )
+        self._apscheduler.add_job(
+            self._purge_old_logs,
+            "interval",
+            hours=24,
+            id="log_purge",
+            max_instances=1,
+            coalesce=True,
+        )
         self._apscheduler.start()
+
+        # Run purge immediately on startup to clean up before the first tick.
+        await self._purge_old_logs()
+
         log.info("Scheduler started (system_enabled=%s)", self._system_enabled)
 
     async def stop(self) -> None:
@@ -180,6 +192,26 @@ class Scheduler:
             if tid not in thermostat_ids:
                 del self._engines[tid]
                 log.info("CycleEngine removed for %s", tid)
+
+    # ------------------------------------------------------------------
+    # Log purge
+    # ------------------------------------------------------------------
+
+    async def _purge_old_logs(self) -> None:
+        """Delete event and cycle logs older than their configured retention periods."""
+        event_days = int(await db.get_system_setting(
+            self._db_conn, "event_log_retention_days", "7"
+        ))
+        cycle_days = int(await db.get_system_setting(
+            self._db_conn, "cycle_log_retention_days", "30"
+        ))
+        ev_count = await db.purge_event_logs(self._db_conn, event_days)
+        cy_count = await db.purge_cycle_logs(self._db_conn, cycle_days)
+        if ev_count or cy_count:
+            log.info(
+                "Log purge complete — removed %d event rows (>%dd), %d cycle rows (>%dd)",
+                ev_count, event_days, cy_count, cycle_days,
+            )
 
     # ------------------------------------------------------------------
     # Tick

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -202,13 +202,60 @@ export const deleteThermostat = (entity_id: string) =>
 // System
 // ---------------------------------------------------------------------------
 
+export interface LogRetentionSettings {
+  event_log_retention_days: number;
+  cycle_log_retention_days: number;
+}
+
+export interface EventLogParams {
+  limit?: number;
+  offset?: number;
+  category?: string;
+  since?: string;
+  until?: string;
+  levels?: string[];
+}
+
+export interface CycleLogParams {
+  limit?: number;
+  offset?: number;
+  since?: string;
+  until?: string;
+}
+
 export const getStatus = () => api<ZoneStatus[]>("/api/status");
-export const getLogs = (limit = 50) => api<CycleLog[]>(`/api/logs?limit=${limit}`);
-export const getEventLogs = (limit = 200, category?: string) => {
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (category) params.set("category", category);
-  return api<EventLogEntry[]>(`/api/logs/events?${params}`);
+
+export const getLogs = (params: CycleLogParams = {}) => {
+  const p = new URLSearchParams();
+  if (params.limit != null) p.set("limit", String(params.limit));
+  if (params.offset != null) p.set("offset", String(params.offset));
+  if (params.since) p.set("since", params.since);
+  if (params.until) p.set("until", params.until);
+  return api<CycleLog[]>(`/api/logs?${p}`);
 };
+
+export const getEventLogs = (params: EventLogParams = {}) => {
+  const p = new URLSearchParams();
+  if (params.limit != null) p.set("limit", String(params.limit));
+  if (params.offset != null) p.set("offset", String(params.offset));
+  if (params.category) p.set("category", params.category);
+  if (params.since) p.set("since", params.since);
+  if (params.until) p.set("until", params.until);
+  if (params.levels?.length) p.set("level", params.levels.join(","));
+  return api<EventLogEntry[]>(`/api/logs/events?${p}`);
+};
+
+export const clearEventLogs = () =>
+  api<{ cleared: boolean }>("/api/logs/events", { method: "DELETE" });
+
+export const getLogRetention = () =>
+  api<LogRetentionSettings>("/api/settings/log-retention");
+
+export const setLogRetention = (data: Partial<LogRetentionSettings>) =>
+  api<LogRetentionSettings>("/api/settings/log-retention", {
+    method: "POST", body: JSON.stringify(data),
+  });
+
 export const getSystemStatus = () => api<SystemStatus>("/api/system/status");
 export const setSystemEnabled = (enabled: boolean) =>
   api<SystemStatus>("/api/system/enabled", { method: "POST", body: JSON.stringify({ enabled }) });

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -1,5 +1,116 @@
 import { useEffect, useRef, useState } from "react";
-import { getLogs, getEventLogs, connectWS, type CycleLog, type EventLogEntry } from "../api";
+import {
+  getLogs, getEventLogs, clearEventLogs, getLogRetention, setLogRetention,
+  connectWS,
+  type CycleLog, type EventLogEntry, type LogRetentionSettings,
+} from "../api";
+
+// ---------------------------------------------------------------------------
+// Shared: time-window helpers
+// ---------------------------------------------------------------------------
+
+type TimePreset = "1h" | "6h" | "24h" | "7d" | "custom";
+
+const PRESETS: { label: string; value: TimePreset }[] = [
+  { label: "1h",  value: "1h"  },
+  { label: "6h",  value: "6h"  },
+  { label: "24h", value: "24h" },
+  { label: "7d",  value: "7d"  },
+  { label: "Custom", value: "custom" },
+];
+
+function presetToSince(preset: TimePreset): string | undefined {
+  if (preset === "custom") return undefined;
+  const ms: Record<string, number> = { "1h": 1, "6h": 6, "24h": 24, "7d": 168 };
+  const d = new Date();
+  d.setHours(d.getHours() - ms[preset]);
+  return d.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Shared: confirmation modal
+// ---------------------------------------------------------------------------
+
+function ConfirmModal({
+  title,
+  message,
+  confirmLabel = "Confirm",
+  onConfirm,
+  onCancel,
+}: {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onCancel()}>
+      <div className="modal" style={{ maxWidth: 440 }}>
+        <div className="modal-title">{title}</div>
+        <p style={{ color: "var(--gray-700)", marginBottom: "1.5rem" }}>{message}</p>
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onCancel}>Cancel</button>
+          <button className="btn btn-danger" onClick={onConfirm}>{confirmLabel}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared: time-window controls
+// ---------------------------------------------------------------------------
+
+function TimeWindowControls({
+  preset,
+  customFrom,
+  customTo,
+  onPreset,
+  onCustomFrom,
+  onCustomTo,
+}: {
+  preset: TimePreset;
+  customFrom: string;
+  customTo: string;
+  onPreset: (p: TimePreset) => void;
+  onCustomFrom: (v: string) => void;
+  onCustomTo: (v: string) => void;
+}) {
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: ".4rem", alignItems: "center" }}>
+      <span className="text-sm text-muted" style={{ marginRight: ".25rem" }}>Window:</span>
+      {PRESETS.map(p => (
+        <button
+          key={p.value}
+          className={`btn btn-sm ${preset === p.value ? "btn-primary" : "btn-secondary"}`}
+          onClick={() => onPreset(p.value)}
+        >
+          {p.label}
+        </button>
+      ))}
+      {preset === "custom" && (
+        <>
+          <input
+            type="datetime-local"
+            className="form-control form-control-sm"
+            style={{ width: "auto" }}
+            value={customFrom}
+            onChange={e => onCustomFrom(e.target.value)}
+          />
+          <span className="text-sm text-muted">to</span>
+          <input
+            type="datetime-local"
+            className="form-control form-control-sm"
+            style={{ width: "auto" }}
+            value={customTo}
+            onChange={e => onCustomTo(e.target.value)}
+          />
+        </>
+      )}
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Cycle History tab
@@ -50,49 +161,65 @@ function LogRow({ log }: { log: CycleLog }) {
   );
 }
 
+const PAGE_SIZE = 50;
+
 function CycleHistory() {
   const [logs, setLogs] = useState<CycleLog[]>([]);
   const [loading, setLoading] = useState(true);
-  const [limit, setLimit] = useState(50);
+  const [hasMore, setHasMore] = useState(false);
+  const [offset, setOffset] = useState(0);
 
-  const load = async () => {
+  const [preset, setPreset] = useState<TimePreset>("24h");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+
+  const buildParams = (currentOffset: number) => {
+    const since = preset !== "custom" ? presetToSince(preset) : (customFrom ? new Date(customFrom).toISOString() : undefined);
+    const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
+    return { limit: PAGE_SIZE, offset: currentOffset, since, until };
+  };
+
+  const load = async (reset = false) => {
     setLoading(true);
-    const l = await getLogs(limit);
-    setLogs(l);
+    const nextOffset = reset ? 0 : offset;
+    const rows = await getLogs(buildParams(nextOffset));
+    if (reset) {
+      setLogs(rows);
+      setOffset(rows.length);
+    } else {
+      setLogs(prev => [...prev, ...rows]);
+      setOffset(prev => prev + rows.length);
+    }
+    setHasMore(rows.length === PAGE_SIZE);
     setLoading(false);
   };
 
-  useEffect(() => { load(); }, [limit]);
-
-  if (loading) return <div className="loading"><div className="spinner" /> Loading logs…</div>;
+  useEffect(() => { load(true); }, [preset, customFrom, customTo]);
 
   return (
     <div>
-      <div style={{ display: "flex", justifyContent: "flex-end", gap: ".5rem", marginBottom: "1rem" }}>
-        <select className="form-control form-control-sm" value={limit} onChange={e => setLimit(Number(e.target.value))}>
-          <option value={20}>Last 20</option>
-          <option value={50}>Last 50</option>
-          <option value={100}>Last 100</option>
-        </select>
-        <button className="btn btn-secondary" onClick={load}>↻ Refresh</button>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: "1rem", alignItems: "center" }}>
+        <TimeWindowControls
+          preset={preset} customFrom={customFrom} customTo={customTo}
+          onPreset={p => { setPreset(p); }}
+          onCustomFrom={setCustomFrom}
+          onCustomTo={setCustomTo}
+        />
+        <button className="btn btn-secondary btn-sm" onClick={() => load(true)}>↻ Refresh</button>
       </div>
 
-      {logs.length === 0 ? (
-        <div className="card"><div className="empty-state"><p>No cycle logs yet. Cycles will appear here once the system starts running.</p></div></div>
+      {loading && logs.length === 0 ? (
+        <div className="loading"><div className="spinner" /> Loading logs…</div>
+      ) : logs.length === 0 ? (
+        <div className="card"><div className="empty-state"><p>No cycle logs in this time window.</p></div></div>
       ) : (
         <div className="card">
           <div className="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th>ID</th>
-                  <th>Thermostat</th>
-                  <th>Mode</th>
-                  <th>Started</th>
-                  <th>Ended</th>
-                  <th>Duration</th>
-                  <th>Rooms</th>
-                  <th></th>
+                  <th>ID</th><th>Thermostat</th><th>Mode</th>
+                  <th>Started</th><th>Ended</th><th>Duration</th><th>Rooms</th><th></th>
                 </tr>
               </thead>
               <tbody>
@@ -100,6 +227,13 @@ function CycleHistory() {
               </tbody>
             </table>
           </div>
+          {hasMore && (
+            <div style={{ padding: ".75rem 1rem", borderTop: "1px solid var(--gray-200)" }}>
+              <button className="btn btn-secondary btn-sm" onClick={() => load(false)} disabled={loading}>
+                {loading ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -117,6 +251,7 @@ const LEVEL_COLORS: Record<string, string> = {
 };
 
 const CATEGORIES = ["all", "system", "api", "engine", "presence", "ha", "dev", "reconcile"];
+const ALL_LEVELS = ["info", "warning", "error"];
 
 function EventEntry({ entry }: { entry: EventLogEntry }) {
   const [expanded, setExpanded] = useState(false);
@@ -144,44 +279,108 @@ function EventEntry({ entry }: { entry: EventLogEntry }) {
 function LiveFeed() {
   const [entries, setEntries] = useState<EventLogEntry[]>([]);
   const [category, setCategory] = useState("all");
+  const [levels, setLevels] = useState<string[]>(ALL_LEVELS);
   const [paused, setPaused] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [showClearModal, setShowClearModal] = useState(false);
+  const [clearing, setClearing] = useState(false);
+
+  const [preset, setPreset] = useState<TimePreset>("1h");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+
   const bottomRef = useRef<HTMLDivElement>(null);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
 
-  // Initial load
-  useEffect(() => {
-    getEventLogs(200, category === "all" ? undefined : category)
-      .then(data => { setEntries(data.reverse()); setLoading(false); })
-      .catch(() => setLoading(false));
-  }, [category]);
+  const buildParams = (currentOffset: number) => {
+    const since = preset !== "custom" ? presetToSince(preset) : (customFrom ? new Date(customFrom).toISOString() : undefined);
+    const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
+    return {
+      limit: PAGE_SIZE,
+      offset: currentOffset,
+      category: category !== "all" ? category : undefined,
+      since,
+      until,
+      levels: levels.length < ALL_LEVELS.length ? levels : undefined,
+    };
+  };
 
-  // WebSocket subscription for new events
+  const load = async (reset = false) => {
+    setLoading(true);
+    const nextOffset = reset ? 0 : offset;
+    const rows = await getEventLogs(buildParams(nextOffset));
+    // API returns newest-first; reverse so feed shows oldest-at-top
+    const ordered = [...rows].reverse();
+    if (reset) {
+      setEntries(ordered);
+      setOffset(rows.length);
+    } else {
+      // Load more appends older entries at the top
+      setEntries(prev => [...ordered, ...prev]);
+      setOffset(prev => prev + rows.length);
+    }
+    setHasMore(rows.length === PAGE_SIZE);
+    setLoading(false);
+  };
+
+  useEffect(() => { load(true); }, [category, levels, preset, customFrom, customTo]);
+
+  // WebSocket: append new events in real time (unless paused or filtered out)
   useEffect(() => {
     const cleanup = connectWS((event) => {
       if (event.type === "log_event" && !pausedRef.current) {
         const entry = event.data as unknown as EventLogEntry;
-        if (category === "all" || entry.category === category) {
+        const catOk = category === "all" || entry.category === category;
+        const lvlOk = levels.includes(entry.level);
+        if (catOk && lvlOk) {
           setEntries(prev => [...prev.slice(-499), entry]);
         }
       }
     });
     return cleanup;
-  }, [category]);
+  }, [category, levels]);
 
-  // Auto-scroll to bottom when entries change (unless paused)
+  // Auto-scroll to bottom when entries change
   useEffect(() => {
-    if (!paused) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
+    if (!paused) bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [entries, paused]);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading events…</div>;
+  const toggleLevel = (lv: string) =>
+    setLevels(prev => prev.includes(lv) ? prev.filter(l => l !== lv) : [...prev, lv]);
+
+  const handleClear = async () => {
+    setClearing(true);
+    try {
+      await clearEventLogs();
+      setEntries([]);
+      setOffset(0);
+      setHasMore(false);
+    } finally {
+      setClearing(false);
+      setShowClearModal(false);
+    }
+  };
+
+  if (loading && entries.length === 0) {
+    return <div className="loading"><div className="spinner" /> Loading events…</div>;
+  }
 
   return (
     <div>
-      <div style={{ display: "flex", gap: ".5rem", marginBottom: ".75rem", alignItems: "center" }}>
+      {/* Filter bar */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: ".75rem", alignItems: "center" }}>
+        <TimeWindowControls
+          preset={preset} customFrom={customFrom} customTo={customTo}
+          onPreset={p => { setPreset(p); }}
+          onCustomFrom={setCustomFrom}
+          onCustomTo={setCustomTo}
+        />
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: ".75rem", alignItems: "center" }}>
+        {/* Category */}
         <select
           className="form-control form-control-sm"
           value={category}
@@ -189,22 +388,148 @@ function LiveFeed() {
         >
           {CATEGORIES.map(c => <option key={c} value={c}>{c === "all" ? "All categories" : c}</option>)}
         </select>
-        <button
-          className={`btn ${paused ? "btn-primary" : "btn-secondary"}`}
-          onClick={() => setPaused(p => !p)}
-        >
-          {paused ? "▶ Resume" : "⏸ Pause"}
-        </button>
-        <span className="text-sm text-muted">{entries.length} events</span>
+
+        {/* Level toggles */}
+        <span className="text-sm text-muted">Levels:</span>
+        {ALL_LEVELS.map(lv => (
+          <button
+            key={lv}
+            className={`btn btn-sm ${levels.includes(lv) ? "btn-primary" : "btn-secondary"}`}
+            style={{ color: levels.includes(lv) ? undefined : "var(--gray-500)" }}
+            onClick={() => toggleLevel(lv)}
+          >
+            {lv}
+          </button>
+        ))}
+
+        <div style={{ marginLeft: "auto", display: "flex", gap: ".5rem", alignItems: "center" }}>
+          <span className="text-sm text-muted">{entries.length} events</span>
+          <button
+            className={`btn btn-sm ${paused ? "btn-primary" : "btn-secondary"}`}
+            onClick={() => setPaused(p => !p)}
+          >
+            {paused ? "▶ Resume" : "⏸ Pause"}
+          </button>
+          <button
+            className="btn btn-sm btn-danger"
+            onClick={() => setShowClearModal(true)}
+            disabled={clearing}
+          >
+            Clear logs
+          </button>
+        </div>
       </div>
+
+      {/* Load more (older entries) */}
+      {hasMore && (
+        <div style={{ marginBottom: ".5rem" }}>
+          <button className="btn btn-secondary btn-sm" onClick={() => load(false)} disabled={loading}>
+            {loading ? "Loading…" : "Load older entries"}
+          </button>
+        </div>
+      )}
 
       <div className="card event-feed">
         {entries.length === 0 ? (
-          <div className="empty-state"><p>No events yet. Events will appear here in real time.</p></div>
+          <div className="empty-state"><p>No events in this time window.</p></div>
         ) : (
           entries.map((e, i) => <EventEntry key={e.id ?? i} entry={e} />)
         )}
         <div ref={bottomRef} />
+      </div>
+
+      {showClearModal && (
+        <ConfirmModal
+          title="Clear all event logs?"
+          message="This will permanently delete all event log entries from the database. This action cannot be undone."
+          confirmLabel="Clear all logs"
+          onConfirm={handleClear}
+          onCancel={() => setShowClearModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Retention settings tab
+// ---------------------------------------------------------------------------
+
+function RetentionSettings() {
+  const [form, setForm] = useState<LogRetentionSettings>({
+    event_log_retention_days: 7,
+    cycle_log_retention_days: 30,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getLogRetention().then(data => { setForm(data); setLoading(false); }).catch(() => setLoading(false));
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const updated = await setLogRetention(form);
+      setForm(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div className="loading"><div className="spinner" /> Loading settings…</div>;
+
+  return (
+    <div className="card" style={{ maxWidth: 560 }}>
+      <div className="card-title" style={{ marginBottom: ".25rem" }}>Log Retention</div>
+      <p className="text-sm text-muted" style={{ marginBottom: "1.5rem" }}>
+        Configure how long log data is kept. The scheduler runs a purge daily and on each startup.
+      </p>
+
+      {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+
+      <div className="form-group">
+        <label className="form-label">Event log retention (days)</label>
+        <input
+          className="form-control"
+          type="number"
+          min="1"
+          value={form.event_log_retention_days}
+          onChange={e => setForm(f => ({ ...f, event_log_retention_days: Math.max(1, parseInt(e.target.value) || 1) }))}
+        />
+        <div className="form-hint">
+          Event logs capture every engine action, vent movement, presence event, and state change.
+          High volume — recommended 7 days. Older rows are deleted automatically.
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Cycle history retention (days)</label>
+        <input
+          className="form-control"
+          type="number"
+          min="1"
+          value={form.cycle_log_retention_days}
+          onChange={e => setForm(f => ({ ...f, cycle_log_retention_days: Math.max(1, parseInt(e.target.value) || 1) }))}
+        />
+        <div className="form-hint">
+          Cycle history records one entry per HVAC cycle (start/stop, rooms, duration).
+          Much lower volume than event logs — safe to keep for 30+ days.
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: ".75rem", alignItems: "center" }}>
+        <button className="btn btn-primary" onClick={save} disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {saved && <span className="badge badge-green">Saved!</span>}
       </div>
     </div>
   );
@@ -215,28 +540,31 @@ function LiveFeed() {
 // ---------------------------------------------------------------------------
 
 export default function Logs() {
-  const [tab, setTab] = useState<"history" | "feed">("feed");
+  const [tab, setTab] = useState<"feed" | "history" | "retention">("feed");
 
   return (
     <div>
       <div className="page-header">
         <div>
           <div className="page-title">Logs</div>
-          <div className="page-subtitle">Cycle history and live event feed</div>
+          <div className="page-subtitle">Cycle history, live event feed, and retention settings</div>
         </div>
         <div className="tab-bar">
-          <button
-            className={`tab-btn ${tab === "feed" ? "active" : ""}`}
-            onClick={() => setTab("feed")}
-          >Live Feed</button>
-          <button
-            className={`tab-btn ${tab === "history" ? "active" : ""}`}
-            onClick={() => setTab("history")}
-          >Cycle History</button>
+          <button className={`tab-btn ${tab === "feed" ? "active" : ""}`} onClick={() => setTab("feed")}>
+            Live Feed
+          </button>
+          <button className={`tab-btn ${tab === "history" ? "active" : ""}`} onClick={() => setTab("history")}>
+            Cycle History
+          </button>
+          <button className={`tab-btn ${tab === "retention" ? "active" : ""}`} onClick={() => setTab("retention")}>
+            Retention
+          </button>
         </div>
       </div>
 
-      {tab === "history" ? <CycleHistory /> : <LiveFeed />}
+      {tab === "feed" && <LiveFeed />}
+      {tab === "history" && <CycleHistory />}
+      {tab === "retention" && <RetentionSettings />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #3

### Backend
- `db.py`: `get_event_logs` / `get_cycle_logs` now accept `offset`, `since`, `until`, `levels` params for filtering and pagination; added `purge_event_logs`, `purge_cycle_logs`, `clear_event_logs`
- `routes.py`: new `GET/POST /api/settings/log-retention` endpoints; `DELETE /api/logs/events` to clear all event logs; updated existing log endpoints to pass through new filter params
- `scheduler.py`: daily APScheduler purge job (runs at startup + every 24h) reading retention periods from `system_settings`

### Frontend
- `api.ts`: `LogRetentionSettings`, `EventLogParams`, `CycleLogParams` types; `clearEventLogs`, `getLogRetention`, `setLogRetention` functions; `getLogs`/`getEventLogs` updated to accept param objects
- `Logs.tsx` complete rewrite — 3 tabs:
  - **Live Feed**: time window presets (1h / 6h / 24h / 7d / Custom datetime-local), independent multi-select level filter chips (info / warning / error), category dropdown, offset-based "Load more" pagination, clear-logs button with `ConfirmModal` (no browser `alert()`)
  - **Cycle History**: same time window controls, Load more pagination
  - **Retention**: separate configurable retention periods for high-volume event logs and low-volume cycle history, with helper text explaining the difference

## Test plan
- [ ] Event log level filter chips work independently (multi-select, any combination)
- [ ] Time window presets update the feed instantly; custom range picker works
- [ ] "Load more" appends the next page without resetting existing entries
- [ ] Clear logs button shows `ConfirmModal`, cancelling does nothing, confirming clears and refreshes
- [ ] Retention settings save and persist across page reload
- [ ] Daily purge fires on startup and removes rows older than configured retention
- [ ] `GET /api/logs/events?level=warning,error` returns only matching levels
- [ ] `GET /api/logs/events?since=...&until=...` filters by time window

🤖 Generated with [Claude Code](https://claude.com/claude-code)