### PR TITLE
ci: fix contributor lookup — prevent 422 JSON leaking into CHANGELOG

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -109,11 +109,16 @@ jobs:
           CONTRIBUTORS=$(git log "${PREV_TAG}..HEAD" --format='%aN' \
             | sort -u \
             | while read -r name; do
-                # Try to resolve GitHub username from commit email
                 EMAIL=$(git log "${PREV_TAG}..HEAD" --author="$name" \
                   --format='%aE' | head -1)
-                GH_USER=$(gh api "search/users?q=${EMAIL}+in:email" \
-                  --jq '.items[0].login' 2>/dev/null || echo "")
+                GH_USER=""
+                # Skip bot/noreply emails — they always fail the Search API
+                if ! echo "$EMAIL" | grep -qE '(noreply\.github\.com|github-actions)'; then
+                  # Gate on exit code so a 4xx error body never leaks into GH_USER
+                  if RAW=$(gh api "search/users?q=${EMAIL}+in:email" 2>/dev/null); then
+                    GH_USER=$(echo "$RAW" | jq -r '.items[0].login // empty' 2>/dev/null || true)
+                  fi
+                fi
                 if [ -n "$GH_USER" ]; then
                   echo "- [@${GH_USER}](https://github.com/${GH_USER})"
                 else


### PR DESCRIPTION
## Summary

Fixes #43.

Bot commit authors (e.g. `github-actions[bot]`) have emails with URL-unsafe characters (`+`, `[`) that cause the GitHub Search API to return HTTP 422 errors. Because `gh api` writes error bodies to **stdout**, and the original `$(cmd || echo "")` pattern captured both, the full JSON error ended up verbatim in `CHANGELOG.md` and the Release PR body.

Three changes to the contributor lookup in `.github/workflows/release-pr.yml`:

- **Skip bot/noreply emails** before making any API call — they always fail with 422 and will never resolve to a username
- **Gate on exit code** using `if RAW=$(gh api ...)` so a 4xx response body on stdout never leaks into `GH_USER`
- **Use `// empty` in jq** so a missing field produces an empty string instead of the literal `"null"`

## Test plan

- [ ] Verify bot/noreply emails (e.g. `*@users.noreply.github.com`, `github-actions[bot]`) are skipped without an API call
- [ ] Verify a simulated `gh api` 4xx response does not appear in the contributor list
- [ ] Verify a real user email resolves correctly to a GitHub username
- [ ] Verify next release PR contributor list contains only real usernames or plain `git log` names — no JSON bleed-through

https://claude.ai/code/session_01E3HmvE6DXAKVbJQQq5KAA7