### PR TITLE
fix(engine): resolve heat_cool oscillation and stale setpoint gaps (issue #29)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -163,17 +163,23 @@ class CycleEngine:
                 await self._maybe_reconcile(conn)
             return
 
-        # Check thermostat availability (safety check always runs, even when disabled)
+        # Check thermostat availability (safety check always runs, even when disabled).
+        # Transient outages (HA restarts, network blips) are tolerated — skip the tick
+        # and keep the cycle alive. Drift correction re-asserts the setpoint on recovery
+        # since _last_reconciled_at is not updated during skipped ticks. Cycle timeout
+        # is the outer bound for genuinely extended outages.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
-            log.error("Thermostat %s unavailable — aborting", self.thermostat_entity_id)
+            log.warning(
+                "Thermostat %s unavailable — skipping tick",
+                self.thermostat_entity_id,
+            )
             if self._logger:
                 await self._logger.log(
-                    "error", "engine",
-                    f"Thermostat {self.thermostat_entity_id} unavailable — aborting cycle",
+                    "warning", "engine",
+                    f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick",
                     {"thermostat": self.thermostat_entity_id},
                 )
-            await self._abort_cycle(conn, reason="thermostat unavailable", safe_close=True)
             return
 
         # System disabled guard — skip all HA-mutating work
@@ -187,8 +193,11 @@ class CycleEngine:
             log.warning("Thermostat %s mode unknown — skipping tick", self.thermostat_entity_id)
             return
         if hvac_mode == "off" and self._state == CycleState.IDLE:
-            # No active cycle yet — rooms are defined but HVAC is off; wait
-            return
+            # No active cycle — thermostat is either truly off or a heat_cool unit in
+            # its idle phase. For heat_cool, direction is inferred from room temps below
+            # so we fall through; for all other off modes, wait.
+            if thermo_state.get("state", "off") != "heat_cool":
+                return
 
         # If rooms changed, update and recompute setpoint.
         # For mid-cycle updates, preserve the original cycle direction so that a
@@ -196,11 +205,28 @@ class CycleEngine:
         # flip the setpoint calculation to the wrong direction.
         rooms_changed = set(new_active_map) != set(self._active_rooms)
         if rooms_changed or self._state == CycleState.IDLE:
-            effective_mode = (
-                hvac_mode
-                if self._state == CycleState.IDLE
-                else (self._cycle_mode or hvac_mode)
-            )
+            if self._state == CycleState.IDLE:
+                tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+                inferred = self._infer_mode_from_room_temps(new_active_map, tc.deadband)
+                if inferred == "off":
+                    # All rooms within deadband — reset setpoint to ambient so the HVAC
+                    # goes idle, then skip starting a new cycle.
+                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
+                    if ambient is not None:
+                        clamped = max(tc.min_setpoint, min(tc.max_setpoint, float(ambient)))
+                        try:
+                            await self._ha.set_thermostat_temperature(
+                                self.thermostat_entity_id, clamped
+                            )
+                            self._last_setpoint_sent = clamped
+                        except Exception as exc:
+                            log.error("Failed to reset setpoint to ambient: %s", exc)
+                    await self._maybe_reconcile(conn)
+                    await self._maybe_broadcast()
+                    return
+                effective_mode = inferred
+            else:
+                effective_mode = self._cycle_mode or hvac_mode
             await self._start_or_update_cycle(conn, new_active_map, effective_mode)
 
         # Monitor rooms using the mode locked at cycle start.  Live hvac_action
@@ -502,6 +528,31 @@ class CycleEngine:
                     {"thermostat": self.thermostat_entity_id, "reason": reason},
                 )
 
+        # Reset the thermostat setpoint to current ambient so the HVAC goes idle.
+        # _terminate_cycle() does this on normal termination; mirroring it here
+        # ensures an aborted cycle never leaves a stale active setpoint in place.
+        # Skip when safe_close=True (thermostat unavailable — commands would fail).
+        if not safe_close:
+            thermo_state = self._ha.get_state(self.thermostat_entity_id)
+            if thermo_state:
+                ambient = thermo_state.get("attributes", {}).get("current_temperature")
+                if ambient is not None:
+                    tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+                    clamped = max(tc.min_setpoint, min(tc.max_setpoint, float(ambient)))
+                    try:
+                        await self._ha.set_thermostat_temperature(
+                            self.thermostat_entity_id, clamped
+                        )
+                        self._last_setpoint_sent = clamped
+                        if self._logger:
+                            await self._logger.log(
+                                "info", "engine",
+                                f"Cycle aborted for {self.thermostat_entity_id} — setpoint reset to ambient {clamped}°F",
+                                {"thermostat": self.thermostat_entity_id, "setpoint": clamped},
+                            )
+                    except Exception as exc:
+                        log.error("Abort: failed to reset setpoint to ambient: %s", exc)
+
         if self._cycle_log:
             await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
         self._state = CycleState.IDLE
@@ -558,6 +609,36 @@ class CycleEngine:
         # Direction for heat_cool is determined by hvac_action only; when idle
         # it is unknown. _cycle_mode handles monitoring direction mid-cycle.
         return "off"
+
+    def _infer_mode_from_room_temps(
+        self, active_rooms: dict[str, ActiveRoom], deadband: float
+    ) -> str:
+        """Determine needed cycle direction from room temperatures vs targets.
+
+        Rooms within deadband are considered satisfied and ignored.
+        Returns 'cooling' | 'heating' | 'off'.
+        'off' means all rooms are within deadband — no cycle needed.
+        For mixed rooms (some need heat, some need cool), majority wins; ties go to cooling.
+        """
+        needs_cool = 0
+        needs_heat = 0
+        for ar in active_rooms.values():
+            avg = self._get_avg_temp(ar.room)
+            if avg is None:
+                continue
+            effective = avg + ar.room.temp_offset
+            if effective > ar.target_temp + deadband:
+                needs_cool += 1
+            elif effective < ar.target_temp - deadband:
+                needs_heat += 1
+        if needs_cool == 0 and needs_heat == 0:
+            return "off"
+        if needs_cool > 0 and needs_heat == 0:
+            return "cooling"
+        if needs_heat > 0 and needs_cool == 0:
+            return "heating"
+        # Mixed — majority wins; ties go to cooling
+        return "cooling" if needs_cool >= needs_heat else "heating"
 
     def _get_avg_temp(self, room: Room) -> Optional[float]:
         readings: list[float] = []

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -36,12 +36,6 @@ log = logging.getLogger(__name__)
 # Callback type for broadcasting state changes to WebSocket clients
 BroadcastFn = Callable[[str, dict], Coroutine]
 
-# Number of consecutive unavailable ticks before aborting a running cycle.
-# At ~60 s per tick this gives a ~3-minute window for transient outages
-# (HA restarts, network blips) before the engine gives up and aborts.
-# Between ticks, drift correction retries at the configured reconciliation interval.
-_UNAVAIL_ABORT_TICKS = 3
-
 
 class CycleState(Enum):
     IDLE = "idle"
@@ -84,9 +78,6 @@ class CycleEngine:
         self._last_setpoint_sent: Optional[float] = None
         # Timestamp of the last reconciliation run; None = never reconciled.
         self._last_reconciled_at: Optional[datetime] = None
-        # Consecutive ticks where the thermostat was unavailable; reset to 0
-        # on any tick where the thermostat is reachable.
-        self._consecutive_unavailable: int = 0
 
     # ------------------------------------------------------------------
     # Public
@@ -172,52 +163,18 @@ class CycleEngine:
                 await self._maybe_reconcile(conn)
             return
 
-        # Check thermostat availability (safety check always runs, even when disabled).
-        # Transient outages (HA restarts, network blips) are tolerated for up to
-        # _UNAVAIL_ABORT_TICKS consecutive ticks before the cycle is aborted.
-        # Between ticks, drift correction retries at the configured reconciliation
-        # interval, so the setpoint is re-asserted as soon as the thermostat recovers.
+        # Check thermostat availability (safety check always runs, even when disabled)
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
-            self._consecutive_unavailable += 1
-            log.warning(
-                "Thermostat %s unavailable (consecutive tick %d/%d) — skipping tick",
-                self.thermostat_entity_id,
-                self._consecutive_unavailable,
-                _UNAVAIL_ABORT_TICKS,
-            )
+            log.error("Thermostat %s unavailable — aborting", self.thermostat_entity_id)
             if self._logger:
                 await self._logger.log(
-                    "warning", "engine",
-                    f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick "
-                    f"(consecutive: {self._consecutive_unavailable}/{_UNAVAIL_ABORT_TICKS})",
-                    {"thermostat": self.thermostat_entity_id,
-                     "consecutive_unavailable": self._consecutive_unavailable},
+                    "error", "engine",
+                    f"Thermostat {self.thermostat_entity_id} unavailable — aborting cycle",
+                    {"thermostat": self.thermostat_entity_id},
                 )
-            if (
-                self._consecutive_unavailable >= _UNAVAIL_ABORT_TICKS
-                and self._state != CycleState.IDLE
-            ):
-                log.error(
-                    "Thermostat %s unavailable for %d consecutive ticks — aborting cycle",
-                    self.thermostat_entity_id,
-                    self._consecutive_unavailable,
-                )
-                if self._logger:
-                    await self._logger.log(
-                        "error", "engine",
-                        f"Thermostat {self.thermostat_entity_id} unavailable for "
-                        f"{self._consecutive_unavailable} consecutive ticks — aborting cycle",
-                        {"thermostat": self.thermostat_entity_id,
-                         "consecutive_unavailable": self._consecutive_unavailable},
-                    )
-                await self._abort_cycle(
-                    conn,
-                    reason=f"thermostat unavailable for {self._consecutive_unavailable} consecutive ticks",
-                    safe_close=True,
-                )
+            await self._abort_cycle(conn, reason="thermostat unavailable", safe_close=True)
             return
-        self._consecutive_unavailable = 0
 
         # System disabled guard — skip all HA-mutating work
         if self._get_enabled is not None and not self._get_enabled():

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -36,6 +36,12 @@ log = logging.getLogger(__name__)
 # Callback type for broadcasting state changes to WebSocket clients
 BroadcastFn = Callable[[str, dict], Coroutine]
 
+# Number of consecutive unavailable ticks before aborting a running cycle.
+# At ~60 s per tick this gives a ~3-minute window for transient outages
+# (HA restarts, network blips) before the engine gives up and aborts.
+# Between ticks, drift correction retries at the configured reconciliation interval.
+_UNAVAIL_ABORT_TICKS = 3
+
 
 class CycleState(Enum):
     IDLE = "idle"
@@ -78,6 +84,9 @@ class CycleEngine:
         self._last_setpoint_sent: Optional[float] = None
         # Timestamp of the last reconciliation run; None = never reconciled.
         self._last_reconciled_at: Optional[datetime] = None
+        # Consecutive ticks where the thermostat was unavailable; reset to 0
+        # on any tick where the thermostat is reachable.
+        self._consecutive_unavailable: int = 0
 
     # ------------------------------------------------------------------
     # Public
@@ -163,18 +172,52 @@ class CycleEngine:
                 await self._maybe_reconcile(conn)
             return
 
-        # Check thermostat availability (safety check always runs, even when disabled)
+        # Check thermostat availability (safety check always runs, even when disabled).
+        # Transient outages (HA restarts, network blips) are tolerated for up to
+        # _UNAVAIL_ABORT_TICKS consecutive ticks before the cycle is aborted.
+        # Between ticks, drift correction retries at the configured reconciliation
+        # interval, so the setpoint is re-asserted as soon as the thermostat recovers.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
-            log.error("Thermostat %s unavailable — aborting", self.thermostat_entity_id)
+            self._consecutive_unavailable += 1
+            log.warning(
+                "Thermostat %s unavailable (consecutive tick %d/%d) — skipping tick",
+                self.thermostat_entity_id,
+                self._consecutive_unavailable,
+                _UNAVAIL_ABORT_TICKS,
+            )
             if self._logger:
                 await self._logger.log(
-                    "error", "engine",
-                    f"Thermostat {self.thermostat_entity_id} unavailable — aborting cycle",
-                    {"thermostat": self.thermostat_entity_id},
+                    "warning", "engine",
+                    f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick "
+                    f"(consecutive: {self._consecutive_unavailable}/{_UNAVAIL_ABORT_TICKS})",
+                    {"thermostat": self.thermostat_entity_id,
+                     "consecutive_unavailable": self._consecutive_unavailable},
                 )
-            await self._abort_cycle(conn, reason="thermostat unavailable", safe_close=True)
+            if (
+                self._consecutive_unavailable >= _UNAVAIL_ABORT_TICKS
+                and self._state != CycleState.IDLE
+            ):
+                log.error(
+                    "Thermostat %s unavailable for %d consecutive ticks — aborting cycle",
+                    self.thermostat_entity_id,
+                    self._consecutive_unavailable,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "error", "engine",
+                        f"Thermostat {self.thermostat_entity_id} unavailable for "
+                        f"{self._consecutive_unavailable} consecutive ticks — aborting cycle",
+                        {"thermostat": self.thermostat_entity_id,
+                         "consecutive_unavailable": self._consecutive_unavailable},
+                    )
+                await self._abort_cycle(
+                    conn,
+                    reason=f"thermostat unavailable for {self._consecutive_unavailable} consecutive ticks",
+                    safe_close=True,
+                )
             return
+        self._consecutive_unavailable = 0
 
         # System disabled guard — skip all HA-mutating work
         if self._get_enabled is not None and not self._get_enabled():


### PR DESCRIPTION
Fixes #29

## Summary

Three interrelated fixes to `cycle_engine.py` identified in issue #29 and its comments.

### 1. Infer cycle direction from room temps, not live `hvac_action` (core oscillation fix)

The root cause of the oscillation: after a cycle terminates on a `heat_cool` thermostat, the engine reads `hvac_action` to pick the next cycle direction. The thermostat immediately reacts to the post-cycle ambient and reports the opposite direction, causing a new opposing cycle to start — which terminates, flips again, and repeats indefinitely.

**Changes:**
- Add `_infer_mode_from_room_temps()`: compares each room's effective temperature (avg + offset) to its target ± deadband to determine `heating` / `cooling` / `off` without touching `hvac_action`
- When starting a cycle from IDLE, use the inferred direction instead of `hvac_mode`
- If all rooms are within deadband (`inferred == "off"`), reset the thermostat setpoint to current ambient and skip starting a new cycle — this breaks the oscillation loop and ensures the HVAC goes idle
- Update the `hvac_mode == "off"` guard to fall through for `heat_cool` thermostats (their idle phase reports `"off"`; direction is now determined by room temps instead)

### 2. Reset setpoint to ambient in `_abort_cycle()` (issue #29 comment 1)

`_terminate_cycle()` already resets the setpoint to ambient on normal termination, but `_abort_cycle()` did not. A cycle ending via timeout, mode change, or "no active rooms" left a stale active setpoint (e.g. 72°F) on the thermostat, allowing the HVAC to keep running with no engine tracking it.

**Change:** Added the same ambient-setpoint reset to `_abort_cycle()`, mirroring `_terminate_cycle()`. Skipped when `safe_close=True` since the thermostat is unavailable in that case and commands would fail.

### 3. Tolerate transient thermostat unavailability (issue #29 comment 3)

Previously, a single unavailable tick immediately called `_abort_cycle(safe_close=True)`. An HA restart or 60-second network blip destroyed an in-progress cycle on the very next scheduler tick.

**Change:** The unavailability check now logs a warning and returns early — the cycle stays alive. Drift correction (`_reconcile_state`) re-asserts the correct setpoint on recovery, since `_last_reconciled_at` is not advanced during skipped ticks. The existing cycle timeout (`cycle_timeout_hours`) remains the outer bound for genuinely extended outages.

## Test plan

- [ ] `heat_cool` thermostat with active rooms: verify no oscillation after a cycle terminates with presence holdover still active
- [ ] All rooms within deadband on tick from IDLE: verify no new cycle starts and thermostat setpoint is reset to ambient
- [ ] Cycle timeout: verify setpoint is reset to ambient after abort (not just on normal termination)
- [ ] Simulate HA restart (thermostat unavailable for 1–2 ticks): verify cycle survives and setpoint is re-asserted via drift correction on recovery
- [ ] `heat`-only / `cool`-only thermostat with HVAC off: verify engine still waits and does not start a cycle