### PR TITLE
fix/feat: cycle engine reliability — bugs #32, startup restore, reconciliation, duplicate cycles

### DIFF
--- a/smart_vent/Dockerfile
+++ b/smart_vent/Dockerfile
@@ -30,12 +30,18 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 # Copy backend source
 COPY backend/ backend/
 
+# Copy config.yaml so the version can be extracted and baked into the frontend bundle
+COPY config.yaml config.yaml
+
 # Install frontend deps then build (separate COPY for better layer caching)
 COPY frontend/package.json frontend/package-lock.json frontend/
 RUN cd frontend && npm ci
 
 COPY frontend/ frontend/
-RUN cd frontend && npm run build
+# Extract the version from config.yaml and pass it as a Vite build-time constant.
+# Vite replaces import.meta.env.VITE_APP_VERSION with the literal string in the bundle.
+RUN VITE_APP_VERSION=$(grep '^version:' /app/config.yaml | sed "s/version: //;s/[\"']//g" | tr -d ' ') \
+    && cd frontend && VITE_APP_VERSION=$VITE_APP_VERSION npm run build
 
 # Copy run script
 COPY run.sh /run.sh

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -528,6 +528,52 @@ async def delete_holdover_state(conn: aiosqlite.Connection, room_id: str) -> Non
 # Cycle logs
 # ---------------------------------------------------------------------------
 
+async def close_open_cycle_logs(
+    conn: aiosqlite.Connection,
+    thermostat_entity_id: str,
+    ended_at: Optional[datetime] = None,
+) -> int:
+    """
+    Close all open (ended_at IS NULL) cycle logs for a thermostat.
+
+    Called before starting a new cycle so that orphaned rows from a previous
+    server run (or an exception-path that left a dangling open log) do not
+    accumulate. Returns the number of rows closed.
+    """
+    if ended_at is None:
+        ended_at = datetime.utcnow()
+    async with conn.execute(
+        "UPDATE cycle_logs SET ended_at=? WHERE thermostat_entity_id=? AND ended_at IS NULL",
+        (ended_at.isoformat(), thermostat_entity_id),
+    ) as cur:
+        count = cur.rowcount or 0
+    await conn.commit()
+    return count
+
+
+async def get_open_cycle_logs(
+    conn: aiosqlite.Connection,
+    thermostat_entity_id: str,
+) -> list[CycleLog]:
+    """Return all open (ended_at IS NULL) cycle logs for a thermostat, newest first."""
+    async with conn.execute(
+        "SELECT * FROM cycle_logs WHERE thermostat_entity_id=? AND ended_at IS NULL ORDER BY started_at DESC",
+        (thermostat_entity_id,),
+    ) as cur:
+        rows = await cur.fetchall()
+    return [
+        CycleLog(
+            id=r["id"],
+            thermostat_entity_id=r["thermostat_entity_id"],
+            started_at=datetime.fromisoformat(r["started_at"]),
+            mode=r["mode"],
+            rooms_json=r["rooms_json"],
+            ended_at=None,
+        )
+        for r in rows
+    ]
+
+
 async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
     await conn.execute(
         "INSERT INTO cycle_logs(id,thermostat_entity_id,started_at,ended_at,mode,rooms_json) VALUES(?,?,?,?,?,?)",

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -284,6 +284,25 @@ class CycleEngine:
             # cycle lifetime to avoid mid-cycle mode misdetection (issue #26).
             self._cycle_mode = hvac_mode
 
+            # Close any open cycle logs left over from a previous server run or
+            # from an exception that occurred after a prior insert but before the
+            # state transition completed. Without this, restarting while a cycle
+            # is active produces a second open row, showing two "Active" entries
+            # in the UI for the same thermostat.
+            orphaned = await db.close_open_cycle_logs(conn, self.thermostat_entity_id)
+            if orphaned > 0:
+                log.warning(
+                    "Closed %d orphaned open cycle log(s) for %s before starting new cycle",
+                    orphaned, self.thermostat_entity_id,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "warning", "engine",
+                        f"Closed {orphaned} orphaned cycle log(s) for {self.thermostat_entity_id} "
+                        f"(stale from previous server run or failed state transition)",
+                        {"thermostat": self.thermostat_entity_id, "orphaned_count": orphaned},
+                    )
+
             # Start a fresh cycle
             rooms_snapshot = {
                 ar.room.id: {"name": ar.room.name, "target": ar.target_temp, "source": ar.source}
@@ -295,6 +314,10 @@ class CycleEngine:
                 rooms_json=json.dumps(rooms_snapshot),
             )
             await db.insert_cycle_log(conn, self._cycle_log)
+            # Transition to RUNNING immediately after the DB insert so that if
+            # any subsequent await raises, the next tick takes the running-cycle
+            # path rather than treating the engine as IDLE and inserting again.
+            self._state = CycleState.RUNNING
             self._room_cycle_states = {}
             for ar in new_active_map.values():
                 rcs = RoomCycleState(
@@ -304,7 +327,6 @@ class CycleEngine:
                 )
                 self._room_cycle_states[ar.room.id] = rcs
                 await db.upsert_room_cycle_state(conn, rcs)
-            self._state = CycleState.RUNNING
             room_names = [ar.room.name for ar in new_active_map.values()]
             log.info(
                 "Cycle started for %s — mode=%s rooms=%s",
@@ -773,6 +795,45 @@ class CycleEngine:
 
         All corrections are logged as 'warning' under category 'reconcile'.
         """
+        # Always log that reconciliation ran — even when nothing needs correcting.
+        # This gives operators a heartbeat to confirm the reconciler is active.
+        thermo_state_now = self._ha.get_state(self.thermostat_entity_id) or {}
+        ha_mode_now = thermo_state_now.get("state", "unknown")
+        ha_setpoint_now = thermo_state_now.get("attributes", {}).get("temperature")
+        log.info(
+            "Reconcile %s: engine_state=%s ha_mode=%s ha_setpoint=%s "
+            "cycle_ha_mode=%s last_setpoint_sent=%s",
+            self.thermostat_entity_id, self._state.value,
+            ha_mode_now, ha_setpoint_now,
+            self._cycle_ha_mode, self._last_setpoint_sent,
+        )
+        if self._logger:
+            await self._logger.log(
+                "info", "reconcile",
+                f"Reconcile {self.thermostat_entity_id}: engine={self._state.value}, "
+                f"ha_mode={ha_mode_now!r}, ha_setpoint={ha_setpoint_now}, "
+                f"expected_mode={self._cycle_ha_mode!r}, "
+                f"expected_setpoint={self._last_setpoint_sent}, "
+                f"active_rooms={len(self._active_rooms)}, "
+                f"cycle_id={self._cycle_log.id if self._cycle_log else 'none'}",
+                {
+                    "thermostat": self.thermostat_entity_id,
+                    "engine_state": self._state.value,
+                    "ha_mode": ha_mode_now,
+                    "ha_setpoint": ha_setpoint_now,
+                    "expected_mode": self._cycle_ha_mode,
+                    "expected_setpoint": self._last_setpoint_sent,
+                    "active_rooms": len(self._active_rooms),
+                    "cycle_id": self._cycle_log.id if self._cycle_log else None,
+                    "db_min_setpoint": tc.min_setpoint,
+                    "db_max_setpoint": tc.max_setpoint,
+                    "db_deadband": tc.deadband,
+                    "db_min_open_vents": tc.min_open_vents,
+                    "db_max_vent_closed_min": tc.max_vent_closed_min,
+                    "db_reconciliation_interval_min": tc.reconciliation_interval_min,
+                },
+            )
+
         if self._state == CycleState.RUNNING:
             all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
             for room_id, ar in self._active_rooms.items():
@@ -892,6 +953,123 @@ class CycleEngine:
                                 {"entity_id": vent.entity_id, "room_id": room.id,
                                  "thermostat": self.thermostat_entity_id},
                             )
+
+            # DB settings check (idle): warn if the HA thermostat setpoint is
+            # outside the configured bounds — could indicate an external actor
+            # set an unsafe temperature while the system was not running a cycle.
+            if ha_setpoint_now is not None:
+                try:
+                    sp = float(ha_setpoint_now)
+                    if sp < tc.min_setpoint or sp > tc.max_setpoint:
+                        log.warning(
+                            "Reconcile (idle): thermostat %s setpoint %.1f is outside "
+                            "configured bounds [%.1f, %.1f]",
+                            self.thermostat_entity_id, sp, tc.min_setpoint, tc.max_setpoint,
+                        )
+                        if self._logger:
+                            await self._logger.log(
+                                "warning", "reconcile",
+                                f"DB settings drift (idle): thermostat {self.thermostat_entity_id} "
+                                f"setpoint {sp:.1f}°F is outside configured bounds "
+                                f"[{tc.min_setpoint:.1f}, {tc.max_setpoint:.1f}]°F — "
+                                f"external actor may have changed it",
+                                {"entity_id": self.thermostat_entity_id,
+                                 "ha_setpoint": sp,
+                                 "db_min_setpoint": tc.min_setpoint,
+                                 "db_max_setpoint": tc.max_setpoint},
+                            )
+                except (ValueError, TypeError):
+                    pass
+
+    async def restore_from_db(self, conn: aiosqlite.Connection) -> None:
+        """
+        Restore in-memory cycle state from DB at startup.
+
+        If an open cycle log exists for this thermostat, the engine resumes
+        it rather than starting fresh on the first tick. This preserves:
+          - Which rooms had already hit their target (vent_closed_at)
+          - The original cycle start timestamp (timeout clock continues)
+          - Vent expectations so reconciliation can correct post-restart drift
+
+        Multiple open logs (from the pre-fix duplicate-cycle bug) are handled
+        by closing all but the most recent and restoring from the newest one.
+        Rooms that no longer exist in DB are skipped with a warning.
+        """
+        open_logs = await db.get_open_cycle_logs(conn, self.thermostat_entity_id)
+        if not open_logs:
+            return
+
+        # Close duplicates (all but the most recent); newest-first order from DB
+        to_restore = open_logs[0]
+        if len(open_logs) > 1:
+            now = datetime.utcnow()
+            for stale in open_logs[1:]:
+                await db.close_cycle_log(conn, stale.id, now)
+            log.warning(
+                "Closed %d duplicate open cycle log(s) for %s on startup",
+                len(open_logs) - 1, self.thermostat_entity_id,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "warning", "engine",
+                    f"Closed {len(open_logs) - 1} duplicate open cycle log(s) for "
+                    f"{self.thermostat_entity_id} on startup",
+                    {"thermostat": self.thermostat_entity_id,
+                     "duplicate_count": len(open_logs) - 1},
+                )
+
+        # Restore cycle log metadata
+        self._cycle_log = to_restore
+        self._cycle_mode = to_restore.mode  # 'heating' | 'cooling'
+        self._cycle_ha_mode = "cool" if to_restore.mode == "cooling" else "heat"
+
+        # Restore per-room cycle states (which rooms hit target, when vents closed)
+        room_states = await db.get_room_cycle_states(conn, to_restore.id)
+        self._room_cycle_states = {rcs.room_id: rcs for rcs in room_states}
+
+        # Restore active rooms and vents from the rooms_json snapshot + DB
+        try:
+            rooms_snapshot: dict = json.loads(to_restore.rooms_json)
+        except (json.JSONDecodeError, TypeError):
+            rooms_snapshot = {}
+
+        skipped = 0
+        for room_id, snap in rooms_snapshot.items():
+            room = await db.get_room(conn, room_id)
+            if room is None:
+                log.warning(
+                    "Restore: room %s from cycle %s no longer exists — skipping",
+                    room_id, to_restore.id,
+                )
+                skipped += 1
+                continue
+            target = float(snap.get("target", 0.0))
+            source = snap.get("source", "schedule")
+            self._active_rooms[room_id] = ActiveRoom(room=room, target_temp=target, source=source)
+            self._room_vents[room_id] = await db.get_room_vents(conn, room_id)
+
+        # Transition to RUNNING
+        self._state = CycleState.RUNNING
+
+        # Force reconciliation on first tick — _last_setpoint_sent can't be
+        # recovered from DB, so setpoint won't be checked, but mode drift will be.
+        self._last_reconciled_at = None
+
+        room_names = [ar.room.name for ar in self._active_rooms.values()]
+        log.info(
+            "Restored cycle %s for %s (mode=%s, rooms=%s%s)",
+            to_restore.id, self.thermostat_entity_id, to_restore.mode, room_names,
+            f", skipped {skipped} deleted rooms" if skipped else "",
+        )
+        if self._logger:
+            await self._logger.log(
+                "info", "engine",
+                f"Restored cycle {to_restore.id} for {self.thermostat_entity_id} "
+                f"from DB on startup (mode={to_restore.mode}, rooms={room_names})",
+                {"thermostat": self.thermostat_entity_id, "cycle_id": to_restore.id,
+                 "mode": to_restore.mode, "rooms": room_names,
+                 "rooms_skipped": skipped},
+            )
 
     async def _maybe_broadcast(self) -> None:
         if self._broadcast:

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -144,6 +144,11 @@ class Scheduler:
         self._system_enabled = enabled
         await db.set_system_setting(self._db_conn, "system_enabled", "1" if enabled else "0")
         log.info("System %s", "enabled" if enabled else "disabled")
+        if not enabled:
+            # Abort any running cycles immediately — don't wait for the next 60s tick.
+            # Each engine's _do_tick will see the disabled flag and call _abort_cycle.
+            tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]
+            await asyncio.gather(*tasks, return_exceptions=True)
         if self._broadcast:
             await self._broadcast("system_enabled_changed", {"enabled": enabled})
 
@@ -187,6 +192,9 @@ class Scheduler:
                 )
                 self._engines[tid] = engine
                 log.info("CycleEngine created for %s", tid)
+                # Restore any in-progress cycle state from DB so the engine
+                # doesn't start cold after a server restart.
+                await engine.restore_from_db(self._db_conn)
 
         for tid in list(self._engines):
             if tid not in thermostat_ids:

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -1,6 +1,6 @@
 name: "Flair Replacement"
 description: "HVAC cycle manager using Flair vents and Home Assistant thermostats"
-version: "0.5.0"
+version: "0.4.2"
 slug: "flair_replacement"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"
 arch:

--- a/smart_vent/frontend/src/main.tsx
+++ b/smart_vent/frontend/src/main.tsx
@@ -150,6 +150,9 @@ function Nav() {
       <NavLink to="/" end className="nav-brand" style={{ textDecoration: "none" }}>
         <span className="nav-icon">🌡</span>
         Flair Replacement
+        <span style={{ fontSize: ".65rem", opacity: 0.45, marginLeft: ".4rem", fontWeight: 400, letterSpacing: 0 }}>
+          v{import.meta.env.VITE_APP_VERSION ?? "dev"}
+        </span>
       </NavLink>
 
       {/* Desktop links */}

--- a/smart_vent/frontend/src/vite-env.d.ts
+++ b/smart_vent/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_VERSION?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

This PR resolves all 7 bugs from issue #32, implements both features from issue #35, and adds three additional reliability improvements discovered during review.

---

## Bug Fixes (issue #32)

### Bug 1 — Deferred vent close silently swallowed
**Before:** When `min_open_vents` prevented a room's vent from closing, the event was only logged at `DEBUG` level — invisible in production.
**After:** Promoted to `WARNING` via the event logger with full context: which vents were blocked, current open count vs threshold.

### Bug 2 — `heat_cool` thermostats not set to correct HA mode at cycle start
**Before:** `set_thermostat_temperature` had no `hvac_mode` parameter. On a `heat_cool` thermostat the HVAC would continue in whichever direction it was already going.
**After:** `ha_client.py` accepts an optional `hvac_mode` arg. The engine maps `heating → "heat"` / `cooling → "cool"` and passes it with the setpoint call, so HA switches to the correct mode atomically.

### Bug 3 — Overshoot setpoint incorrectly clamped to min/max bounds
**Before:** The overshoot setpoint (used to drive HVAC harder during a cycle) was clamped to `[min_setpoint, max_setpoint]`, defeating the purpose of overshoot entirely.
**After:** Clamping removed from the overshoot path. The bounds check still protects the *ambient reset* path.

### Bug 4 — Reconciliation only checked setpoint drift, not mode drift
**Before:** If an external actor changed the thermostat mode mid-cycle (e.g. from `cool` to `off`), reconciliation would re-assert the setpoint but not the mode — the HVAC would remain off.
**After:** Reconciliation checks `current_mode != _cycle_ha_mode` and re-asserts mode and setpoint together in one service call.

### Bug 5 — System disable waited up to 60s to abort running cycles
**Before:** `set_system_enabled(False)` only set a flag. The abort path only ran on the next scheduled tick.
**After:** `Scheduler.set_system_enabled(False)` immediately fires `_tick_engine` on every engine via `asyncio.gather`. Each engine's `_do_tick` sees the disabled flag and calls `_abort_cycle` — vents open, thermostat resets to ambient, cycle log closes within milliseconds.

### Bug 6 — Last room in a multi-room zone couldn't close its vent
**Before:** `min_open_vents` was checked against the full zone vent count without any bypass for the final room. If only one room was left, closing its vent would drop the open count below the threshold — so the cycle would never terminate.
**After:** When the room being processed is the last one with an open vent (`sum(1 for r in _room_cycle_states.values() if r.vent_closed_at is None) == 1`), the `min_open_vents` guard is bypassed. Works for single-room zones and for multi-room zones where all other rooms have already closed.

### Bug 7 — `max_vent_closed_min = 0` comment said "unlimited" but code treated it as disabled
**Before:** Comment read `# 0 = unlimited`, but the feature is completely skipped when the value is 0.
**After:** Comment corrected to `# minutes before a closed vent is force-reopened; 0 = no limit (feature off by default)`.

---

## Features (issue #35)

### Addon version shown in UI
The version from `config.yaml` is extracted by `grep`/`sed` in the `Dockerfile` and passed to Vite as `VITE_APP_VERSION` at build time. Vite hardcodes the literal string into the compiled JS bundle — no runtime API or `bashio` call needed. Displays as small muted text next to the nav brand on every page (e.g. `v0.4.2`). Falls back to `dev` for local builds.

### Immediate cycle abort on system disable
Covered under Bug 5 above.

---

## Additional Reliability Improvements

### Duplicate active cycle logs fixed
Three root causes produced multiple `ended_at IS NULL` rows for the same thermostat:
1. Server restart orphaned the previous open log (engine starts cold)
2. Exception between `insert_cycle_log` and `self._state = CycleState.RUNNING` left an open row that the next tick would duplicate
3. No DB-level guard existed

**Fix:** `close_open_cycle_logs()` is called before every new cycle insert, closing any orphaned open rows. `self._state = CycleState.RUNNING` is set immediately after the insert (before room state upserts) so a mid-upsert exception can't produce a second orphan.

### Startup cycle restore
`CycleEngine.restore_from_db()` is called from `Scheduler._sync_engines` for every newly created engine. It reads the open cycle log from DB and restores full in-memory state: `_cycle_log`, `_cycle_mode`, `_cycle_ha_mode`, `_room_cycle_states`, `_active_rooms`, `_room_vents`. After a server restart the engine resumes from where it left off rather than starting a duplicate cycle. Forces immediate reconciliation on the first tick to correct any drift that occurred during the outage. Rooms deleted between restart and restore are skipped with a warning.

### Reconciliation always logs + DB settings check
`_reconcile_state` now emits an `info` event log at the start of every run — even when nothing needs correcting — so the Logs page shows a clear heartbeat confirming the reconciler is active. The log includes engine state, HA thermostat mode/setpoint, expected mode/setpoint, cycle ID, and all key DB config values. In IDLE mode, reconciliation also warns if the HA thermostat's setpoint is outside the configured `min_setpoint`/`max_setpoint` bounds, catching external actors that changed the thermostat while no cycle was running.

> Note: reconciliation only runs when `reconciliation_interval_min > 0` in the thermostat config (defaults to `0` / disabled).

---

## Files Changed

| File | What changed |
|---|---|
| `backend/engine/cycle_engine.py` | Bugs 2–6, duplicate fix, startup restore, reconciliation improvements |
| `backend/engine/vent_controller.py` | Bug 1 — deferred close event logging |
| `backend/ha_client.py` | Bug 2 — `hvac_mode` param on `set_thermostat_temperature` |
| `backend/models.py` | Bug 7 — corrected comment |
| `backend/db.py` | `close_open_cycle_logs`, `get_open_cycle_logs` |
| `backend/scheduler.py` | Immediate abort on disable, `restore_from_db` wiring |
| `frontend/src/main.tsx` | Version badge in nav |
| `frontend/src/vite-env.d.ts` | TypeScript type for `VITE_APP_VERSION` |
| `Dockerfile` | Build-time version injection |