### PR TITLE
feat(#8): CHANGELOG.md, v0.4.0 version bump, tag-triggered release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,17 @@
 name: Build & Push Docker Image
 
+# Triggers:
+#   pull_request → main : build-only validation (no push, no credentials)
+#   push → main         : build + push :latest and :<version from config.yaml>
+#
+# NOTE: v* tags no longer trigger this workflow directly. The release-pr.yml
+# workflow handles tag events by creating a release PR. Once that PR is merged
+# to main, this workflow publishes the versioned image.
+
 on:
   push:
     branches:
       - main
-    tags:
-      - "v*.*.*"
   pull_request:
     branches:
       - main
@@ -44,11 +50,14 @@ jobs:
           cache-to: type=gha,mode=max
 
   # -----------------------------------------------------------------------
-  # Main / tag publish: build and push to GHCR.
-  # Only runs on pushes to main or semver tags — never on pull_request events.
+  # Main publish: build and push to GHCR.
+  # Pushes two tags:
+  #   :latest         — always, on every merge to main
+  #   :<version>      — read from smart_vent/config.yaml (e.g. "0.4.0")
+  # Only runs on pushes to main — never on pull_request events.
   # -----------------------------------------------------------------------
   build-and-push:
-    name: Build & Push (main / release)
+    name: Build & Push (main release)
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -58,6 +67,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Read version from config.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' smart_vent/config.yaml \
+            | sed 's/version:[[:space:]]*//' \
+            | tr -d '"')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building image version: ${VERSION}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -75,13 +93,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # latest on every main push
-            type=raw,value=latest,enable={{is_default_branch}}
-            # short commit SHA
-            type=sha,prefix=sha-
-            # semver tags: v1.2.3 → 1.2.3, 1.2, 1
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.version }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,208 @@
+name: Create Release PR
+
+# Triggered when a semver tag is pushed (e.g. git tag v0.4.0 && git push --tags).
+# This workflow:
+#   1. Derives the version from the tag
+#   2. Finds the previous release tag to bound the changelog range
+#   3. Generates changelog bullets from merged PRs in that range
+#   4. Lists unique contributors for the range
+#   5. Prepends a new section to CHANGELOG.md
+#   6. Bumps version in smart_vent/config.yaml
+#   7. Opens a PR "Release vX.Y.Z" → main for review
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history and all tags so git log ranges work correctly
+          fetch-depth: 0
+
+      - name: Derive version and previous tag
+        id: versions
+        run: |
+          TAG="${GITHUB_REF_NAME}"                      # e.g. v0.4.0
+          VERSION="${TAG#v}"                            # e.g. 0.4.0
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Find the most recent tag that is strictly older than this one
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            # No previous tag — use the initial commit
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+            echo "prev_is_sha=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prev_is_sha=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION}, Previous boundary: ${PREV_TAG}"
+
+      - name: Generate changelog entries
+        id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREV_TAG: ${{ steps.versions.outputs.prev_tag }}
+          VERSION: ${{ steps.versions.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          # --- Collect PR numbers from commit messages in range ---
+          PR_NUMS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"%s" \
+            | grep -oE '#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -un)
+
+          echo "PRs found: ${PR_NUMS}"
+
+          # --- Build bullet list from PR titles ---
+          BULLETS=""
+          for NUM in $PR_NUMS; do
+            # Try to fetch PR info; skip if it's actually an issue number (no PR)
+            PR_JSON=$(gh pr view "$NUM" --repo "$REPO" \
+              --json number,title,url,closingIssuesReferences 2>/dev/null || echo "")
+            if [ -z "$PR_JSON" ]; then
+              continue
+            fi
+
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+            PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+
+            # Build issue links from closing references
+            ISSUE_LINKS=""
+            ISSUE_REFS=$(echo "$PR_JSON" | jq -r '.closingIssuesReferences[]?.number' 2>/dev/null || echo "")
+            for INUM in $ISSUE_REFS; do
+              ISSUE_URL="https://github.com/${REPO}/issues/${INUM}"
+              if [ -n "$ISSUE_LINKS" ]; then
+                ISSUE_LINKS="${ISSUE_LINKS}, [#${INUM}](${ISSUE_URL})"
+              else
+                ISSUE_LINKS="[#${INUM}](${ISSUE_URL})"
+              fi
+            done
+
+            if [ -n "$ISSUE_LINKS" ]; then
+              BULLETS="${BULLETS}- ${PR_TITLE} (${ISSUE_LINKS}, [#${PR_NUM}](${PR_URL}))\n"
+            else
+              BULLETS="${BULLETS}- ${PR_TITLE} ([#${PR_NUM}](${PR_URL}))\n"
+            fi
+          done
+
+          # Fallback if no PRs were found
+          if [ -z "$BULLETS" ]; then
+            BULLETS="- Miscellaneous improvements and fixes\n"
+          fi
+
+          # --- Collect unique contributors ---
+          CONTRIBUTORS=$(git log "${PREV_TAG}..HEAD" --format='%aN' \
+            | sort -u \
+            | while read -r name; do
+                # Try to resolve GitHub username from commit email
+                EMAIL=$(git log "${PREV_TAG}..HEAD" --author="$name" \
+                  --format='%aE' | head -1)
+                GH_USER=$(gh api "search/users?q=${EMAIL}+in:email" \
+                  --jq '.items[0].login' 2>/dev/null || echo "")
+                if [ -n "$GH_USER" ]; then
+                  echo "- [@${GH_USER}](https://github.com/${GH_USER})"
+                else
+                  echo "- ${name}"
+                fi
+              done)
+
+          if [ -z "$CONTRIBUTORS" ]; then
+            CONTRIBUTORS="- @${GITHUB_ACTOR}"
+          fi
+
+          # --- Write to files for next steps (avoid env size limits) ---
+          printf '%b' "$BULLETS" > /tmp/bullets.txt
+          printf '%s' "$CONTRIBUTORS" > /tmp/contributors.txt
+
+          # Also capture for PR body
+          echo "bullets_file=/tmp/bullets.txt" >> "$GITHUB_OUTPUT"
+          echo "contributors_file=/tmp/contributors.txt" >> "$GITHUB_OUTPUT"
+
+      - name: Update CHANGELOG.md
+        env:
+          VERSION: ${{ steps.versions.outputs.version }}
+        run: |
+          BULLETS=$(cat /tmp/bullets.txt)
+          CONTRIBUTORS=$(cat /tmp/contributors.txt)
+          DATE=$(date +%Y-%m-%d)
+
+          NEW_SECTION="## ${VERSION}\n\n### Added\n\n${BULLETS}\n### Contributors\n\n${CONTRIBUTORS}\n\n---\n\n"
+
+          # Prepend new section after the H1 title line
+          awk -v section="$NEW_SECTION" '
+            /^# Changelog/ { print; print ""; printf "%s", section; next }
+            { print }
+          ' smart_vent/CHANGELOG.md > /tmp/CHANGELOG_new.md
+
+          mv /tmp/CHANGELOG_new.md smart_vent/CHANGELOG.md
+
+      - name: Bump version in config.yaml
+        env:
+          VERSION: ${{ steps.versions.outputs.version }}
+        run: |
+          sed -i "s/^version: \".*\"/version: \"${VERSION}\"/" smart_vent/config.yaml
+
+      - name: Create release branch, commit, and push
+        env:
+          TAG: ${{ steps.versions.outputs.tag }}
+          VERSION: ${{ steps.versions.outputs.version }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="release/${TAG}"
+          git checkout -b "$BRANCH"
+          git add smart_vent/CHANGELOG.md smart_vent/config.yaml
+          git commit -m "chore: release ${TAG} — bump version and update changelog"
+          git push origin "$BRANCH"
+
+      - name: Open Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.versions.outputs.tag }}
+          VERSION: ${{ steps.versions.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          BULLETS=$(cat /tmp/bullets.txt)
+          CONTRIBUTORS=$(cat /tmp/contributors.txt)
+          BRANCH="release/${TAG}"
+
+          PR_BODY="## Release ${TAG}
+
+This PR was automatically generated by the release workflow.
+
+### What's new in ${VERSION}
+
+${BULLETS}
+
+### Contributors
+
+${CONTRIBUTORS}
+
+---
+
+**Merging this PR will:**
+- Publish \`ghcr.io/${REPO}:${VERSION}\` and \`ghcr.io/${REPO}:latest\` to the GitHub Container Registry
+- Make the new version available to Home Assistant Supervisor"
+
+          gh pr create \
+            --repo "$REPO" \
+            --title "Release ${TAG}" \
+            --body "$PR_BODY" \
+            --head "$BRANCH" \
+            --base main

--- a/smart_vent/CHANGELOG.md
+++ b/smart_vent/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.4.0
+
+### Added
+
+- **Logging improvements** — configurable retention periods for event and cycle logs, time-window presets (1 h / 6 h / 24 h / 7 d) with custom date-range picker, independent multi-select level filter chips (info / warning / error), offset-based load-more pagination, clear-logs button with confirmation modal, and a dedicated Retention settings tab ([#3](https://github.com/dhruvb14/smart-thermostat-with-vents/issues/3), [#7](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/7))
+- **State drift correction** — periodic reconciliation of vent positions and thermostat setpoint against actual Home Assistant state corrects any external changes; vents now re-open automatically when a cycle terminates ([#2](https://github.com/dhruvb14/smart-thermostat-with-vents/issues/2), [#6](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/6))
+- **Sensor-only room support** — rooms with no vents (monitor-only / sensor-only) no longer block cycle termination; UI label updated to "Sensor-only room" ([#1](https://github.com/dhruvb14/smart-thermostat-with-vents/issues/1), [#4](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/4))
+- **CI safety** — Docker build workflow split into a build-only job (PRs, no registry credentials) and a build-and-push job (main/tags only), preventing accidental image publishes from forks or PRs ([#5](https://github.com/dhruvb14/smart-thermostat-with-vents/issues/5), [#4](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/4))
+
+### Contributors
+
+- [@dhruvb14](https://github.com/dhruvb14)
+
+---
+
+## 0.3.0
+
+- Initial public release: room scheduling, presence holdover, developer mode, live room status cards, schedule countdown timers, and backup/restore support

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -1,6 +1,6 @@
 name: "Flair Replacement"
 description: "HVAC cycle manager using Flair vents and Home Assistant thermostats"
-version: "0.3.0"
+version: "0.4.0"
 slug: "flair_replacement"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"
 arch:


### PR DESCRIPTION
## Summary

Closes #8

### Changes

- **`smart_vent/CHANGELOG.md`** — New file. `0.3.0` section documents the initial public release; `0.4.0` section covers the three features shipped since then, each with links to their issue and PR:
  - Logging improvements (#3, #7)
  - State drift correction (#2, #6)
  - Sensor-only room support + CI safety (#1, #5, #4)
  - Contributors listed at the bottom of each section

- **`smart_vent/config.yaml`** — `version` bumped `0.3.0` → `0.4.0`

- **`.github/workflows/release-pr.yml`** — New workflow. On `v*.*.*` tag push:
  1. Finds previous release tag to bound the commit range
  2. Parses merged PR numbers from commit messages, fetches PR titles + linked issues via GitHub API
  3. Collects unique contributors and resolves GitHub usernames
  4. Prepends a new section to `CHANGELOG.md` and bumps `config.yaml`
  5. Creates branch `release/vX.Y.Z`, commits, pushes, opens a PR to `main` for review

- **`.github/workflows/docker.yml`** — Removed `tags: ["v*.*.*"]` trigger (tags no longer directly publish images — that would race the release PR). `build-and-push` now reads `version` from `config.yaml` and pushes both `:latest` and `:<version>` on every merge to `main`.

### Release flow going forward

```
git tag v0.5.0 && git push --tags
  → release-pr.yml creates PR "Release v0.5.0" with auto-generated changelog
  → you review and merge
  → docker.yml publishes :0.5.0 + :latest
```

## Test plan
- [ ] `CHANGELOG.md` renders correctly on GitHub (check links, formatting)
- [ ] `config.yaml` version reads `0.4.0`
- [ ] After merge: `docker.yml` pushes both `:0.4.0` and `:latest` to GHCR
- [ ] Push `v0.5.0` tag to a test branch to verify `release-pr.yml` fires and creates a valid PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)