### PR TITLE
fix(engine): full audit — vent timing, thermostat setpoint, and min/max bounds correctness (issue #32)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -184,18 +184,9 @@ class CycleEngine:
             return
 
         # System disabled guard — if a cycle is running, abort it immediately.
+        # _abort_cycle handles all logging; no pre-call log needed here.
         if self._get_enabled is not None and not self._get_enabled():
             if self._state != CycleState.IDLE:
-                log.warning(
-                    "System disabled while cycle running for %s — aborting cycle",
-                    self.thermostat_entity_id,
-                )
-                if self._logger:
-                    await self._logger.log(
-                        "warning", "engine",
-                        f"System disabled — aborting running cycle for {self.thermostat_entity_id}",
-                        {"thermostat": self.thermostat_entity_id},
-                    )
                 await self._abort_cycle(conn, reason="system disabled")
             else:
                 log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
@@ -427,24 +418,28 @@ class CycleEngine:
 
             if at_target and rcs.vent_closed_at is None:
                 # Try to close the vent.
-                # Bug 6: if this is the only active room and min_open_vents would
-                # block the close, bypass the constraint and close anyway — leaving
-                # it open would deadlock the cycle forever.
+                # Bug 6: if this is the last room whose vent still needs to close and
+                # min_open_vents would block the close, bypass the constraint and close
+                # anyway — leaving it open would deadlock the cycle forever.
+                # "Last vent needing close" covers both single-room zones AND multi-room
+                # zones where all other rooms have already had their vents closed.
                 vents = self._room_vents.get(room_id, [])
-                is_last_room = len(self._active_rooms) == 1
-                if is_last_room and tc.min_open_vents > 0:
+                is_last_vent_to_close = sum(
+                    1 for r in self._room_cycle_states.values() if r.vent_closed_at is None
+                ) == 1
+                if is_last_vent_to_close and tc.min_open_vents > 0:
                     open_count = self._vent._count_open_vents(all_zone_vents)
                     would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
                     if open_count - would_close < tc.min_open_vents:
                         log.warning(
-                            "Room %s is last active room — bypassing min_open_vents to close vent and terminate",
+                            "Room %s is last vent needing close — bypassing min_open_vents to terminate",
                             ar.room.name,
                         )
                         if self._logger:
                             await self._logger.log(
                                 "warning", "engine",
-                                f"Room {ar.room.name} is the only active room — "
-                                f"bypassing min_open_vents={tc.min_open_vents} to close vent and terminate",
+                                f"Room {ar.room.name} is the last vent needing close — "
+                                f"bypassing min_open_vents={tc.min_open_vents} to terminate cycle",
                                 {"room_id": room_id, "room_name": ar.room.name,
                                  "min_open_vents": tc.min_open_vents},
                             )

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -426,11 +426,39 @@ class CycleEngine:
             at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode, tc.deadband)
 
             if at_target and rcs.vent_closed_at is None:
-                # Try to close the vent
+                # Try to close the vent.
+                # Bug 6: if this is the only active room and min_open_vents would
+                # block the close, bypass the constraint and close anyway — leaving
+                # it open would deadlock the cycle forever.
                 vents = self._room_vents.get(room_id, [])
-                closed = await self._vent.close_room_vents(
-                    vents, all_zone_vents, tc, self._room_cycle_states
-                )
+                is_last_room = len(self._active_rooms) == 1
+                if is_last_room and tc.min_open_vents > 0:
+                    open_count = self._vent._count_open_vents(all_zone_vents)
+                    would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
+                    if open_count - would_close < tc.min_open_vents:
+                        log.warning(
+                            "Room %s is last active room — bypassing min_open_vents to close vent and terminate",
+                            ar.room.name,
+                        )
+                        if self._logger:
+                            await self._logger.log(
+                                "warning", "engine",
+                                f"Room {ar.room.name} is the only active room — "
+                                f"bypassing min_open_vents={tc.min_open_vents} to close vent and terminate",
+                                {"room_id": room_id, "room_name": ar.room.name,
+                                 "min_open_vents": tc.min_open_vents},
+                            )
+                        for v in vents:
+                            await self._ha.close_cover(v.entity_id)
+                        closed = True
+                    else:
+                        closed = await self._vent.close_room_vents(
+                            vents, all_zone_vents, tc, self._room_cycle_states
+                        )
+                else:
+                    closed = await self._vent.close_room_vents(
+                        vents, all_zone_vents, tc, self._room_cycle_states
+                    )
                 if closed:
                     rcs.vent_closed_at = datetime.utcnow()
                     if rcs.reached_at is None:

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -68,6 +68,7 @@ class CycleEngine:
         self._state = CycleState.IDLE
         self._cycle_log: Optional[CycleLog] = None
         self._cycle_mode: Optional[str] = None  # mode locked at cycle start; used for monitoring
+        self._cycle_ha_mode: Optional[str] = None  # 'heat' or 'cool' — explicit HA mode sent
         self._active_rooms: dict[str, ActiveRoom] = {}  # room_id → ActiveRoom
         self._room_cycle_states: dict[str, RoomCycleState] = {}  # room_id → state
         self._room_vents: dict[str, list[RoomVent]] = {}  # room_id → vents
@@ -213,12 +214,12 @@ class CycleEngine:
                     # goes idle, then skip starting a new cycle.
                     ambient = thermo_state.get("attributes", {}).get("current_temperature")
                     if ambient is not None:
-                        clamped = max(tc.min_setpoint, min(tc.max_setpoint, float(ambient)))
+                        ambient_f = float(ambient)
                         try:
                             await self._ha.set_thermostat_temperature(
-                                self.thermostat_entity_id, clamped
+                                self.thermostat_entity_id, ambient_f
                             )
-                            self._last_setpoint_sent = clamped
+                            self._last_setpoint_sent = ambient_f
                         except Exception as exc:
                             log.error("Failed to reset setpoint to ambient: %s", exc)
                     await self._maybe_reconcile(conn)
@@ -448,23 +449,27 @@ class CycleEngine:
         log.info("All rooms at target for %s — terminating cycle", self.thermostat_entity_id)
         self._state = CycleState.TERMINATING
 
-        # Set thermostat setpoint to its own current ambient → HVAC shuts off
+        # Set thermostat setpoint to its own current ambient → HVAC shuts off.
+        # Leave the thermostat in the cycle's mode (heat/cool) — setting setpoint=ambient
+        # means the HVAC satisfies itself immediately and goes idle.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
             ambient = thermo_state.get("attributes", {}).get("current_temperature")
             if ambient is not None:
-                tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
-                clamped = max(tc.min_setpoint, min(tc.max_setpoint, float(ambient)))
+                ambient_f = float(ambient)
                 try:
                     await self._ha.set_thermostat_temperature(
-                        self.thermostat_entity_id, clamped
+                        self.thermostat_entity_id, ambient_f,
+                        hvac_mode=self._cycle_ha_mode,
                     )
-                    self._last_setpoint_sent = clamped
+                    self._last_setpoint_sent = ambient_f
                     if self._logger:
                         await self._logger.log(
                             "info", "engine",
-                            f"Cycle terminated for {self.thermostat_entity_id} — setpoint reset to ambient {clamped}°F",
-                            {"thermostat": self.thermostat_entity_id, "setpoint": clamped,
+                            f"Cycle terminated for {self.thermostat_entity_id} — "
+                            f"setpoint reset to ambient {ambient_f}°F",
+                            {"thermostat": self.thermostat_entity_id, "setpoint": ambient_f,
+                             "hvac_mode": self._cycle_ha_mode,
                              "cycle_id": self._cycle_log.id if self._cycle_log else None},
                         )
                 except Exception as exc:
@@ -480,6 +485,7 @@ class CycleEngine:
 
         self._state = CycleState.IDLE
         self._cycle_mode = None
+        self._cycle_ha_mode = None
         self._cycle_log = None
         self._active_rooms = {}
         self._room_cycle_states = {}
@@ -537,18 +543,20 @@ class CycleEngine:
             if thermo_state:
                 ambient = thermo_state.get("attributes", {}).get("current_temperature")
                 if ambient is not None:
-                    tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
-                    clamped = max(tc.min_setpoint, min(tc.max_setpoint, float(ambient)))
+                    ambient_f = float(ambient)
                     try:
                         await self._ha.set_thermostat_temperature(
-                            self.thermostat_entity_id, clamped
+                            self.thermostat_entity_id, ambient_f,
+                            hvac_mode=self._cycle_ha_mode,
                         )
-                        self._last_setpoint_sent = clamped
+                        self._last_setpoint_sent = ambient_f
                         if self._logger:
                             await self._logger.log(
                                 "info", "engine",
-                                f"Cycle aborted for {self.thermostat_entity_id} — setpoint reset to ambient {clamped}°F",
-                                {"thermostat": self.thermostat_entity_id, "setpoint": clamped},
+                                f"Cycle aborted for {self.thermostat_entity_id} — "
+                                f"setpoint reset to ambient {ambient_f}°F",
+                                {"thermostat": self.thermostat_entity_id, "setpoint": ambient_f,
+                                 "hvac_mode": self._cycle_ha_mode},
                             )
                     except Exception as exc:
                         log.error("Abort: failed to reset setpoint to ambient: %s", exc)
@@ -557,6 +565,7 @@ class CycleEngine:
             await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
         self._state = CycleState.IDLE
         self._cycle_mode = None
+        self._cycle_ha_mode = None
         self._cycle_log = None
         self._active_rooms = {}
         self._room_cycle_states = {}
@@ -672,19 +681,27 @@ class CycleEngine:
             return
         if hvac_mode == "cooling":
             setpoint = min(targets) - tc.overshoot_delta
+            ha_mode = "cool"
         else:
             setpoint = max(targets) + tc.overshoot_delta
-        clamped = max(tc.min_setpoint, min(tc.max_setpoint, setpoint))
+            ha_mode = "heat"
         try:
-            await self._ha.set_thermostat_temperature(self.thermostat_entity_id, clamped)
+            # Pass hvac_mode explicitly so heat_cool thermostats switch to the correct
+            # single-direction mode. HA silently ignores temperature-only calls for
+            # heat_cool mode (Bug 2).
+            await self._ha.set_thermostat_temperature(
+                self.thermostat_entity_id, setpoint, hvac_mode=ha_mode
+            )
             # Track what we last commanded so reconciliation can detect external drift.
-            self._last_setpoint_sent = clamped
+            self._last_setpoint_sent = setpoint
+            self._cycle_ha_mode = ha_mode  # track the mode we locked the thermostat into
             if self._logger:
                 await self._logger.log(
                     "info", "engine",
-                    f"Setpoint for {self.thermostat_entity_id} set to {clamped}°F (mode={hvac_mode})",
-                    {"thermostat": self.thermostat_entity_id, "setpoint": clamped,
-                     "hvac_mode": hvac_mode, "targets": targets},
+                    f"Setpoint for {self.thermostat_entity_id} set to {setpoint:.1f}°F "
+                    f"(mode={hvac_mode}, ha_mode={ha_mode})",
+                    {"thermostat": self.thermostat_entity_id, "setpoint": setpoint,
+                     "hvac_mode": hvac_mode, "ha_mode": ha_mode, "targets": targets},
                 )
         except Exception as exc:
             log.error("Failed to set thermostat setpoint: %s", exc)

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -779,34 +779,63 @@ class CycleEngine:
                                  "thermostat": self.thermostat_entity_id},
                             )
 
-            # Check thermostat setpoint drift.
-            if self._last_setpoint_sent is not None:
+            # Check thermostat mode and setpoint drift.
+            if self._last_setpoint_sent is not None or self._cycle_ha_mode is not None:
                 thermo_state = self._ha.get_state(self.thermostat_entity_id)
                 if thermo_state:
-                    current_sp = thermo_state.get("attributes", {}).get("temperature")
-                    if current_sp is not None:
-                        drift = abs(float(current_sp) - self._last_setpoint_sent)
-                        if drift > 0.1:  # tolerance for float rounding in HA
+                    needs_reassert = False
+
+                    # Re-assert mode if the thermostat was switched off or to heat_cool
+                    # mid-cycle (Bug 4). The cycle-locked ha_mode must be the active mode.
+                    if self._cycle_ha_mode is not None:
+                        current_mode = thermo_state.get("state", "")
+                        if current_mode != self._cycle_ha_mode:
                             log.warning(
-                                "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
-                                self.thermostat_entity_id, current_sp, self._last_setpoint_sent,
+                                "Reconcile: thermostat %s mode drifted %s→%s — re-asserting",
+                                self.thermostat_entity_id, current_mode, self._cycle_ha_mode,
                             )
                             if self._logger:
                                 await self._logger.log(
                                     "warning", "reconcile",
-                                    f"Drift: thermostat {self.thermostat_entity_id} setpoint changed "
-                                    f"from {self._last_setpoint_sent:.1f}°F to {float(current_sp):.1f}°F "
-                                    f"— re-asserting",
+                                    f"Drift: thermostat {self.thermostat_entity_id} mode changed "
+                                    f"from {current_mode!r} to {self._cycle_ha_mode!r} — re-asserting",
                                     {"entity_id": self.thermostat_entity_id,
-                                     "expected": self._last_setpoint_sent,
-                                     "actual": float(current_sp)},
+                                     "expected_mode": self._cycle_ha_mode,
+                                     "actual_mode": current_mode},
                                 )
-                            try:
-                                await self._ha.set_thermostat_temperature(
-                                    self.thermostat_entity_id, self._last_setpoint_sent
+                            needs_reassert = True
+
+                    # Re-assert setpoint if it drifted externally.
+                    if self._last_setpoint_sent is not None:
+                        current_sp = thermo_state.get("attributes", {}).get("temperature")
+                        if current_sp is not None:
+                            drift = abs(float(current_sp) - self._last_setpoint_sent)
+                            if drift > 0.1:  # tolerance for float rounding in HA
+                                log.warning(
+                                    "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
+                                    self.thermostat_entity_id, current_sp, self._last_setpoint_sent,
                                 )
-                            except Exception as exc:
-                                log.error("Reconcile: failed to re-assert setpoint: %s", exc)
+                                if self._logger:
+                                    await self._logger.log(
+                                        "warning", "reconcile",
+                                        f"Drift: thermostat {self.thermostat_entity_id} setpoint changed "
+                                        f"from {self._last_setpoint_sent:.1f}°F to {float(current_sp):.1f}°F "
+                                        f"— re-asserting",
+                                        {"entity_id": self.thermostat_entity_id,
+                                         "expected": self._last_setpoint_sent,
+                                         "actual": float(current_sp)},
+                                    )
+                                needs_reassert = True
+
+                    if needs_reassert:
+                        try:
+                            await self._ha.set_thermostat_temperature(
+                                self.thermostat_entity_id,
+                                self._last_setpoint_sent,
+                                hvac_mode=self._cycle_ha_mode,
+                            )
+                        except Exception as exc:
+                            log.error("Reconcile: failed to re-assert mode+setpoint: %s", exc)
 
         else:
             # IDLE — all zone vents should be open; load fresh from DB.

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -685,6 +685,9 @@ class CycleEngine:
         else:
             setpoint = max(targets) + tc.overshoot_delta
             ha_mode = "heat"
+        # No clamping: min/max_setpoint are repurposed as emergency thresholds (Bug 3).
+        # The overshoot setpoint is sent as-is; it is derived from room targets which
+        # are user-configured comfort values and don't need a safety rail here.
         try:
             # Pass hvac_mode explicitly so heat_cool thermostats switch to the correct
             # single-direction mode. HA silently ignores temperature-only calls for

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -183,9 +183,22 @@ class CycleEngine:
                 )
             return
 
-        # System disabled guard — skip all HA-mutating work
+        # System disabled guard — if a cycle is running, abort it immediately.
         if self._get_enabled is not None and not self._get_enabled():
-            log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
+            if self._state != CycleState.IDLE:
+                log.warning(
+                    "System disabled while cycle running for %s — aborting cycle",
+                    self.thermostat_entity_id,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "warning", "engine",
+                        f"System disabled — aborting running cycle for {self.thermostat_entity_id}",
+                        {"thermostat": self.thermostat_entity_id},
+                    )
+                await self._abort_cycle(conn, reason="system disabled")
+            else:
+                log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
             return
 
         # Detect HVAC mode

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -3,7 +3,7 @@ Vent controller: open/close Flair cover entities with safety enforcement.
 
 Safety rules enforced here:
 - min_open_vents: never drop total open vent count below this threshold
-- max_vent_closed_min: reopen a vent that has been closed too long (0 = disabled)
+- max_vent_closed_min: opt-in safety valve — reopen a vent closed too long (0 = disabled, the default)
 """
 from __future__ import annotations
 

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -64,11 +64,20 @@ class VentController:
             currently_open = self._count_open_vents(all_zone_vents)
             would_close = len([v for v in vents if self._is_open(v.entity_id)])
             if currently_open - would_close < tc.min_open_vents:
-                log.debug(
+                log.warning(
                     "Deferring vent close — would drop to %d open (min=%d)",
                     currently_open - would_close,
                     tc.min_open_vents,
                 )
+                if self._logger:
+                    vent_ids = [v.entity_id for v in vents]
+                    await self._logger.log(
+                        "warning", "engine",
+                        f"Vent close deferred — would drop to {currently_open - would_close} open "
+                        f"(min_open_vents={tc.min_open_vents}): {vent_ids}",
+                        {"entity_ids": vent_ids, "currently_open": currently_open,
+                         "would_close": would_close, "min_open_vents": tc.min_open_vents},
+                    )
                 return False
 
         for vent in vents:

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -118,15 +118,20 @@ class VentController:
             if now - states.vent_closed_at >= limit:
                 vents = room_vents.get(room_id, [])
                 if vents:
+                    duration_min = (now - states.vent_closed_at).total_seconds() / 60
+                    vent_ids = [v.entity_id for v in vents]
                     log.warning(
-                        "Room %s vents closed > %d min — reopening for safety",
-                        room_id, tc.max_vent_closed_min,
+                        "Room %s vents %s closed %.1f min (max=%d) — reopening for safety",
+                        room_id, vent_ids, duration_min, tc.max_vent_closed_min,
                     )
                     if self._logger:
                         await self._logger.log(
                             "warning", "engine",
-                            f"Force-reopening vents for room {room_id} — closed > {tc.max_vent_closed_min}min",
-                            {"room_id": room_id, "max_vent_closed_min": tc.max_vent_closed_min},
+                            f"Force-reopening vents for room {room_id} — "
+                            f"closed {duration_min:.1f}min (max={tc.max_vent_closed_min}min): {vent_ids}",
+                            {"room_id": room_id, "entity_ids": vent_ids,
+                             "duration_closed_min": round(duration_min, 1),
+                             "max_vent_closed_min": tc.max_vent_closed_min},
                         )
                     await self.open_room_vents(vents)
                     # Reset vent_closed_at so the timer restarts

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -146,20 +146,27 @@ class HAClient:
         }
         return await self._send(msg)
 
-    async def set_thermostat_temperature(self, entity_id: str, temperature: float) -> None:
+    async def set_thermostat_temperature(
+        self,
+        entity_id: str,
+        temperature: float,
+        hvac_mode: Optional[str] = None,
+    ) -> None:
+        service_data: dict = {"entity_id": entity_id, "temperature": temperature}
+        if hvac_mode is not None:
+            service_data["hvac_mode"] = hvac_mode
         if self.dev_mode:
-            msg = f"[DEV] Would set thermostat {entity_id} → {temperature:.1f}°F"
-            log.info(msg)
+            mode_note = f", hvac_mode={hvac_mode}" if hvac_mode else ""
+            log.info("[DEV] Would set thermostat %s → %.1f°F%s", entity_id, temperature, mode_note)
             if self._dev_logger:
                 await self._dev_logger.log("info", "dev",
-                    f"Would set thermostat → {temperature:.1f}°F",
-                    {"entity_id": entity_id, "temperature": temperature, "action": "set_thermostat"})
+                    f"Would set thermostat → {temperature:.1f}°F{mode_note}",
+                    {"entity_id": entity_id, "temperature": temperature,
+                     "hvac_mode": hvac_mode, "action": "set_thermostat"})
             return
-        log.info("Setting %s setpoint → %.1f°F", entity_id, temperature)
-        await self.call_service(
-            "climate", "set_temperature",
-            {"entity_id": entity_id, "temperature": temperature},
-        )
+        log.info("Setting %s setpoint → %.1f°F%s", entity_id, temperature,
+                 f", hvac_mode={hvac_mode}" if hvac_mode else "")
+        await self.call_service("climate", "set_temperature", service_data)
 
     async def open_cover(self, entity_id: str) -> None:
         if self.dev_mode:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -103,7 +103,7 @@ class ThermostatConfig:
     min_setpoint: float = 60.0
     max_setpoint: float = 85.0
     deadband: float = 0.5       # ±°F
-    max_vent_closed_min: int = 0  # 0 = unlimited
+    max_vent_closed_min: int = 0  # 0 = disabled (opt-in safety valve only; mid-cycle force-reopens are off by default)
     min_open_vents: int = 1
     overshoot_delta: float = 2.0
     cycle_timeout_hours: float = 3.0

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -103,7 +103,7 @@ class ThermostatConfig:
     min_setpoint: float = 60.0
     max_setpoint: float = 85.0
     deadband: float = 0.5       # ±°F
-    max_vent_closed_min: int = 0  # 0 = disabled (opt-in safety valve only; mid-cycle force-reopens are off by default)
+    max_vent_closed_min: int = 0  # minutes before a closed vent is force-reopened; 0 = no limit (feature off by default)
     min_open_vents: int = 1
     overshoot_delta: float = 2.0
     cycle_timeout_hours: float = 3.0


### PR DESCRIPTION
## Summary

Full implementation of the bug fixes from issue #32 — vent timing, thermostat setpoint, and min/max bounds correctness audit.

- **Bug 1** — Deferred vent closes (due to `min_open_vents`) were only written to `log.debug`, invisible in the UI event log. Promoted to event logger `warning` with full context (entity IDs, open count, min required).
- **Bug 2** — `heat_cool` / auto thermostats were silently ignoring `climate.set_temperature` calls. `set_thermostat_temperature` now accepts an explicit `hvac_mode` param (`heat`/`cool`) and passes it to HA. Terminate and abort ambient resets also pass the cycle-locked mode.
- **Bug 3** — `min_setpoint`/`max_setpoint` were incorrectly clamping the overshoot setpoint and all ambient resets. Clamping removed entirely; those fields are now reserved for emergency thresholds (Decision C).
- **Bug 4** — Reconciliation now re-asserts `hvac_mode` in addition to setpoint. If the thermostat is switched off or to `heat_cool` mid-cycle, the next reconciliation pass corrects both mode and setpoint in a single HA call.
- **Bug 5** — Disabling the system while a cycle was running left the cycle in `RUNNING` state indefinitely. Now immediately calls `_abort_cycle` (opens vents, resets thermostat to ambient, closes cycle log).
- **Bug 6** — Single-room zone with `min_open_vents=1` deadlocked forever — the last vent close was always deferred. Fixed to bypass the constraint when this is the last vent needing to close (covers single-room zones and multi-room zones where all others have already closed).
- **Bug 7** — `max_vent_closed_min` comment said `0 = unlimited` but the code treats 0 as disabled (no force-reopens). Comment corrected to `0 = no limit (feature off by default)`.

## Post-implementation edge case fixes

Three additional corrections found during review:

- Bug 6 bypass condition was `len(active_rooms) == 1` — too narrow. Changed to count rooms with `vent_closed_at is None`; triggers correctly for the last-vent-to-close in any zone size.
- Bug 5 was double-logging the abort (once before `_abort_cycle`, once inside it). Removed the redundant pre-call log.
- `check_max_closed_duration` logged the max threshold but not the actual duration closed. Now logs `duration_closed_min` alongside the threshold and vent entity IDs per Decision E.

## Files changed

- `smart_vent/backend/engine/cycle_engine.py` — bugs 2, 3, 4, 5, 6
- `smart_vent/backend/engine/vent_controller.py` — bugs 1, 7, duration logging
- `smart_vent/backend/ha_client.py` — bug 2 (`hvac_mode` param)
- `smart_vent/backend/models.py` — bug 7 (comment fix)

## Test plan

- [ ] Verify deferred vent close appears as `warning` in the UI event log (not just Python logs)
- [ ] Test with a `heat_cool` thermostat — confirm cycle start switches to explicit `heat`/`cool` mode
- [ ] Confirm cycle terminate/abort resets setpoint to ambient without clamping
- [ ] Manually switch thermostat off mid-cycle — confirm reconciliation re-asserts mode + setpoint
- [ ] Disable the system while a cycle is running — confirm immediate abort and vent open
- [ ] Single-room zone with `min_open_vents=1` — confirm cycle terminates cleanly when room hits target
- [ ] 3-room zone where 2 rooms have closed — confirm last room closes despite `min_open_vents` constraint