### PR TITLE
Fix cycle mode detection and vent state on abort (#26)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -67,6 +67,7 @@ class CycleEngine:
 
         self._state = CycleState.IDLE
         self._cycle_log: Optional[CycleLog] = None
+        self._cycle_mode: Optional[str] = None  # mode locked at cycle start; used for monitoring
         self._active_rooms: dict[str, ActiveRoom] = {}  # room_id → ActiveRoom
         self._room_cycle_states: dict[str, RoomCycleState] = {}  # room_id → state
         self._room_vents: dict[str, list[RoomVent]] = {}  # room_id → vents
@@ -189,13 +190,24 @@ class CycleEngine:
             # No active cycle yet — rooms are defined but HVAC is off; wait
             return
 
-        # If rooms changed, update and recompute setpoint
+        # If rooms changed, update and recompute setpoint.
+        # For mid-cycle updates, preserve the original cycle direction so that a
+        # momentary hvac_action="idle" (common on heat_cool thermostats) does not
+        # flip the setpoint calculation to the wrong direction.
         rooms_changed = set(new_active_map) != set(self._active_rooms)
         if rooms_changed or self._state == CycleState.IDLE:
-            await self._start_or_update_cycle(conn, new_active_map, hvac_mode)
+            effective_mode = (
+                hvac_mode
+                if self._state == CycleState.IDLE
+                else (self._cycle_mode or hvac_mode)
+            )
+            await self._start_or_update_cycle(conn, new_active_map, effective_mode)
 
-        # Monitor rooms
-        await self._monitor_rooms(conn, hvac_mode)
+        # Monitor rooms using the mode locked at cycle start.  Live hvac_action
+        # oscillates between "cooling"/"heating" and "idle" between HVAC bursts;
+        # re-reading it each tick causes _is_at_target() to use the wrong
+        # comparison direction during the idle phase (see issue #26).
+        await self._monitor_rooms(conn, self._cycle_mode or hvac_mode)
 
         # Check cycle timeout
         if self._cycle_log and self._state == CycleState.RUNNING:
@@ -237,6 +249,10 @@ class CycleEngine:
         self._active_rooms = new_active_map
 
         if self._state == CycleState.IDLE:
+            # Lock in the cycle direction — used by _monitor_rooms for the entire
+            # cycle lifetime to avoid mid-cycle mode misdetection (issue #26).
+            self._cycle_mode = hvac_mode
+
             # Start a fresh cycle
             rooms_snapshot = {
                 ar.room.id: {"name": ar.room.name, "target": ar.target_temp, "source": ar.source}
@@ -294,13 +310,30 @@ class CycleEngine:
                     )
 
             for room_id in removed:
-                # Close vents for removed rooms
+                # Close vents for removed rooms, respecting min_open_vents.
+                # Previously closed directly via ha.close_cover(), bypassing the
+                # VentController safety check (issue #26 Bug 3).
                 vents = self._room_vents.get(room_id, [])
-                for v in vents:
-                    try:
-                        await self._ha.close_cover(v.entity_id)
-                    except Exception as exc:
-                        log.error("Error closing vent %s: %s", v.entity_id, exc)
+                if vents:
+                    all_zone_vents_now = [v for vl in self._room_vents.values() for v in vl]
+                    can_close = True
+                    if tc.min_open_vents > 0:
+                        open_count = self._vent._count_open_vents(all_zone_vents_now)
+                        would_close = sum(
+                            1 for v in vents if self._vent._is_open(v.entity_id)
+                        )
+                        if open_count - would_close < tc.min_open_vents:
+                            can_close = False
+                            log.warning(
+                                "Cannot close removed room %s vents — would violate min_open_vents=%d",
+                                room_id, tc.min_open_vents,
+                            )
+                    if can_close:
+                        for v in vents:
+                            try:
+                                await self._ha.close_cover(v.entity_id)
+                            except Exception as exc:
+                                log.error("Error closing vent %s: %s", v.entity_id, exc)
                 self._room_cycle_states.pop(room_id, None)
                 log.info("Room %s removed from cycle (became idle)", room_id)
                 if self._logger:
@@ -420,6 +453,7 @@ class CycleEngine:
         all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
 
         self._state = CycleState.IDLE
+        self._cycle_mode = None
         self._cycle_log = None
         self._active_rooms = {}
         self._room_cycle_states = {}
@@ -449,12 +483,29 @@ class CycleEngine:
                 {"thermostat": self.thermostat_entity_id, "reason": reason,
                  "cycle_id": self._cycle_log.id if self._cycle_log else None},
             )
+
+        all_vents = [v for vl in self._room_vents.values() for v in vl]
         if safe_close:
-            all_vents = [v for vl in self._room_vents.values() for v in vl]
+            # Thermostat unavailable — close everything for safety
             await self._vent.close_all_zone_vents(all_vents)
+        elif all_vents:
+            # Abnormal termination (no active rooms, timeout, mode change) —
+            # return all vents to open/idle state, mirroring _terminate_cycle.
+            # Previously vents were left in whatever physical state they happened
+            # to be in, which could leave rooms closed with no engine tracking
+            # until the next IDLE reconciliation pass.
+            await self._vent.open_room_vents(all_vents)
+            if self._logger:
+                await self._logger.log(
+                    "info", "engine",
+                    f"Cycle aborted for {self.thermostat_entity_id} ({reason}) — all zone vents re-opened",
+                    {"thermostat": self.thermostat_entity_id, "reason": reason},
+                )
+
         if self._cycle_log:
             await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
         self._state = CycleState.IDLE
+        self._cycle_mode = None
         self._cycle_log = None
         self._active_rooms = {}
         self._room_cycle_states = {}
@@ -480,20 +531,32 @@ class CycleEngine:
     # ------------------------------------------------------------------
 
     def _read_hvac_mode(self) -> str:
-        """Return 'heating'|'cooling'|'off'|'unknown'."""
+        """Return 'heating'|'cooling'|'off'|'unknown'.
+
+        hvac_action is the authoritative source when the HVAC is actively
+        running. When action is 'idle' (HVAC satisfied its setpoint), we fall
+        back to hvac_mode — but only for unambiguous single-direction modes
+        ('heat' / 'cool'). For 'heat_cool' (auto) mode the thermostat's
+        direction can only be determined from the action attribute; mapping it
+        to 'heating' was incorrect and caused _is_at_target() to use the wrong
+        comparison direction during the idle phase of a cooling cycle.
+        """
         state = self._ha.get_state(self.thermostat_entity_id)
         if state is None:
             return "unknown"
-        # hvac_action is more reliable than hvac_mode
+        # hvac_action is the most reliable signal
         action = state.get("attributes", {}).get("hvac_action", "")
         if action in ("heating", "cooling"):
             return action
-        # Fall back to hvac_mode
+        # Fall back to hvac_mode only for unambiguous single-direction modes
         mode = state.get("state", "off")
-        if mode in ("heat", "heat_cool"):
+        if mode == "heat":
             return "heating"
-        if mode in ("cool",):
+        if mode == "cool":
             return "cooling"
+        # heat_cool (auto), off, unavailable, and anything else → "off"
+        # Direction for heat_cool is determined by hvac_action only; when idle
+        # it is unknown. _cycle_mode handles monitoring direction mid-cycle.
         return "off"
 
     def _get_avg_temp(self, room: Room) -> Optional[float]:

--- a/smart_vent/frontend/src/pages/DevMode.tsx
+++ b/smart_vent/frontend/src/pages/DevMode.tsx
@@ -23,7 +23,10 @@ function actionColor(details: Record<string, unknown> | null): string {
 }
 
 function fmtTime(ts: string): string {
-  const d = new Date(ts);
+  // Append "Z" so the browser treats the bare UTC ISO string as UTC and
+  // converts it to the user's local timezone (without "Z" browsers interpret
+  // it as local time, displaying UTC hours as if they were already local).
+  const d = new Date(ts + "Z");
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
 

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -136,8 +136,8 @@ function LogRow({ log }: { log: CycleLog }) {
         <td>
           <span className={`badge badge-${log.mode === "cooling" ? "blue" : "orange"}`}>{log.mode}</span>
         </td>
-        <td>{new Date(log.started_at).toLocaleString()}</td>
-        <td>{log.ended_at ? new Date(log.ended_at).toLocaleString() : <span className="badge badge-green">Active</span>}</td>
+        <td>{new Date(log.started_at + "Z").toLocaleString()}</td>
+        <td>{log.ended_at ? new Date(log.ended_at + "Z").toLocaleString() : <span className="badge badge-green">Active</span>}</td>
         <td>{duration(log.started_at, log.ended_at)}</td>
         <td>{rooms.length}</td>
         <td>{expanded ? "▲" : "▼"}</td>


### PR DESCRIPTION
## Summary

Fixes three bugs in `backend/engine/cycle_engine.py` that caused vents to never close during presence-triggered cooling cycles on `heat_cool` (auto-mode) thermostats, leaving the HVAC running indefinitely. Closes #26.

## Root Causes Fixed

### Bug 1 — `_read_hvac_mode()` misidentified mode during HVAC idle phase (primary)

`heat_cool` thermostat state was mapped to `"heating"` as a fallback when `hvac_action="idle"`. On a cooling cycle, the HVAC goes idle **exactly** when the room reaches the target temperature (it satisfied its own setpoint). The wrong mode caused `_is_at_target()` to evaluate `avg >= target` (heating) instead of `avg <= target` (cooling), so the room was never marked "at target" and the vent never closed. The HVAC would cycle back on, the room would reheat above target, and the pattern would repeat indefinitely.

**Fix:** Removed the `heat_cool → "heating"` mapping. Direction for `heat_cool` thermostats is determined solely by `hvac_action`; when idle, it is unknown. Added docstring explaining the reasoning.

### Bug 2 — Monitoring mode re-read from live HA state every tick

Even if `_read_hvac_mode()` were correct, re-reading it each tick means the mode used in `_monitor_rooms()` changes whenever `hvac_action` oscillates. The "at target" window (room at or below cooling target) always coincides with `hvac_action="idle"`, so the check always ran with the wrong mode.

**Fix:** Added `self._cycle_mode: Optional[str]` locked at cycle start. `_monitor_rooms()` and mid-cycle setpoint updates now use `self._cycle_mode` instead of re-reading live state. Reset to `None` on both terminate and abort.

### Bug 3 — `_abort_cycle()` left vents in place on non-safety aborts

For "no active rooms", timeout, and mode-change aborts, vents were left in whatever physical state they happened to be in. This left rooms with closed vents and no engine tracking until the next IDLE reconciliation pass (up to `reconciliation_interval_min` minutes later).

**Fix:** Re-open all zone vents in the non-`safe_close` abort path, mirroring the existing behavior of `_terminate_cycle()`.

### Bug 4 — Removed-room vent closures bypassed `min_open_vents`

When rooms left a running cycle mid-cycle, their vents were closed via `ha.close_cover()` directly, skipping the `min_open_vents` safety check that `VentController.close_room_vents()` enforces.

**Fix:** Added a `min_open_vents` pre-check before closing removed-room vents, consistent with the monitoring path.

## Test Plan

- [ ] Verify a cooling cycle on a `heat_cool` thermostat closes vents when rooms reach target
- [ ] Verify vents re-open after cycle abort (no active rooms / timeout)
- [ ] Verify `min_open_vents` is respected when a room leaves a running cycle
- [ ] Confirm no regression on `heat`-only and `cool`-only thermostat modes (unambiguous modes still map correctly in `_read_hvac_mode()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)