### PR TITLE
ci(lint): add ruff linting and formatting enforcement (issue #10)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  python-lint:
+    name: Python (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check smart_vent/backend/
+      - run: ruff format --check smart_vent/backend/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check smart_vent/backend/
-      - run: ruff format --check smart_vent/backend/
+      - run: ruff check backend/
+        working-directory: smart_vent
+      - run: ruff format --check backend/
+        working-directory: smart_vent

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -100,9 +100,7 @@ async def create_room(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     await db.upsert_room(conn, room)
     await refresh(request)
-    await emit(
-        request, "info", "api", f"Room created: {room.name}", {"room_id": room.id}
-    )
+    await emit(request, "info", "api", f"Room created: {room.name}", {"room_id": room.id})
     return json_response(room.__dict__, status=201)
 
 
@@ -147,9 +145,7 @@ async def update_room(request: web.Request) -> web.Response:
             setattr(room, field, body[field])
     await db.upsert_room(conn, room)
     await refresh(request)
-    await emit(
-        request, "info", "api", f"Room updated: {room.name}", {"room_id": room.id}
-    )
+    await emit(request, "info", "api", f"Room updated: {room.name}", {"room_id": room.id})
     return json_response(room.__dict__)
 
 
@@ -161,9 +157,7 @@ async def delete_room(request: web.Request) -> web.Response:
         return error("Room not found", 404)
     await db.delete_room(conn, room.id)
     await refresh(request)
-    await emit(
-        request, "info", "api", f"Room deleted: {room.name}", {"room_id": room.id}
-    )
+    await emit(request, "info", "api", f"Room deleted: {room.name}", {"room_id": room.id})
     return json_response({"deleted": room.id})
 
 
@@ -185,9 +179,7 @@ async def add_sensor(request: web.Request) -> web.Response:
     if not body.get("entity_id"):
         return error("entity_id required")
     conn = await get_conn(request)
-    s = RoomSensor.create(
-        room_id=request.match_info["room_id"], entity_id=body["entity_id"]
-    )
+    s = RoomSensor.create(room_id=request.match_info["room_id"], entity_id=body["entity_id"])
     await db.add_room_sensor(conn, s)
     await emit(
         request,
@@ -226,9 +218,7 @@ async def add_vent(request: web.Request) -> web.Response:
     if not body.get("entity_id"):
         return error("entity_id required")
     conn = await get_conn(request)
-    v = RoomVent.create(
-        room_id=request.match_info["room_id"], entity_id=body["entity_id"]
-    )
+    v = RoomVent.create(room_id=request.match_info["room_id"], entity_id=body["entity_id"])
     await db.add_room_vent(conn, v)
     await emit(
         request,
@@ -243,9 +233,7 @@ async def add_vent(request: web.Request) -> web.Response:
 @routes.delete("/api/rooms/{room_id}/vents/{entity_id:.*}")
 async def remove_vent(request: web.Request) -> web.Response:
     conn = await get_conn(request)
-    await db.remove_room_vent(
-        conn, request.match_info["room_id"], request.match_info["entity_id"]
-    )
+    await db.remove_room_vent(conn, request.match_info["room_id"], request.match_info["entity_id"])
     return json_response({"deleted": True})
 
 
@@ -334,9 +322,7 @@ async def create_schedule(request: web.Request) -> web.Response:
     existing = await db.get_schedules_for_room(conn, request.match_info["room_id"])
     for e in existing:
         if room_manager.schedules_overlap(s, e):
-            days_str = ", ".join(
-                room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week)
-            )
+            days_str = ", ".join(room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week))
             return error(
                 f"Overlaps with existing block on {days_str} "
                 f"{e.start_time.strftime('%H:%M')}–{e.end_time.strftime('%H:%M')}"
@@ -367,9 +353,7 @@ async def update_schedule(request: web.Request) -> web.Response:
         if e.id == schedule.id:
             continue
         if room_manager.schedules_overlap(schedule, e):
-            days_str = ", ".join(
-                room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week)
-            )
+            days_str = ", ".join(room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week))
             return error(
                 f"Overlaps with existing block on {days_str} "
                 f"{e.start_time.strftime('%H:%M')}–{e.end_time.strftime('%H:%M')}"
@@ -601,16 +585,12 @@ async def ha_entities(request: web.Request) -> web.Response:
         entities = [e for e in entities if has_attribute in e.get("attributes", {})]
     # Optional icon exclusion filter
     if exclude_icon:
-        entities = [
-            e for e in entities if e.get("attributes", {}).get("icon") != exclude_icon
-        ]
+        entities = [e for e in entities if e.get("attributes", {}).get("icon") != exclude_icon]
     result = [
         {
             "entity_id": e["entity_id"],
             "state": e.get("state"),
-            "friendly_name": e.get("attributes", {}).get(
-                "friendly_name", e["entity_id"]
-            ),
+            "friendly_name": e.get("attributes", {}).get("friendly_name", e["entity_id"]),
         }
         for e in entities
     ]
@@ -625,18 +605,14 @@ async def get_logs(request: web.Request) -> web.Response:
     offset = int(request.rel_url.query.get("offset", 0))
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
-    logs = await db.get_cycle_logs(
-        conn, limit=limit, offset=offset, since=since, until=until
-    )
+    logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
     return json_response(
         [
             {
                 "id": log_entry.id,
                 "thermostat_entity_id": log_entry.thermostat_entity_id,
                 "started_at": log_entry.started_at.isoformat(),
-                "ended_at": log_entry.ended_at.isoformat()
-                if log_entry.ended_at
-                else None,
+                "ended_at": log_entry.ended_at.isoformat() if log_entry.ended_at else None,
                 "mode": log_entry.mode,
                 "rooms": json.loads(log_entry.rooms_json),
             }
@@ -654,11 +630,7 @@ async def get_event_logs(request: web.Request) -> web.Response:
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
     level_param = request.rel_url.query.get("level") or None
-    levels = (
-        [lv.strip() for lv in level_param.split(",") if lv.strip()]
-        if level_param
-        else None
-    )
+    levels = [lv.strip() for lv in level_param.split(",") if lv.strip()] if level_param else None
     logs = await db.get_event_logs(
         conn,
         limit=limit,
@@ -683,9 +655,7 @@ async def clear_event_logs(request: web.Request) -> web.Response:
 async def get_log_retention(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
-    cycle_days = int(
-        await db.get_system_setting(conn, "cycle_log_retention_days", "30")
-    )
+    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
     return json_response(
         {
             "event_log_retention_days": event_days,
@@ -705,9 +675,7 @@ async def set_log_retention(request: web.Request) -> web.Response:
         days = max(1, int(body["cycle_log_retention_days"]))
         await db.set_system_setting(conn, "cycle_log_retention_days", str(days))
     event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
-    cycle_days = int(
-        await db.get_system_setting(conn, "cycle_log_retention_days", "30")
-    )
+    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
     return json_response(
         {
             "event_log_retention_days": event_days,
@@ -740,9 +708,7 @@ async def set_system_enabled(request: web.Request) -> web.Response:
     enabled = bool(body["enabled"])
     await request.app["scheduler"].set_system_enabled(enabled)
     state_str = "enabled" if enabled else "disabled"
-    await emit(
-        request, "info", "system", f"System {state_str} via API", {"enabled": enabled}
-    )
+    await emit(request, "info", "system", f"System {state_str} via API", {"enabled": enabled})
     return json_response({"enabled": enabled})
 
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -4,6 +4,7 @@ aiohttp REST API routes.
 All handlers are thin: validate input, call db helpers, return JSON.
 The scheduler instance is attached to app['scheduler'].
 """
+
 from __future__ import annotations
 
 import json
@@ -12,11 +13,13 @@ import os
 import shutil
 import sqlite3
 import tempfile
-from datetime import datetime, timedelta, time
+from datetime import datetime, time, timedelta
 from typing import Any
 
 from aiohttp import web
 
+from .. import db
+from ..engine import room_manager
 from ..models import (
     Room,
     RoomOverride,
@@ -24,10 +27,7 @@ from ..models import (
     RoomSensor,
     RoomVent,
     Schedule,
-    ThermostatConfig,
 )
-from .. import db
-from ..engine import room_manager
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ routes = web.RouteTableDef()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def json_response(data: Any, status: int = 200) -> web.Response:
     return web.Response(
@@ -58,7 +59,13 @@ async def refresh(request: web.Request) -> None:
     await request.app["scheduler"].refresh_engines()
 
 
-async def emit(request: web.Request, level: str, category: str, message: str, details: dict | None = None) -> None:
+async def emit(
+    request: web.Request,
+    level: str,
+    category: str,
+    message: str,
+    details: dict | None = None,
+) -> None:
     """Emit a log event via the EventLogger if available."""
     logger = request.app.get("event_logger")
     if logger:
@@ -68,6 +75,7 @@ async def emit(request: web.Request, level: str, category: str, message: str, de
 # ---------------------------------------------------------------------------
 # Rooms
 # ---------------------------------------------------------------------------
+
 
 @routes.get("/api/rooms")
 async def list_rooms(request: web.Request) -> web.Response:
@@ -92,7 +100,9 @@ async def create_room(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     await db.upsert_room(conn, room)
     await refresh(request)
-    await emit(request, "info", "api", f"Room created: {room.name}", {"room_id": room.id})
+    await emit(
+        request, "info", "api", f"Room created: {room.name}", {"room_id": room.id}
+    )
     return json_response(room.__dict__, status=201)
 
 
@@ -106,13 +116,15 @@ async def get_room(request: web.Request) -> web.Response:
     vents = await db.get_room_vents(conn, room.id)
     presence = await db.get_room_presence_sensors(conn, room.id)
     schedules = await db.get_schedules_for_room(conn, room.id)
-    return json_response({
-        **room.__dict__,
-        "sensors": [s.__dict__ for s in sensors],
-        "vents": [v.__dict__ for v in vents],
-        "presence_sensors": [p.__dict__ for p in presence],
-        "schedules": [_schedule_to_dict(s) for s in schedules],
-    })
+    return json_response(
+        {
+            **room.__dict__,
+            "sensors": [s.__dict__ for s in sensors],
+            "vents": [v.__dict__ for v in vents],
+            "presence_sensors": [p.__dict__ for p in presence],
+            "schedules": [_schedule_to_dict(s) for s in schedules],
+        }
+    )
 
 
 @routes.put("/api/rooms/{room_id}")
@@ -122,13 +134,22 @@ async def update_room(request: web.Request) -> web.Response:
     if not room:
         return error("Room not found", 404)
     body = await request.json()
-    for field in ("name", "thermostat_entity_id", "include_thermostat_sensor",
-                  "system_wide_temp", "presence_holdover_hours", "notes", "temp_offset"):
+    for field in (
+        "name",
+        "thermostat_entity_id",
+        "include_thermostat_sensor",
+        "system_wide_temp",
+        "presence_holdover_hours",
+        "notes",
+        "temp_offset",
+    ):
         if field in body:
             setattr(room, field, body[field])
     await db.upsert_room(conn, room)
     await refresh(request)
-    await emit(request, "info", "api", f"Room updated: {room.name}", {"room_id": room.id})
+    await emit(
+        request, "info", "api", f"Room updated: {room.name}", {"room_id": room.id}
+    )
     return json_response(room.__dict__)
 
 
@@ -140,13 +161,16 @@ async def delete_room(request: web.Request) -> web.Response:
         return error("Room not found", 404)
     await db.delete_room(conn, room.id)
     await refresh(request)
-    await emit(request, "info", "api", f"Room deleted: {room.name}", {"room_id": room.id})
+    await emit(
+        request, "info", "api", f"Room deleted: {room.name}", {"room_id": room.id}
+    )
     return json_response({"deleted": room.id})
 
 
 # ---------------------------------------------------------------------------
 # Room sensors
 # ---------------------------------------------------------------------------
+
 
 @routes.get("/api/rooms/{room_id}/sensors")
 async def list_sensors(request: web.Request) -> web.Response:
@@ -161,9 +185,17 @@ async def add_sensor(request: web.Request) -> web.Response:
     if not body.get("entity_id"):
         return error("entity_id required")
     conn = await get_conn(request)
-    s = RoomSensor.create(room_id=request.match_info["room_id"], entity_id=body["entity_id"])
+    s = RoomSensor.create(
+        room_id=request.match_info["room_id"], entity_id=body["entity_id"]
+    )
     await db.add_room_sensor(conn, s)
-    await emit(request, "info", "api", f"Sensor added to room {request.match_info['room_id']}: {body['entity_id']}", {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Sensor added to room {request.match_info['room_id']}: {body['entity_id']}",
+        {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]},
+    )
     return json_response(s.__dict__, status=201)
 
 
@@ -180,6 +212,7 @@ async def remove_sensor(request: web.Request) -> web.Response:
 # Room vents
 # ---------------------------------------------------------------------------
 
+
 @routes.get("/api/rooms/{room_id}/vents")
 async def list_vents(request: web.Request) -> web.Response:
     conn = await get_conn(request)
@@ -193,9 +226,17 @@ async def add_vent(request: web.Request) -> web.Response:
     if not body.get("entity_id"):
         return error("entity_id required")
     conn = await get_conn(request)
-    v = RoomVent.create(room_id=request.match_info["room_id"], entity_id=body["entity_id"])
+    v = RoomVent.create(
+        room_id=request.match_info["room_id"], entity_id=body["entity_id"]
+    )
     await db.add_room_vent(conn, v)
-    await emit(request, "info", "api", f"Vent added to room {request.match_info['room_id']}: {body['entity_id']}", {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Vent added to room {request.match_info['room_id']}: {body['entity_id']}",
+        {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]},
+    )
     return json_response(v.__dict__, status=201)
 
 
@@ -211,6 +252,7 @@ async def remove_vent(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 # Room presence sensors
 # ---------------------------------------------------------------------------
+
 
 @routes.get("/api/rooms/{room_id}/presence")
 async def list_presence(request: web.Request) -> web.Response:
@@ -229,7 +271,13 @@ async def add_presence(request: web.Request) -> web.Response:
         room_id=request.match_info["room_id"], entity_id=body["entity_id"]
     )
     await db.add_room_presence_sensor(conn, p)
-    await emit(request, "info", "api", f"Presence sensor added to room {request.match_info['room_id']}: {body['entity_id']}", {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Presence sensor added to room {request.match_info['room_id']}: {body['entity_id']}",
+        {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]},
+    )
     return json_response(p.__dict__, status=201)
 
 
@@ -245,6 +293,7 @@ async def remove_presence(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 # Schedules
 # ---------------------------------------------------------------------------
+
 
 def _schedule_to_dict(s: Schedule) -> dict:
     return {
@@ -285,7 +334,9 @@ async def create_schedule(request: web.Request) -> web.Response:
     existing = await db.get_schedules_for_room(conn, request.match_info["room_id"])
     for e in existing:
         if room_manager.schedules_overlap(s, e):
-            days_str = ", ".join(room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week))
+            days_str = ", ".join(
+                room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week)
+            )
             return error(
                 f"Overlaps with existing block on {days_str} "
                 f"{e.start_time.strftime('%H:%M')}–{e.end_time.strftime('%H:%M')}"
@@ -316,7 +367,9 @@ async def update_schedule(request: web.Request) -> web.Response:
         if e.id == schedule.id:
             continue
         if room_manager.schedules_overlap(schedule, e):
-            days_str = ", ".join(room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week))
+            days_str = ", ".join(
+                room_manager.DAYS_SHORT[d] for d in sorted(e.days_of_week)
+            )
             return error(
                 f"Overlaps with existing block on {days_str} "
                 f"{e.start_time.strftime('%H:%M')}–{e.end_time.strftime('%H:%M')}"
@@ -336,6 +389,7 @@ async def delete_schedule(request: web.Request) -> web.Response:
 # Thermostat configs
 # ---------------------------------------------------------------------------
 
+
 @routes.get("/api/thermostats")
 async def list_thermostats(request: web.Request) -> web.Response:
     conn = await get_conn(request)
@@ -351,15 +405,29 @@ async def create_thermostat(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     # Load defaults then apply body fields
     tc = await db.get_thermostat_config(conn, body["thermostat_entity_id"])
-    for field in ("name", "default_temp", "min_setpoint", "max_setpoint", "deadband",
-                  "max_vent_closed_min", "min_open_vents", "overshoot_delta", "cycle_timeout_hours",
-                  "reconciliation_interval_min"):
+    for field in (
+        "name",
+        "default_temp",
+        "min_setpoint",
+        "max_setpoint",
+        "deadband",
+        "max_vent_closed_min",
+        "min_open_vents",
+        "overshoot_delta",
+        "cycle_timeout_hours",
+        "reconciliation_interval_min",
+    ):
         if field in body:
             setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
     await refresh(request)
-    await emit(request, "info", "api", f"Thermostat registered: {tc.name or tc.thermostat_entity_id}",
-               {"entity_id": tc.thermostat_entity_id})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Thermostat registered: {tc.name or tc.thermostat_entity_id}",
+        {"entity_id": tc.thermostat_entity_id},
+    )
     return json_response(tc.__dict__, status=201)
 
 
@@ -370,16 +438,27 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
     tc = await db.get_thermostat_config(conn, entity_id)
     body = await request.json()
     for field in (
-        "name", "default_temp",
-        "min_setpoint", "max_setpoint", "deadband", "max_vent_closed_min",
-        "min_open_vents", "overshoot_delta", "cycle_timeout_hours",
+        "name",
+        "default_temp",
+        "min_setpoint",
+        "max_setpoint",
+        "deadband",
+        "max_vent_closed_min",
+        "min_open_vents",
+        "overshoot_delta",
+        "cycle_timeout_hours",
         "reconciliation_interval_min",
     ):
         if field in body:
             setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
-    await emit(request, "info", "api", f"Thermostat updated: {tc.name or tc.thermostat_entity_id}",
-               {"entity_id": tc.thermostat_entity_id})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Thermostat updated: {tc.name or tc.thermostat_entity_id}",
+        {"entity_id": tc.thermostat_entity_id},
+    )
     return json_response(tc.__dict__)
 
 
@@ -389,13 +468,20 @@ async def delete_thermostat(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     await db.delete_thermostat_config(conn, entity_id)
     await refresh(request)
-    await emit(request, "info", "api", f"Thermostat removed: {entity_id}", {"entity_id": entity_id})
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Thermostat removed: {entity_id}",
+        {"entity_id": entity_id},
+    )
     return json_response({"deleted": entity_id})
 
 
 # ---------------------------------------------------------------------------
 # Overrides
 # ---------------------------------------------------------------------------
+
 
 @routes.post("/api/rooms/{room_id}/override")
 async def set_override(request: web.Request) -> web.Response:
@@ -410,11 +496,13 @@ async def set_override(request: web.Request) -> web.Response:
     )
     conn = await get_conn(request)
     await db.set_room_override(conn, override)
-    return json_response({
-        "room_id": override.room_id,
-        "target_temp": override.target_temp,
-        "expires_at": override.expires_at.isoformat(),
-    })
+    return json_response(
+        {
+            "room_id": override.room_id,
+            "target_temp": override.target_temp,
+            "expires_at": override.expires_at.isoformat(),
+        }
+    )
 
 
 @routes.delete("/api/rooms/{room_id}/override")
@@ -427,6 +515,7 @@ async def clear_override(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 # Room active-status (for UI cards)
 # ---------------------------------------------------------------------------
+
 
 @routes.post("/api/rooms/active-status")
 async def rooms_active_status(request: web.Request) -> web.Response:
@@ -455,6 +544,7 @@ async def rooms_active_status(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 # System status + HA entity proxy
 # ---------------------------------------------------------------------------
+
 
 @routes.get("/api/status")
 async def status(request: web.Request) -> web.Response:
@@ -499,8 +589,8 @@ async def ha_states(request: web.Request) -> web.Response:
 @routes.get("/api/ha/entities")
 async def ha_entities(request: web.Request) -> web.Response:
     domain = request.rel_url.query.get("domain")
-    has_attribute = request.rel_url.query.get("has_attribute")   # e.g. "hvac_action"
-    exclude_icon = request.rel_url.query.get("exclude_icon")     # e.g. "mdi:door-open"
+    has_attribute = request.rel_url.query.get("has_attribute")  # e.g. "hvac_action"
+    exclude_icon = request.rel_url.query.get("exclude_icon")  # e.g. "mdi:door-open"
     ha = request.app["ha"]
     if domain:
         entities = await ha.get_entities_by_domain(domain)
@@ -512,14 +602,15 @@ async def ha_entities(request: web.Request) -> web.Response:
     # Optional icon exclusion filter
     if exclude_icon:
         entities = [
-            e for e in entities
-            if e.get("attributes", {}).get("icon") != exclude_icon
+            e for e in entities if e.get("attributes", {}).get("icon") != exclude_icon
         ]
     result = [
         {
             "entity_id": e["entity_id"],
             "state": e.get("state"),
-            "friendly_name": e.get("attributes", {}).get("friendly_name", e["entity_id"]),
+            "friendly_name": e.get("attributes", {}).get(
+                "friendly_name", e["entity_id"]
+            ),
         }
         for e in entities
     ]
@@ -534,18 +625,24 @@ async def get_logs(request: web.Request) -> web.Response:
     offset = int(request.rel_url.query.get("offset", 0))
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
-    logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
-    return json_response([
-        {
-            "id": l.id,
-            "thermostat_entity_id": l.thermostat_entity_id,
-            "started_at": l.started_at.isoformat(),
-            "ended_at": l.ended_at.isoformat() if l.ended_at else None,
-            "mode": l.mode,
-            "rooms": json.loads(l.rooms_json),
-        }
-        for l in logs
-    ])
+    logs = await db.get_cycle_logs(
+        conn, limit=limit, offset=offset, since=since, until=until
+    )
+    return json_response(
+        [
+            {
+                "id": log_entry.id,
+                "thermostat_entity_id": log_entry.thermostat_entity_id,
+                "started_at": log_entry.started_at.isoformat(),
+                "ended_at": log_entry.ended_at.isoformat()
+                if log_entry.ended_at
+                else None,
+                "mode": log_entry.mode,
+                "rooms": json.loads(log_entry.rooms_json),
+            }
+            for log_entry in logs
+        ]
+    )
 
 
 @routes.get("/api/logs/events")
@@ -557,10 +654,19 @@ async def get_event_logs(request: web.Request) -> web.Response:
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
     level_param = request.rel_url.query.get("level") or None
-    levels = [lv.strip() for lv in level_param.split(",") if lv.strip()] if level_param else None
+    levels = (
+        [lv.strip() for lv in level_param.split(",") if lv.strip()]
+        if level_param
+        else None
+    )
     logs = await db.get_event_logs(
-        conn, limit=limit, offset=offset, category=category,
-        since=since, until=until, levels=levels,
+        conn,
+        limit=limit,
+        offset=offset,
+        category=category,
+        since=since,
+        until=until,
+        levels=levels,
     )
     return json_response(logs)
 
@@ -577,11 +683,15 @@ async def clear_event_logs(request: web.Request) -> web.Response:
 async def get_log_retention(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
-    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
-    return json_response({
-        "event_log_retention_days": event_days,
-        "cycle_log_retention_days": cycle_days,
-    })
+    cycle_days = int(
+        await db.get_system_setting(conn, "cycle_log_retention_days", "30")
+    )
+    return json_response(
+        {
+            "event_log_retention_days": event_days,
+            "cycle_log_retention_days": cycle_days,
+        }
+    )
 
 
 @routes.post("/api/settings/log-retention")
@@ -595,24 +705,31 @@ async def set_log_retention(request: web.Request) -> web.Response:
         days = max(1, int(body["cycle_log_retention_days"]))
         await db.set_system_setting(conn, "cycle_log_retention_days", str(days))
     event_days = int(await db.get_system_setting(conn, "event_log_retention_days", "7"))
-    cycle_days = int(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
-    return json_response({
-        "event_log_retention_days": event_days,
-        "cycle_log_retention_days": cycle_days,
-    })
+    cycle_days = int(
+        await db.get_system_setting(conn, "cycle_log_retention_days", "30")
+    )
+    return json_response(
+        {
+            "event_log_retention_days": event_days,
+            "cycle_log_retention_days": cycle_days,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # System enable / disable + developer mode
 # ---------------------------------------------------------------------------
 
+
 @routes.get("/api/system/status")
 async def system_status(request: web.Request) -> web.Response:
     scheduler = request.app["scheduler"]
-    return json_response({
-        "enabled": scheduler.get_system_enabled(),
-        "dev_mode": scheduler.get_dev_mode(),
-    })
+    return json_response(
+        {
+            "enabled": scheduler.get_system_enabled(),
+            "dev_mode": scheduler.get_dev_mode(),
+        }
+    )
 
 
 @routes.post("/api/system/enabled")
@@ -623,7 +740,9 @@ async def set_system_enabled(request: web.Request) -> web.Response:
     enabled = bool(body["enabled"])
     await request.app["scheduler"].set_system_enabled(enabled)
     state_str = "enabled" if enabled else "disabled"
-    await emit(request, "info", "system", f"System {state_str} via API", {"enabled": enabled})
+    await emit(
+        request, "info", "system", f"System {state_str} via API", {"enabled": enabled}
+    )
     return json_response({"enabled": enabled})
 
 
@@ -645,6 +764,7 @@ async def set_dev_mode(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 # Backup / Restore
 # ---------------------------------------------------------------------------
+
 
 @routes.get("/api/backup")
 async def backup_db(request: web.Request) -> web.Response:

--- a/smart_vent/backend/api/ws_handler.py
+++ b/smart_vent/backend/api/ws_handler.py
@@ -2,15 +2,14 @@
 WebSocket handler for live UI updates.
 Clients connect to /ws and receive JSON push events.
 """
+
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import weakref
-from typing import Optional
 
-from aiohttp import web, WSMsgType
+from aiohttp import WSMsgType, web
 
 log = logging.getLogger(__name__)
 

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -3,12 +3,12 @@ SQLite database layer using aiosqlite.
 All public functions are async and accept an aiosqlite.Connection.
 Call `init_db(conn)` once at startup to create tables.
 """
+
 from __future__ import annotations
 
 import json
 import logging
 from datetime import datetime, time, timedelta
-from typing import Optional
 
 import aiosqlite
 
@@ -165,7 +165,8 @@ _MIGRATIONS = [
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _dt(s: Optional[str]) -> Optional[datetime]:
+
+def _dt(s: str | None) -> datetime | None:
     return datetime.fromisoformat(s) if s else None
 
 
@@ -173,7 +174,7 @@ def _t(s: str) -> time:
     return time.fromisoformat(s)
 
 
-def _dts(dt: Optional[datetime]) -> Optional[str]:
+def _dts(dt: datetime | None) -> str | None:
     return dt.isoformat() if dt else None
 
 
@@ -181,19 +182,22 @@ def _dts(dt: Optional[datetime]) -> Optional[str]:
 # Rooms
 # ---------------------------------------------------------------------------
 
+
 async def get_all_rooms(conn: aiosqlite.Connection) -> list[Room]:
     async with conn.execute("SELECT * FROM rooms ORDER BY name") as cur:
         rows = await cur.fetchall()
     return [_row_to_room(r) for r in rows]
 
 
-async def get_room(conn: aiosqlite.Connection, room_id: str) -> Optional[Room]:
+async def get_room(conn: aiosqlite.Connection, room_id: str) -> Room | None:
     async with conn.execute("SELECT * FROM rooms WHERE id=?", (room_id,)) as cur:
         row = await cur.fetchone()
     return _row_to_room(row) if row else None
 
 
-async def get_rooms_for_thermostat(conn: aiosqlite.Connection, thermostat_entity_id: str) -> list[Room]:
+async def get_rooms_for_thermostat(
+    conn: aiosqlite.Connection, thermostat_entity_id: str
+) -> list[Room]:
     async with conn.execute(
         "SELECT * FROM rooms WHERE thermostat_entity_id=? ORDER BY name",
         (thermostat_entity_id,),
@@ -230,9 +234,14 @@ async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
              temp_offset=excluded.temp_offset
         """,
         (
-            room.id, room.name, room.thermostat_entity_id,
-            int(room.include_thermostat_sensor), room.system_wide_temp,
-            room.presence_holdover_hours, room.notes, room.temp_offset,
+            room.id,
+            room.name,
+            room.thermostat_entity_id,
+            int(room.include_thermostat_sensor),
+            room.system_wide_temp,
+            room.presence_holdover_hours,
+            room.notes,
+            room.temp_offset,
         ),
     )
     await conn.commit()
@@ -247,10 +256,18 @@ async def delete_room(conn: aiosqlite.Connection, room_id: str) -> None:
 # Room sub-entities (sensors, vents, presence)
 # ---------------------------------------------------------------------------
 
-async def get_room_sensors(conn: aiosqlite.Connection, room_id: str) -> list[RoomSensor]:
-    async with conn.execute("SELECT * FROM room_sensors WHERE room_id=?", (room_id,)) as cur:
+
+async def get_room_sensors(
+    conn: aiosqlite.Connection, room_id: str
+) -> list[RoomSensor]:
+    async with conn.execute(
+        "SELECT * FROM room_sensors WHERE room_id=?", (room_id,)
+    ) as cur:
         rows = await cur.fetchall()
-    return [RoomSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
+    return [
+        RoomSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
+        for r in rows
+    ]
 
 
 async def add_room_sensor(conn: aiosqlite.Connection, s: RoomSensor) -> None:
@@ -261,15 +278,24 @@ async def add_room_sensor(conn: aiosqlite.Connection, s: RoomSensor) -> None:
     await conn.commit()
 
 
-async def remove_room_sensor(conn: aiosqlite.Connection, room_id: str, entity_id: str) -> None:
-    await conn.execute("DELETE FROM room_sensors WHERE room_id=? AND entity_id=?", (room_id, entity_id))
+async def remove_room_sensor(
+    conn: aiosqlite.Connection, room_id: str, entity_id: str
+) -> None:
+    await conn.execute(
+        "DELETE FROM room_sensors WHERE room_id=? AND entity_id=?", (room_id, entity_id)
+    )
     await conn.commit()
 
 
 async def get_room_vents(conn: aiosqlite.Connection, room_id: str) -> list[RoomVent]:
-    async with conn.execute("SELECT * FROM room_vents WHERE room_id=?", (room_id,)) as cur:
+    async with conn.execute(
+        "SELECT * FROM room_vents WHERE room_id=?", (room_id,)
+    ) as cur:
         rows = await cur.fetchall()
-    return [RoomVent(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
+    return [
+        RoomVent(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
+        for r in rows
+    ]
 
 
 async def add_room_vent(conn: aiosqlite.Connection, v: RoomVent) -> None:
@@ -280,18 +306,31 @@ async def add_room_vent(conn: aiosqlite.Connection, v: RoomVent) -> None:
     await conn.commit()
 
 
-async def remove_room_vent(conn: aiosqlite.Connection, room_id: str, entity_id: str) -> None:
-    await conn.execute("DELETE FROM room_vents WHERE room_id=? AND entity_id=?", (room_id, entity_id))
+async def remove_room_vent(
+    conn: aiosqlite.Connection, room_id: str, entity_id: str
+) -> None:
+    await conn.execute(
+        "DELETE FROM room_vents WHERE room_id=? AND entity_id=?", (room_id, entity_id)
+    )
     await conn.commit()
 
 
-async def get_room_presence_sensors(conn: aiosqlite.Connection, room_id: str) -> list[RoomPresenceSensor]:
-    async with conn.execute("SELECT * FROM room_presence_sensors WHERE room_id=?", (room_id,)) as cur:
+async def get_room_presence_sensors(
+    conn: aiosqlite.Connection, room_id: str
+) -> list[RoomPresenceSensor]:
+    async with conn.execute(
+        "SELECT * FROM room_presence_sensors WHERE room_id=?", (room_id,)
+    ) as cur:
         rows = await cur.fetchall()
-    return [RoomPresenceSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
+    return [
+        RoomPresenceSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
+        for r in rows
+    ]
 
 
-async def add_room_presence_sensor(conn: aiosqlite.Connection, p: RoomPresenceSensor) -> None:
+async def add_room_presence_sensor(
+    conn: aiosqlite.Connection, p: RoomPresenceSensor
+) -> None:
     await conn.execute(
         "INSERT OR IGNORE INTO room_presence_sensors(id,room_id,entity_id) VALUES (?,?,?)",
         (p.id, p.room_id, p.entity_id),
@@ -299,9 +338,12 @@ async def add_room_presence_sensor(conn: aiosqlite.Connection, p: RoomPresenceSe
     await conn.commit()
 
 
-async def remove_room_presence_sensor(conn: aiosqlite.Connection, room_id: str, entity_id: str) -> None:
+async def remove_room_presence_sensor(
+    conn: aiosqlite.Connection, room_id: str, entity_id: str
+) -> None:
     await conn.execute(
-        "DELETE FROM room_presence_sensors WHERE room_id=? AND entity_id=?", (room_id, entity_id)
+        "DELETE FROM room_presence_sensors WHERE room_id=? AND entity_id=?",
+        (room_id, entity_id),
     )
     await conn.commit()
 
@@ -310,7 +352,10 @@ async def remove_room_presence_sensor(conn: aiosqlite.Connection, room_id: str, 
 # Schedules
 # ---------------------------------------------------------------------------
 
-async def get_schedules_for_room(conn: aiosqlite.Connection, room_id: str) -> list[Schedule]:
+
+async def get_schedules_for_room(
+    conn: aiosqlite.Connection, room_id: str
+) -> list[Schedule]:
     async with conn.execute(
         "SELECT * FROM schedules WHERE room_id=? ORDER BY start_time", (room_id,)
     ) as cur:
@@ -346,8 +391,12 @@ async def upsert_schedule(conn: aiosqlite.Connection, s: Schedule) -> None:
              target_temp=excluded.target_temp
         """,
         (
-            s.id, s.room_id, json.dumps(s.days_of_week),
-            s.start_time.isoformat(), s.end_time.isoformat(), s.target_temp,
+            s.id,
+            s.room_id,
+            json.dumps(s.days_of_week),
+            s.start_time.isoformat(),
+            s.end_time.isoformat(),
+            s.target_temp,
         ),
     )
     await conn.commit()
@@ -362,6 +411,7 @@ async def delete_schedule(conn: aiosqlite.Connection, schedule_id: str) -> None:
 # Thermostat config
 # ---------------------------------------------------------------------------
 
+
 async def get_thermostat_config(
     conn: aiosqlite.Connection, entity_id: str
 ) -> ThermostatConfig:
@@ -374,7 +424,9 @@ async def get_thermostat_config(
     return ThermostatConfig(thermostat_entity_id=entity_id)
 
 
-async def get_all_thermostat_configs(conn: aiosqlite.Connection) -> list[ThermostatConfig]:
+async def get_all_thermostat_configs(
+    conn: aiosqlite.Connection,
+) -> list[ThermostatConfig]:
     async with conn.execute("SELECT * FROM thermostat_configs") as cur:
         rows = await cur.fetchall()
     return [_row_to_tc(r) for r in rows]
@@ -396,7 +448,9 @@ def _row_to_tc(row) -> ThermostatConfig:
     )
 
 
-async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatConfig) -> None:
+async def upsert_thermostat_config(
+    conn: aiosqlite.Connection, tc: ThermostatConfig
+) -> None:
     await conn.execute(
         """INSERT INTO thermostat_configs
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
@@ -416,9 +470,16 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              reconciliation_interval_min=excluded.reconciliation_interval_min
         """,
         (
-            tc.thermostat_entity_id, tc.name, tc.default_temp,
-            tc.min_setpoint, tc.max_setpoint, tc.deadband,
-            tc.max_vent_closed_min, tc.min_open_vents, tc.overshoot_delta, tc.cycle_timeout_hours,
+            tc.thermostat_entity_id,
+            tc.name,
+            tc.default_temp,
+            tc.min_setpoint,
+            tc.max_setpoint,
+            tc.deadband,
+            tc.max_vent_closed_min,
+            tc.min_open_vents,
+            tc.overshoot_delta,
+            tc.cycle_timeout_hours,
             tc.reconciliation_interval_min,
         ),
     )
@@ -436,7 +497,10 @@ async def delete_thermostat_config(conn: aiosqlite.Connection, entity_id: str) -
 # Room overrides
 # ---------------------------------------------------------------------------
 
-async def get_room_override(conn: aiosqlite.Connection, room_id: str) -> Optional[RoomOverride]:
+
+async def get_room_override(
+    conn: aiosqlite.Connection, room_id: str
+) -> RoomOverride | None:
     async with conn.execute(
         "SELECT * FROM room_overrides WHERE room_id=?", (room_id,)
     ) as cur:
@@ -468,7 +532,8 @@ async def clear_room_override(conn: aiosqlite.Connection, room_id: str) -> None:
 
 async def clear_expired_overrides(conn: aiosqlite.Connection) -> None:
     await conn.execute(
-        "DELETE FROM room_overrides WHERE expires_at < ?", (datetime.utcnow().isoformat(),)
+        "DELETE FROM room_overrides WHERE expires_at < ?",
+        (datetime.utcnow().isoformat(),),
     )
     await conn.commit()
 
@@ -477,7 +542,10 @@ async def clear_expired_overrides(conn: aiosqlite.Connection) -> None:
 # Presence holdover state
 # ---------------------------------------------------------------------------
 
-async def get_all_holdover_states(conn: aiosqlite.Connection) -> list[PresenceHoldoverState]:
+
+async def get_all_holdover_states(
+    conn: aiosqlite.Connection,
+) -> list[PresenceHoldoverState]:
     async with conn.execute("SELECT * FROM presence_holdover_state") as cur:
         rows = await cur.fetchall()
     return [
@@ -492,7 +560,7 @@ async def get_all_holdover_states(conn: aiosqlite.Connection) -> list[PresenceHo
 
 async def get_holdover_state(
     conn: aiosqlite.Connection, room_id: str
-) -> Optional[PresenceHoldoverState]:
+) -> PresenceHoldoverState | None:
     async with conn.execute(
         "SELECT * FROM presence_holdover_state WHERE room_id=?", (room_id,)
     ) as cur:
@@ -506,7 +574,9 @@ async def get_holdover_state(
     )
 
 
-async def upsert_holdover_state(conn: aiosqlite.Connection, state: PresenceHoldoverState) -> None:
+async def upsert_holdover_state(
+    conn: aiosqlite.Connection, state: PresenceHoldoverState
+) -> None:
     await conn.execute(
         """INSERT INTO presence_holdover_state(room_id,last_detected_at,expires_at)
            VALUES(?,?,?)
@@ -514,13 +584,19 @@ async def upsert_holdover_state(conn: aiosqlite.Connection, state: PresenceHoldo
              last_detected_at=excluded.last_detected_at,
              expires_at=excluded.expires_at
         """,
-        (state.room_id, state.last_detected_at.isoformat(), state.expires_at.isoformat()),
+        (
+            state.room_id,
+            state.last_detected_at.isoformat(),
+            state.expires_at.isoformat(),
+        ),
     )
     await conn.commit()
 
 
 async def delete_holdover_state(conn: aiosqlite.Connection, room_id: str) -> None:
-    await conn.execute("DELETE FROM presence_holdover_state WHERE room_id=?", (room_id,))
+    await conn.execute(
+        "DELETE FROM presence_holdover_state WHERE room_id=?", (room_id,)
+    )
     await conn.commit()
 
 
@@ -528,10 +604,11 @@ async def delete_holdover_state(conn: aiosqlite.Connection, room_id: str) -> Non
 # Cycle logs
 # ---------------------------------------------------------------------------
 
+
 async def close_open_cycle_logs(
     conn: aiosqlite.Connection,
     thermostat_entity_id: str,
-    ended_at: Optional[datetime] = None,
+    ended_at: datetime | None = None,
 ) -> int:
     """
     Close all open (ended_at IS NULL) cycle logs for a thermostat.
@@ -578,14 +655,20 @@ async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
     await conn.execute(
         "INSERT INTO cycle_logs(id,thermostat_entity_id,started_at,ended_at,mode,rooms_json) VALUES(?,?,?,?,?,?)",
         (
-            log_.id, log_.thermostat_entity_id, log_.started_at.isoformat(),
-            _dts(log_.ended_at), log_.mode, log_.rooms_json,
+            log_.id,
+            log_.thermostat_entity_id,
+            log_.started_at.isoformat(),
+            _dts(log_.ended_at),
+            log_.mode,
+            log_.rooms_json,
         ),
     )
     await conn.commit()
 
 
-async def close_cycle_log(conn: aiosqlite.Connection, cycle_id: str, ended_at: datetime) -> None:
+async def close_cycle_log(
+    conn: aiosqlite.Connection, cycle_id: str, ended_at: datetime
+) -> None:
     await conn.execute(
         "UPDATE cycle_logs SET ended_at=? WHERE id=?", (ended_at.isoformat(), cycle_id)
     )
@@ -596,8 +679,8 @@ async def get_cycle_logs(
     conn: aiosqlite.Connection,
     limit: int = 50,
     offset: int = 0,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
+    since: str | None = None,
+    until: str | None = None,
 ) -> list[CycleLog]:
     conditions: list[str] = []
     params: list = []
@@ -638,7 +721,9 @@ async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> 
     return count
 
 
-async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleState) -> None:
+async def upsert_room_cycle_state(
+    conn: aiosqlite.Connection, rcs: RoomCycleState
+) -> None:
     await conn.execute(
         """INSERT INTO room_cycle_states(cycle_id,room_id,target_temp,reached_at,vent_closed_at)
            VALUES(?,?,?,?,?)
@@ -646,7 +731,13 @@ async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleStat
              reached_at=excluded.reached_at,
              vent_closed_at=excluded.vent_closed_at
         """,
-        (rcs.cycle_id, rcs.room_id, rcs.target_temp, _dts(rcs.reached_at), _dts(rcs.vent_closed_at)),
+        (
+            rcs.cycle_id,
+            rcs.room_id,
+            rcs.target_temp,
+            _dts(rcs.reached_at),
+            _dts(rcs.vent_closed_at),
+        ),
     )
     await conn.commit()
 
@@ -674,6 +765,7 @@ async def get_room_cycle_states(
 # System settings
 # ---------------------------------------------------------------------------
 
+
 async def get_system_setting(
     conn: aiosqlite.Connection, key: str, default: str = ""
 ) -> str:
@@ -684,9 +776,7 @@ async def get_system_setting(
     return row["value"] if row else default
 
 
-async def set_system_setting(
-    conn: aiosqlite.Connection, key: str, value: str
-) -> None:
+async def set_system_setting(conn: aiosqlite.Connection, key: str, value: str) -> None:
     await conn.execute(
         """INSERT INTO system_settings(key,value) VALUES(?,?)
            ON CONFLICT(key) DO UPDATE SET value=excluded.value""",
@@ -709,7 +799,7 @@ async def insert_event_log(
     level: str,
     category: str,
     message: str,
-    details: Optional[str],
+    details: str | None,
 ) -> int:
     """Insert an event log row and return its rowid. Trims to _EVENT_LOG_MAX periodically."""
     async with conn.execute(
@@ -736,10 +826,10 @@ async def get_event_logs(
     conn: aiosqlite.Connection,
     limit: int = 200,
     offset: int = 0,
-    category: Optional[str] = None,
-    since: Optional[str] = None,
-    until: Optional[str] = None,
-    levels: Optional[list[str]] = None,
+    category: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    levels: list[str] | None = None,
 ) -> list[dict]:
     conditions: list[str] = []
     params: list = []

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -257,17 +257,10 @@ async def delete_room(conn: aiosqlite.Connection, room_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def get_room_sensors(
-    conn: aiosqlite.Connection, room_id: str
-) -> list[RoomSensor]:
-    async with conn.execute(
-        "SELECT * FROM room_sensors WHERE room_id=?", (room_id,)
-    ) as cur:
+async def get_room_sensors(conn: aiosqlite.Connection, room_id: str) -> list[RoomSensor]:
+    async with conn.execute("SELECT * FROM room_sensors WHERE room_id=?", (room_id,)) as cur:
         rows = await cur.fetchall()
-    return [
-        RoomSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
-        for r in rows
-    ]
+    return [RoomSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
 
 
 async def add_room_sensor(conn: aiosqlite.Connection, s: RoomSensor) -> None:
@@ -278,9 +271,7 @@ async def add_room_sensor(conn: aiosqlite.Connection, s: RoomSensor) -> None:
     await conn.commit()
 
 
-async def remove_room_sensor(
-    conn: aiosqlite.Connection, room_id: str, entity_id: str
-) -> None:
+async def remove_room_sensor(conn: aiosqlite.Connection, room_id: str, entity_id: str) -> None:
     await conn.execute(
         "DELETE FROM room_sensors WHERE room_id=? AND entity_id=?", (room_id, entity_id)
     )
@@ -288,14 +279,9 @@ async def remove_room_sensor(
 
 
 async def get_room_vents(conn: aiosqlite.Connection, room_id: str) -> list[RoomVent]:
-    async with conn.execute(
-        "SELECT * FROM room_vents WHERE room_id=?", (room_id,)
-    ) as cur:
+    async with conn.execute("SELECT * FROM room_vents WHERE room_id=?", (room_id,)) as cur:
         rows = await cur.fetchall()
-    return [
-        RoomVent(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
-        for r in rows
-    ]
+    return [RoomVent(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
 
 
 async def add_room_vent(conn: aiosqlite.Connection, v: RoomVent) -> None:
@@ -306,9 +292,7 @@ async def add_room_vent(conn: aiosqlite.Connection, v: RoomVent) -> None:
     await conn.commit()
 
 
-async def remove_room_vent(
-    conn: aiosqlite.Connection, room_id: str, entity_id: str
-) -> None:
+async def remove_room_vent(conn: aiosqlite.Connection, room_id: str, entity_id: str) -> None:
     await conn.execute(
         "DELETE FROM room_vents WHERE room_id=? AND entity_id=?", (room_id, entity_id)
     )
@@ -323,14 +307,11 @@ async def get_room_presence_sensors(
     ) as cur:
         rows = await cur.fetchall()
     return [
-        RoomPresenceSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"])
-        for r in rows
+        RoomPresenceSensor(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows
     ]
 
 
-async def add_room_presence_sensor(
-    conn: aiosqlite.Connection, p: RoomPresenceSensor
-) -> None:
+async def add_room_presence_sensor(conn: aiosqlite.Connection, p: RoomPresenceSensor) -> None:
     await conn.execute(
         "INSERT OR IGNORE INTO room_presence_sensors(id,room_id,entity_id) VALUES (?,?,?)",
         (p.id, p.room_id, p.entity_id),
@@ -353,9 +334,7 @@ async def remove_room_presence_sensor(
 # ---------------------------------------------------------------------------
 
 
-async def get_schedules_for_room(
-    conn: aiosqlite.Connection, room_id: str
-) -> list[Schedule]:
+async def get_schedules_for_room(conn: aiosqlite.Connection, room_id: str) -> list[Schedule]:
     async with conn.execute(
         "SELECT * FROM schedules WHERE room_id=? ORDER BY start_time", (room_id,)
     ) as cur:
@@ -412,9 +391,7 @@ async def delete_schedule(conn: aiosqlite.Connection, schedule_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def get_thermostat_config(
-    conn: aiosqlite.Connection, entity_id: str
-) -> ThermostatConfig:
+async def get_thermostat_config(conn: aiosqlite.Connection, entity_id: str) -> ThermostatConfig:
     async with conn.execute(
         "SELECT * FROM thermostat_configs WHERE thermostat_entity_id=?", (entity_id,)
     ) as cur:
@@ -448,9 +425,7 @@ def _row_to_tc(row) -> ThermostatConfig:
     )
 
 
-async def upsert_thermostat_config(
-    conn: aiosqlite.Connection, tc: ThermostatConfig
-) -> None:
+async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatConfig) -> None:
     await conn.execute(
         """INSERT INTO thermostat_configs
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
@@ -487,9 +462,7 @@ async def upsert_thermostat_config(
 
 
 async def delete_thermostat_config(conn: aiosqlite.Connection, entity_id: str) -> None:
-    await conn.execute(
-        "DELETE FROM thermostat_configs WHERE thermostat_entity_id=?", (entity_id,)
-    )
+    await conn.execute("DELETE FROM thermostat_configs WHERE thermostat_entity_id=?", (entity_id,))
     await conn.commit()
 
 
@@ -498,12 +471,8 @@ async def delete_thermostat_config(conn: aiosqlite.Connection, entity_id: str) -
 # ---------------------------------------------------------------------------
 
 
-async def get_room_override(
-    conn: aiosqlite.Connection, room_id: str
-) -> RoomOverride | None:
-    async with conn.execute(
-        "SELECT * FROM room_overrides WHERE room_id=?", (room_id,)
-    ) as cur:
+async def get_room_override(conn: aiosqlite.Connection, room_id: str) -> RoomOverride | None:
+    async with conn.execute("SELECT * FROM room_overrides WHERE room_id=?", (room_id,)) as cur:
         row = await cur.fetchone()
     if not row:
         return None
@@ -574,9 +543,7 @@ async def get_holdover_state(
     )
 
 
-async def upsert_holdover_state(
-    conn: aiosqlite.Connection, state: PresenceHoldoverState
-) -> None:
+async def upsert_holdover_state(conn: aiosqlite.Connection, state: PresenceHoldoverState) -> None:
     await conn.execute(
         """INSERT INTO presence_holdover_state(room_id,last_detected_at,expires_at)
            VALUES(?,?,?)
@@ -594,9 +561,7 @@ async def upsert_holdover_state(
 
 
 async def delete_holdover_state(conn: aiosqlite.Connection, room_id: str) -> None:
-    await conn.execute(
-        "DELETE FROM presence_holdover_state WHERE room_id=?", (room_id,)
-    )
+    await conn.execute("DELETE FROM presence_holdover_state WHERE room_id=?", (room_id,))
     await conn.commit()
 
 
@@ -666,9 +631,7 @@ async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
     await conn.commit()
 
 
-async def close_cycle_log(
-    conn: aiosqlite.Connection, cycle_id: str, ended_at: datetime
-) -> None:
+async def close_cycle_log(conn: aiosqlite.Connection, cycle_id: str, ended_at: datetime) -> None:
     await conn.execute(
         "UPDATE cycle_logs SET ended_at=? WHERE id=?", (ended_at.isoformat(), cycle_id)
     )
@@ -713,17 +676,13 @@ async def get_cycle_logs(
 async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete cycle logs older than N days. Returns number of rows deleted."""
     cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
-    async with conn.execute(
-        "DELETE FROM cycle_logs WHERE started_at < ?", (cutoff,)
-    ) as cur:
+    async with conn.execute("DELETE FROM cycle_logs WHERE started_at < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()
     return count
 
 
-async def upsert_room_cycle_state(
-    conn: aiosqlite.Connection, rcs: RoomCycleState
-) -> None:
+async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleState) -> None:
     await conn.execute(
         """INSERT INTO room_cycle_states(cycle_id,room_id,target_temp,reached_at,vent_closed_at)
            VALUES(?,?,?,?,?)
@@ -742,12 +701,8 @@ async def upsert_room_cycle_state(
     await conn.commit()
 
 
-async def get_room_cycle_states(
-    conn: aiosqlite.Connection, cycle_id: str
-) -> list[RoomCycleState]:
-    async with conn.execute(
-        "SELECT * FROM room_cycle_states WHERE cycle_id=?", (cycle_id,)
-    ) as cur:
+async def get_room_cycle_states(conn: aiosqlite.Connection, cycle_id: str) -> list[RoomCycleState]:
+    async with conn.execute("SELECT * FROM room_cycle_states WHERE cycle_id=?", (cycle_id,)) as cur:
         rows = await cur.fetchall()
     return [
         RoomCycleState(
@@ -766,12 +721,8 @@ async def get_room_cycle_states(
 # ---------------------------------------------------------------------------
 
 
-async def get_system_setting(
-    conn: aiosqlite.Connection, key: str, default: str = ""
-) -> str:
-    async with conn.execute(
-        "SELECT value FROM system_settings WHERE key=?", (key,)
-    ) as cur:
+async def get_system_setting(conn: aiosqlite.Connection, key: str, default: str = "") -> str:
+    async with conn.execute("SELECT value FROM system_settings WHERE key=?", (key,)) as cur:
         row = await cur.fetchone()
     return row["value"] if row else default
 
@@ -869,9 +820,7 @@ async def get_event_logs(
 async def purge_event_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete event logs older than N days. Returns number of rows deleted."""
     cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
-    async with conn.execute(
-        "DELETE FROM event_log WHERE timestamp < ?", (cutoff,)
-    ) as cur:
+    async with conn.execute("DELETE FROM event_log WHERE timestamp < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()
     return count

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -5,17 +5,21 @@ State machine:
   IDLE → RUNNING → (all rooms at target) → TERMINATING → IDLE
   RUNNING → ABORTED (thermostat unavailable, mode change, timeout)
 """
+
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Callable, Coroutine, Optional
 
 import aiosqlite
 
+from .. import db
+from ..event_logger import EventLogger
 from ..ha_client import HAClient
 from ..models import (
     CycleLog,
@@ -26,9 +30,7 @@ from ..models import (
     ThermostatConfig,
     ZoneStatus,
 )
-from ..event_logger import EventLogger
-from .. import db
-from .room_manager import ActiveRoom, get_active_rooms, expire_holdovers
+from .room_manager import ActiveRoom, expire_holdovers, get_active_rooms
 from .vent_controller import VentController
 
 log = logging.getLogger(__name__)
@@ -54,9 +56,9 @@ class CycleEngine:
         thermostat_entity_id: str,
         ha: HAClient,
         vent_ctrl: VentController,
-        broadcast: Optional[BroadcastFn] = None,
-        event_logger: Optional[EventLogger] = None,
-        get_enabled: Optional[Callable[[], bool]] = None,
+        broadcast: BroadcastFn | None = None,
+        event_logger: EventLogger | None = None,
+        get_enabled: Callable[[], bool] | None = None,
     ) -> None:
         self.thermostat_entity_id = thermostat_entity_id
         self._ha = ha
@@ -66,9 +68,13 @@ class CycleEngine:
         self._get_enabled = get_enabled
 
         self._state = CycleState.IDLE
-        self._cycle_log: Optional[CycleLog] = None
-        self._cycle_mode: Optional[str] = None  # mode locked at cycle start; used for monitoring
-        self._cycle_ha_mode: Optional[str] = None  # 'heat' or 'cool' — explicit HA mode sent
+        self._cycle_log: CycleLog | None = None
+        self._cycle_mode: str | None = (
+            None  # mode locked at cycle start; used for monitoring
+        )
+        self._cycle_ha_mode: str | None = (
+            None  # 'heat' or 'cool' — explicit HA mode sent
+        )
         self._active_rooms: dict[str, ActiveRoom] = {}  # room_id → ActiveRoom
         self._room_cycle_states: dict[str, RoomCycleState] = {}  # room_id → state
         self._room_vents: dict[str, list[RoomVent]] = {}  # room_id → vents
@@ -76,9 +82,9 @@ class CycleEngine:
 
         # Last setpoint value successfully sent to HA; used by reconciliation to
         # detect external changes to the thermostat setpoint.
-        self._last_setpoint_sent: Optional[float] = None
+        self._last_setpoint_sent: float | None = None
         # Timestamp of the last reconciliation run; None = never reconciled.
-        self._last_reconciled_at: Optional[datetime] = None
+        self._last_reconciled_at: datetime | None = None
 
     # ------------------------------------------------------------------
     # Public
@@ -89,7 +95,7 @@ class CycleEngine:
         return self._state
 
     @property
-    def current_cycle_id(self) -> Optional[str]:
+    def current_cycle_id(self) -> str | None:
         return self._cycle_log.id if self._cycle_log else None
 
     async def tick(self, conn: aiosqlite.Connection) -> None:
@@ -97,9 +103,7 @@ class CycleEngine:
         async with self._lock:
             await self._do_tick(conn)
 
-    async def handle_presence(
-        self, conn: aiosqlite.Connection, room: Room
-    ) -> None:
+    async def handle_presence(self, conn: aiosqlite.Connection, room: Room) -> None:
         """Called externally when a presence sensor fires for a room in this zone."""
         async with self._lock:
             await self._on_presence(conn, room)
@@ -108,7 +112,9 @@ class CycleEngine:
         """Return a snapshot of the current zone status (no DB call needed)."""
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
-            hvac_action = thermo_state.get("attributes", {}).get("hvac_action", "unknown")
+            hvac_action = thermo_state.get("attributes", {}).get(
+                "hvac_action", "unknown"
+            )
             hvac_mode = thermo_state.get("state", "unknown")
             current_temp = thermo_state.get("attributes", {}).get("current_temperature")
             setpoint = thermo_state.get("attributes", {}).get("temperature")
@@ -148,7 +154,7 @@ class CycleEngine:
 
     async def _do_tick(self, conn: aiosqlite.Connection) -> None:
         # Expire holdovers and overrides first
-        expired = await expire_holdovers(conn)
+        await expire_holdovers(conn)
         await db.clear_expired_overrides(conn)
 
         # Determine which rooms should be active now
@@ -177,7 +183,8 @@ class CycleEngine:
             )
             if self._logger:
                 await self._logger.log(
-                    "warning", "engine",
+                    "warning",
+                    "engine",
                     f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick",
                     {"thermostat": self.thermostat_entity_id},
                 )
@@ -189,20 +196,27 @@ class CycleEngine:
             if self._state != CycleState.IDLE:
                 await self._abort_cycle(conn, reason="system disabled")
             else:
-                log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
+                log.debug(
+                    "System disabled — skipping tick for %s", self.thermostat_entity_id
+                )
             return
 
         # Detect HVAC mode
         hvac_mode = self._read_hvac_mode()
         if hvac_mode == "unknown":
-            log.warning("Thermostat %s mode unknown — skipping tick", self.thermostat_entity_id)
+            log.warning(
+                "Thermostat %s mode unknown — skipping tick", self.thermostat_entity_id
+            )
             return
-        if hvac_mode == "off" and self._state == CycleState.IDLE:
+        if (
+            hvac_mode == "off"
+            and self._state == CycleState.IDLE
+            and thermo_state.get("state", "off") != "heat_cool"
+        ):
             # No active cycle — thermostat is either truly off or a heat_cool unit in
             # its idle phase. For heat_cool, direction is inferred from room temps below
             # so we fall through; for all other off modes, wait.
-            if thermo_state.get("state", "off") != "heat_cool":
-                return
+            return
 
         # If rooms changed, update and recompute setpoint.
         # For mid-cycle updates, preserve the original cycle direction so that a
@@ -218,7 +232,9 @@ class CycleEngine:
                 if inferred == "off":
                     # All rooms within deadband — reset setpoint to ambient so the HVAC
                     # goes idle, then skip starting a new cycle.
-                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
+                    ambient = thermo_state.get("attributes", {}).get(
+                        "current_temperature"
+                    )
                     if ambient is not None:
                         ambient_f = float(ambient)
                         try:
@@ -249,13 +265,18 @@ class CycleEngine:
             if elapsed > timedelta(hours=tc.cycle_timeout_hours):
                 log.warning(
                     "Cycle %s timed out after %.1fh — terminating",
-                    self._cycle_log.id, elapsed.total_seconds() / 3600,
+                    self._cycle_log.id,
+                    elapsed.total_seconds() / 3600,
                 )
                 if self._logger:
                     await self._logger.log(
-                        "warning", "engine",
-                        f"Cycle timed out after {elapsed.total_seconds()/3600:.1f}h for {self.thermostat_entity_id}",
-                        {"thermostat": self.thermostat_entity_id, "cycle_id": self._cycle_log.id},
+                        "warning",
+                        "engine",
+                        f"Cycle timed out after {elapsed.total_seconds() / 3600:.1f}h for {self.thermostat_entity_id}",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "cycle_id": self._cycle_log.id,
+                        },
                     )
                 await self._terminate_cycle(conn)
 
@@ -295,19 +316,28 @@ class CycleEngine:
             if orphaned > 0:
                 log.warning(
                     "Closed %d orphaned open cycle log(s) for %s before starting new cycle",
-                    orphaned, self.thermostat_entity_id,
+                    orphaned,
+                    self.thermostat_entity_id,
                 )
                 if self._logger:
                     await self._logger.log(
-                        "warning", "engine",
+                        "warning",
+                        "engine",
                         f"Closed {orphaned} orphaned cycle log(s) for {self.thermostat_entity_id} "
                         f"(stale from previous server run or failed state transition)",
-                        {"thermostat": self.thermostat_entity_id, "orphaned_count": orphaned},
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "orphaned_count": orphaned,
+                        },
                     )
 
             # Start a fresh cycle
             rooms_snapshot = {
-                ar.room.id: {"name": ar.room.name, "target": ar.target_temp, "source": ar.source}
+                ar.room.id: {
+                    "name": ar.room.name,
+                    "target": ar.target_temp,
+                    "source": ar.source,
+                }
                 for ar in new_active_map.values()
             }
             self._cycle_log = CycleLog.create(
@@ -332,14 +362,21 @@ class CycleEngine:
             room_names = [ar.room.name for ar in new_active_map.values()]
             log.info(
                 "Cycle started for %s — mode=%s rooms=%s",
-                self.thermostat_entity_id, hvac_mode, room_names,
+                self.thermostat_entity_id,
+                hvac_mode,
+                room_names,
             )
             if self._logger:
                 await self._logger.log(
-                    "info", "engine",
+                    "info",
+                    "engine",
                     f"Cycle started for {self.thermostat_entity_id} — mode={hvac_mode}, rooms={room_names}",
-                    {"thermostat": self.thermostat_entity_id, "mode": hvac_mode,
-                     "cycle_id": self._cycle_log.id, "rooms": room_names},
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "mode": hvac_mode,
+                        "cycle_id": self._cycle_log.id,
+                        "rooms": room_names,
+                    },
                 )
         else:
             # Update existing cycle (rooms changed mid-cycle)
@@ -358,10 +395,15 @@ class CycleEngine:
                 log.info("Room %s added to running cycle", ar.room.name)
                 if self._logger:
                     await self._logger.log(
-                        "info", "engine",
+                        "info",
+                        "engine",
                         f"Room {ar.room.name} added to running cycle (source: {ar.source})",
-                        {"room_id": room_id, "room_name": ar.room.name, "source": ar.source,
-                         "target_temp": ar.target_temp},
+                        {
+                            "room_id": room_id,
+                            "room_name": ar.room.name,
+                            "source": ar.source,
+                            "target_temp": ar.target_temp,
+                        },
                     )
 
             for room_id in removed:
@@ -370,7 +412,9 @@ class CycleEngine:
                 # VentController safety check (issue #26 Bug 3).
                 vents = self._room_vents.get(room_id, [])
                 if vents:
-                    all_zone_vents_now = [v for vl in self._room_vents.values() for v in vl]
+                    all_zone_vents_now = [
+                        v for vl in self._room_vents.values() for v in vl
+                    ]
                     can_close = True
                     if tc.min_open_vents > 0:
                         open_count = self._vent._count_open_vents(all_zone_vents_now)
@@ -381,7 +425,8 @@ class CycleEngine:
                             can_close = False
                             log.warning(
                                 "Cannot close removed room %s vents — would violate min_open_vents=%d",
-                                room_id, tc.min_open_vents,
+                                room_id,
+                                tc.min_open_vents,
                             )
                     if can_close:
                         for v in vents:
@@ -393,13 +438,14 @@ class CycleEngine:
                 log.info("Room %s removed from cycle (became idle)", room_id)
                 if self._logger:
                     await self._logger.log(
-                        "info", "engine",
+                        "info",
+                        "engine",
                         f"Room {room_id} removed from cycle (became idle)",
                         {"room_id": room_id},
                     )
 
         # Open all active room vents
-        for room_id, ar in self._active_rooms.items():
+        for room_id in self._active_rooms:
             rcs = self._room_cycle_states.get(room_id)
             if rcs and rcs.vent_closed_at is None:
                 vents = self._room_vents.get(room_id, [])
@@ -431,14 +477,19 @@ class CycleEngine:
             if avg is None:
                 # Room has no sensors (ventless/sensor-only room with no readings).
                 # Skip it for target-check purposes — it cannot block cycle termination.
-                log.warning("Room %s has no available sensors — skipping target check", ar.room.name)
+                log.warning(
+                    "Room %s has no available sensors — skipping target check",
+                    ar.room.name,
+                )
                 continue
 
             # Apply per-room offset: positive offset compensates for post-closure
             # drift (e.g. a room that overcools by 3°F gets offset=+3 so its vent
             # closes 3°F before the actual target, and it drifts to target).
             effective_avg = avg + ar.room.temp_offset
-            at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode, tc.deadband)
+            at_target = _is_at_target(
+                effective_avg, rcs.target_temp, hvac_mode, tc.deadband
+            )
 
             if at_target and rcs.vent_closed_at is None:
                 # Try to close the vent.
@@ -448,12 +499,19 @@ class CycleEngine:
                 # "Last vent needing close" covers both single-room zones AND multi-room
                 # zones where all other rooms have already had their vents closed.
                 vents = self._room_vents.get(room_id, [])
-                is_last_vent_to_close = sum(
-                    1 for r in self._room_cycle_states.values() if r.vent_closed_at is None
-                ) == 1
+                is_last_vent_to_close = (
+                    sum(
+                        1
+                        for r in self._room_cycle_states.values()
+                        if r.vent_closed_at is None
+                    )
+                    == 1
+                )
                 if is_last_vent_to_close and tc.min_open_vents > 0:
                     open_count = self._vent._count_open_vents(all_zone_vents)
-                    would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
+                    would_close = sum(
+                        1 for v in vents if self._vent._is_open(v.entity_id)
+                    )
                     if open_count - would_close < tc.min_open_vents:
                         log.warning(
                             "Room %s is last vent needing close — bypassing min_open_vents to terminate",
@@ -461,11 +519,15 @@ class CycleEngine:
                         )
                         if self._logger:
                             await self._logger.log(
-                                "warning", "engine",
+                                "warning",
+                                "engine",
                                 f"Room {ar.room.name} is the last vent needing close — "
                                 f"bypassing min_open_vents={tc.min_open_vents} to terminate cycle",
-                                {"room_id": room_id, "room_name": ar.room.name,
-                                 "min_open_vents": tc.min_open_vents},
+                                {
+                                    "room_id": room_id,
+                                    "room_name": ar.room.name,
+                                    "min_open_vents": tc.min_open_vents,
+                                },
                             )
                         for v in vents:
                             await self._ha.close_cover(v.entity_id)
@@ -483,19 +545,33 @@ class CycleEngine:
                     if rcs.reached_at is None:
                         rcs.reached_at = datetime.utcnow()
                     await db.upsert_room_cycle_state(conn, rcs)
-                    offset_note = f", offset={ar.room.temp_offset:+.1f}°F" if ar.room.temp_offset != 0 else ""
+                    offset_note = (
+                        f", offset={ar.room.temp_offset:+.1f}°F"
+                        if ar.room.temp_offset != 0
+                        else ""
+                    )
                     log.info(
                         "Room %s hit target %.1f°F (avg=%.1f, effective=%.1f%s) — vent closed",
-                        ar.room.name, rcs.target_temp, avg, effective_avg, offset_note,
+                        ar.room.name,
+                        rcs.target_temp,
+                        avg,
+                        effective_avg,
+                        offset_note,
                     )
                     if self._logger:
                         await self._logger.log(
-                            "info", "engine",
+                            "info",
+                            "engine",
                             f"Room {ar.room.name} reached target {rcs.target_temp}°F "
                             f"(avg={avg:.1f}°F, effective={effective_avg:.1f}°F{offset_note}) — vent closed",
-                            {"room_id": room_id, "room_name": ar.room.name,
-                             "target_temp": rcs.target_temp, "avg_temp": avg,
-                             "effective_avg": effective_avg, "temp_offset": ar.room.temp_offset},
+                            {
+                                "room_id": room_id,
+                                "room_name": ar.room.name,
+                                "target_temp": rcs.target_temp,
+                                "avg_temp": avg,
+                                "effective_avg": effective_avg,
+                                "temp_offset": ar.room.temp_offset,
+                            },
                         )
                 else:
                     all_at_target = False  # deferred
@@ -506,7 +582,9 @@ class CycleEngine:
             await self._terminate_cycle(conn)
 
     async def _terminate_cycle(self, conn: aiosqlite.Connection) -> None:
-        log.info("All rooms at target for %s — terminating cycle", self.thermostat_entity_id)
+        log.info(
+            "All rooms at target for %s — terminating cycle", self.thermostat_entity_id
+        )
         self._state = CycleState.TERMINATING
 
         # Set thermostat setpoint to its own current ambient → HVAC shuts off.
@@ -519,18 +597,25 @@ class CycleEngine:
                 ambient_f = float(ambient)
                 try:
                     await self._ha.set_thermostat_temperature(
-                        self.thermostat_entity_id, ambient_f,
+                        self.thermostat_entity_id,
+                        ambient_f,
                         hvac_mode=self._cycle_ha_mode,
                     )
                     self._last_setpoint_sent = ambient_f
                     if self._logger:
                         await self._logger.log(
-                            "info", "engine",
+                            "info",
+                            "engine",
                             f"Cycle terminated for {self.thermostat_entity_id} — "
                             f"setpoint reset to ambient {ambient_f}°F",
-                            {"thermostat": self.thermostat_entity_id, "setpoint": ambient_f,
-                             "hvac_mode": self._cycle_ha_mode,
-                             "cycle_id": self._cycle_log.id if self._cycle_log else None},
+                            {
+                                "thermostat": self.thermostat_entity_id,
+                                "setpoint": ambient_f,
+                                "hvac_mode": self._cycle_ha_mode,
+                                "cycle_id": self._cycle_log.id
+                                if self._cycle_log
+                                else None,
+                            },
                         )
                 except Exception as exc:
                     log.error("Failed to set termination setpoint: %s", exc)
@@ -552,11 +637,15 @@ class CycleEngine:
         self._room_vents = {}
 
         if all_zone_vents:
-            log.info("Cycle complete — re-opening all zone vents for %s", self.thermostat_entity_id)
+            log.info(
+                "Cycle complete — re-opening all zone vents for %s",
+                self.thermostat_entity_id,
+            )
             await self._vent.open_room_vents(all_zone_vents)
             if self._logger:
                 await self._logger.log(
-                    "info", "engine",
+                    "info",
+                    "engine",
                     f"Cycle complete for {self.thermostat_entity_id} — all zone vents re-opened",
                     {"thermostat": self.thermostat_entity_id},
                 )
@@ -570,10 +659,14 @@ class CycleEngine:
         log.warning("Aborting cycle for %s — %s", self.thermostat_entity_id, reason)
         if self._logger and self._state != CycleState.IDLE:
             await self._logger.log(
-                "warning", "engine",
+                "warning",
+                "engine",
                 f"Cycle aborted for {self.thermostat_entity_id} — {reason}",
-                {"thermostat": self.thermostat_entity_id, "reason": reason,
-                 "cycle_id": self._cycle_log.id if self._cycle_log else None},
+                {
+                    "thermostat": self.thermostat_entity_id,
+                    "reason": reason,
+                    "cycle_id": self._cycle_log.id if self._cycle_log else None,
+                },
             )
 
         all_vents = [v for vl in self._room_vents.values() for v in vl]
@@ -589,7 +682,8 @@ class CycleEngine:
             await self._vent.open_room_vents(all_vents)
             if self._logger:
                 await self._logger.log(
-                    "info", "engine",
+                    "info",
+                    "engine",
                     f"Cycle aborted for {self.thermostat_entity_id} ({reason}) — all zone vents re-opened",
                     {"thermostat": self.thermostat_entity_id, "reason": reason},
                 )
@@ -606,17 +700,22 @@ class CycleEngine:
                     ambient_f = float(ambient)
                     try:
                         await self._ha.set_thermostat_temperature(
-                            self.thermostat_entity_id, ambient_f,
+                            self.thermostat_entity_id,
+                            ambient_f,
                             hvac_mode=self._cycle_ha_mode,
                         )
                         self._last_setpoint_sent = ambient_f
                         if self._logger:
                             await self._logger.log(
-                                "info", "engine",
+                                "info",
+                                "engine",
                                 f"Cycle aborted for {self.thermostat_entity_id} — "
                                 f"setpoint reset to ambient {ambient_f}°F",
-                                {"thermostat": self.thermostat_entity_id, "setpoint": ambient_f,
-                                 "hvac_mode": self._cycle_ha_mode},
+                                {
+                                    "thermostat": self.thermostat_entity_id,
+                                    "setpoint": ambient_f,
+                                    "hvac_mode": self._cycle_ha_mode,
+                                },
                             )
                     except Exception as exc:
                         log.error("Abort: failed to reset setpoint to ambient: %s", exc)
@@ -637,6 +736,7 @@ class CycleEngine:
 
     async def _on_presence(self, conn: aiosqlite.Connection, room: Room) -> None:
         from .room_manager import handle_presence_event
+
         newly_activated = await handle_presence_event(conn, room)
         if newly_activated and self._state == CycleState.RUNNING:
             # Room was just activated — add it mid-cycle on next tick
@@ -683,7 +783,7 @@ class CycleEngine:
         self,
         active_rooms: dict[str, ActiveRoom],
         deadband: float,
-        thermo_state: Optional[dict] = None,
+        thermo_state: dict | None = None,
     ) -> str:
         """Determine needed cycle direction from room temperatures vs targets.
 
@@ -709,14 +809,12 @@ class CycleEngine:
            This is the "ambient ± direction" check from issue #38.
         """
         # Read thermostat ambient once — used for both the fallback and sanity check.
-        thermo_ambient: Optional[float] = None
+        thermo_ambient: float | None = None
         if thermo_state:
             t = thermo_state.get("attributes", {}).get("current_temperature")
             if t is not None:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     thermo_ambient = float(t)
-                except (ValueError, TypeError):
-                    pass
 
         needs_cool = 0
         needs_heat = 0
@@ -763,11 +861,16 @@ class CycleEngine:
                     "Mode contradiction for %s: room sensors voted %r but "
                     "thermostat ambient %.1f°F says %r — using %r. "
                     "Check room sensor temp_offset values or placement.",
-                    self.thermostat_entity_id, inferred, thermo_ambient, corrected, corrected,
+                    self.thermostat_entity_id,
+                    inferred,
+                    thermo_ambient,
+                    corrected,
+                    corrected,
                 )
                 if self._logger:
                     await self._logger.log(
-                        "warning", "engine",
+                        "warning",
+                        "engine",
                         f"Mode contradiction for {self.thermostat_entity_id}: "
                         f"room sensors voted {inferred!r} but thermostat ambient "
                         f"{thermo_ambient:.1f}°F contradicts — overriding to {corrected!r}. "
@@ -784,7 +887,7 @@ class CycleEngine:
 
         return inferred
 
-    def _get_avg_temp(self, room: Room) -> Optional[float]:
+    def _get_avg_temp(self, room: Room) -> float | None:
         readings: list[float] = []
 
         # Re-query the cache for all sensors belonging to this room
@@ -799,10 +902,8 @@ class CycleEngine:
             if thermo:
                 t = thermo.get("attributes", {}).get("current_temperature")
                 if t is not None:
-                    try:
+                    with contextlib.suppress(ValueError, TypeError):
                         readings.append(float(t))
-                    except (ValueError, TypeError):
-                        pass
 
         if not readings:
             return None
@@ -832,14 +933,22 @@ class CycleEngine:
             )
             # Track what we last commanded so reconciliation can detect external drift.
             self._last_setpoint_sent = setpoint
-            self._cycle_ha_mode = ha_mode  # track the mode we locked the thermostat into
+            self._cycle_ha_mode = (
+                ha_mode  # track the mode we locked the thermostat into
+            )
             if self._logger:
                 await self._logger.log(
-                    "info", "engine",
+                    "info",
+                    "engine",
                     f"Setpoint for {self.thermostat_entity_id} set to {setpoint:.1f}°F "
                     f"(mode={hvac_mode}, ha_mode={ha_mode})",
-                    {"thermostat": self.thermostat_entity_id, "setpoint": setpoint,
-                     "hvac_mode": hvac_mode, "ha_mode": ha_mode, "targets": targets},
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "setpoint": setpoint,
+                        "hvac_mode": hvac_mode,
+                        "ha_mode": ha_mode,
+                        "targets": targets,
+                    },
                 )
         except Exception as exc:
             log.error("Failed to set thermostat setpoint: %s", exc)
@@ -859,7 +968,7 @@ class CycleEngine:
             self._last_reconciled_at = now
 
     async def _reconcile_state(
-        self, conn: aiosqlite.Connection, tc: "ThermostatConfig"
+        self, conn: aiosqlite.Connection, tc: ThermostatConfig
     ) -> None:
         """
         Verify actual vent and thermostat state matches engine intent; correct any drift.
@@ -880,13 +989,17 @@ class CycleEngine:
         log.info(
             "Reconcile %s: engine_state=%s ha_mode=%s ha_setpoint=%s "
             "cycle_ha_mode=%s last_setpoint_sent=%s",
-            self.thermostat_entity_id, self._state.value,
-            ha_mode_now, ha_setpoint_now,
-            self._cycle_ha_mode, self._last_setpoint_sent,
+            self.thermostat_entity_id,
+            self._state.value,
+            ha_mode_now,
+            ha_setpoint_now,
+            self._cycle_ha_mode,
+            self._last_setpoint_sent,
         )
         if self._logger:
             await self._logger.log(
-                "info", "reconcile",
+                "info",
+                "reconcile",
                 f"Reconcile {self.thermostat_entity_id}: engine={self._state.value}, "
                 f"ha_mode={ha_mode_now!r}, ha_setpoint={ha_setpoint_now}, "
                 f"expected_mode={self._cycle_ha_mode!r}, "
@@ -913,7 +1026,7 @@ class CycleEngine:
 
         if self._state == CycleState.RUNNING:
             all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
-            for room_id, ar in self._active_rooms.items():
+            for room_id in self._active_rooms:
                 rcs = self._room_cycle_states.get(room_id)
                 vents = self._room_vents.get(room_id, [])
                 if not vents or rcs is None:
@@ -933,10 +1046,14 @@ class CycleEngine:
                             )
                             if self._logger:
                                 await self._logger.log(
-                                    "warning", "reconcile",
+                                    "warning",
+                                    "reconcile",
                                     f"Drift: vent {vent.entity_id} found open but should be closed — re-closed",
-                                    {"entity_id": vent.entity_id, "room_id": room_id,
-                                     "thermostat": self.thermostat_entity_id},
+                                    {
+                                        "entity_id": vent.entity_id,
+                                        "room_id": room_id,
+                                        "thermostat": self.thermostat_entity_id,
+                                    },
                                 )
                     elif not should_be_closed and not actual_open:
                         # External actor closed a vent that the engine opened — re-open.
@@ -947,10 +1064,14 @@ class CycleEngine:
                         )
                         if self._logger:
                             await self._logger.log(
-                                "warning", "reconcile",
+                                "warning",
+                                "reconcile",
                                 f"Drift: vent {vent.entity_id} found closed but should be open — re-opened",
-                                {"entity_id": vent.entity_id, "room_id": room_id,
-                                 "thermostat": self.thermostat_entity_id},
+                                {
+                                    "entity_id": vent.entity_id,
+                                    "room_id": room_id,
+                                    "thermostat": self.thermostat_entity_id,
+                                },
                             )
 
             # Check thermostat mode and setpoint drift.
@@ -966,38 +1087,50 @@ class CycleEngine:
                         if current_mode != self._cycle_ha_mode:
                             log.warning(
                                 "Reconcile: thermostat %s mode drifted %s→%s — re-asserting",
-                                self.thermostat_entity_id, current_mode, self._cycle_ha_mode,
+                                self.thermostat_entity_id,
+                                current_mode,
+                                self._cycle_ha_mode,
                             )
                             if self._logger:
                                 await self._logger.log(
-                                    "warning", "reconcile",
+                                    "warning",
+                                    "reconcile",
                                     f"Drift: thermostat {self.thermostat_entity_id} mode changed "
                                     f"from {current_mode!r} to {self._cycle_ha_mode!r} — re-asserting",
-                                    {"entity_id": self.thermostat_entity_id,
-                                     "expected_mode": self._cycle_ha_mode,
-                                     "actual_mode": current_mode},
+                                    {
+                                        "entity_id": self.thermostat_entity_id,
+                                        "expected_mode": self._cycle_ha_mode,
+                                        "actual_mode": current_mode,
+                                    },
                                 )
                             needs_reassert = True
 
                     # Re-assert setpoint if it drifted externally.
                     if self._last_setpoint_sent is not None:
-                        current_sp = thermo_state.get("attributes", {}).get("temperature")
+                        current_sp = thermo_state.get("attributes", {}).get(
+                            "temperature"
+                        )
                         if current_sp is not None:
                             drift = abs(float(current_sp) - self._last_setpoint_sent)
                             if drift > 0.1:  # tolerance for float rounding in HA
                                 log.warning(
                                     "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
-                                    self.thermostat_entity_id, current_sp, self._last_setpoint_sent,
+                                    self.thermostat_entity_id,
+                                    current_sp,
+                                    self._last_setpoint_sent,
                                 )
                                 if self._logger:
                                     await self._logger.log(
-                                        "warning", "reconcile",
+                                        "warning",
+                                        "reconcile",
                                         f"Drift: thermostat {self.thermostat_entity_id} setpoint changed "
                                         f"from {self._last_setpoint_sent:.1f}°F to {float(current_sp):.1f}°F "
                                         f"— re-asserting",
-                                        {"entity_id": self.thermostat_entity_id,
-                                         "expected": self._last_setpoint_sent,
-                                         "actual": float(current_sp)},
+                                        {
+                                            "entity_id": self.thermostat_entity_id,
+                                            "expected": self._last_setpoint_sent,
+                                            "actual": float(current_sp),
+                                        },
                                     )
                                 needs_reassert = True
 
@@ -1009,7 +1142,9 @@ class CycleEngine:
                                 hvac_mode=self._cycle_ha_mode,
                             )
                         except Exception as exc:
-                            log.error("Reconcile: failed to re-assert mode+setpoint: %s", exc)
+                            log.error(
+                                "Reconcile: failed to re-assert mode+setpoint: %s", exc
+                            )
 
         else:
             # IDLE — all zone vents should be open; load fresh from DB.
@@ -1025,10 +1160,14 @@ class CycleEngine:
                         )
                         if self._logger:
                             await self._logger.log(
-                                "warning", "reconcile",
+                                "warning",
+                                "reconcile",
                                 f"Drift (idle): vent {vent.entity_id} found closed while zone is idle — re-opened",
-                                {"entity_id": vent.entity_id, "room_id": room.id,
-                                 "thermostat": self.thermostat_entity_id},
+                                {
+                                    "entity_id": vent.entity_id,
+                                    "room_id": room.id,
+                                    "thermostat": self.thermostat_entity_id,
+                                },
                             )
 
             # DB settings check (idle): warn if the HA thermostat setpoint is
@@ -1041,19 +1180,25 @@ class CycleEngine:
                         log.warning(
                             "Reconcile (idle): thermostat %s setpoint %.1f is outside "
                             "configured bounds [%.1f, %.1f]",
-                            self.thermostat_entity_id, sp, tc.min_setpoint, tc.max_setpoint,
+                            self.thermostat_entity_id,
+                            sp,
+                            tc.min_setpoint,
+                            tc.max_setpoint,
                         )
                         if self._logger:
                             await self._logger.log(
-                                "warning", "reconcile",
+                                "warning",
+                                "reconcile",
                                 f"DB settings drift (idle): thermostat {self.thermostat_entity_id} "
                                 f"setpoint {sp:.1f}°F is outside configured bounds "
                                 f"[{tc.min_setpoint:.1f}, {tc.max_setpoint:.1f}]°F — "
                                 f"external actor may have changed it",
-                                {"entity_id": self.thermostat_entity_id,
-                                 "ha_setpoint": sp,
-                                 "db_min_setpoint": tc.min_setpoint,
-                                 "db_max_setpoint": tc.max_setpoint},
+                                {
+                                    "entity_id": self.thermostat_entity_id,
+                                    "ha_setpoint": sp,
+                                    "db_min_setpoint": tc.min_setpoint,
+                                    "db_max_setpoint": tc.max_setpoint,
+                                },
                             )
                 except (ValueError, TypeError):
                     pass
@@ -1084,15 +1229,19 @@ class CycleEngine:
                 await db.close_cycle_log(conn, stale.id, now)
             log.warning(
                 "Closed %d duplicate open cycle log(s) for %s on startup",
-                len(open_logs) - 1, self.thermostat_entity_id,
+                len(open_logs) - 1,
+                self.thermostat_entity_id,
             )
             if self._logger:
                 await self._logger.log(
-                    "warning", "engine",
+                    "warning",
+                    "engine",
                     f"Closed {len(open_logs) - 1} duplicate open cycle log(s) for "
                     f"{self.thermostat_entity_id} on startup",
-                    {"thermostat": self.thermostat_entity_id,
-                     "duplicate_count": len(open_logs) - 1},
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "duplicate_count": len(open_logs) - 1,
+                    },
                 )
 
         # Restore cycle log metadata
@@ -1116,13 +1265,16 @@ class CycleEngine:
             if room is None:
                 log.warning(
                     "Restore: room %s from cycle %s no longer exists — skipping",
-                    room_id, to_restore.id,
+                    room_id,
+                    to_restore.id,
                 )
                 skipped += 1
                 continue
             target = float(snap.get("target", 0.0))
             source = snap.get("source", "schedule")
-            self._active_rooms[room_id] = ActiveRoom(room=room, target_temp=target, source=source)
+            self._active_rooms[room_id] = ActiveRoom(
+                room=room, target_temp=target, source=source
+            )
             self._room_vents[room_id] = await db.get_room_vents(conn, room_id)
 
         # Sanity check: verify the restored mode still makes sense given the
@@ -1142,8 +1294,9 @@ class CycleEngine:
                     ambient_now = float(raw)
                     all_targets = [ar.target_temp for ar in self._active_rooms.values()]
                     contradicts = (
-                        (to_restore.mode == "heating" and ambient_now > max(all_targets))
-                        or (to_restore.mode == "cooling" and ambient_now < min(all_targets))
+                        to_restore.mode == "heating" and ambient_now > max(all_targets)
+                    ) or (
+                        to_restore.mode == "cooling" and ambient_now < min(all_targets)
                     )
                     if contradicts:
                         await db.close_cycle_log(conn, to_restore.id, datetime.utcnow())
@@ -1151,12 +1304,17 @@ class CycleEngine:
                             "Restore: discarding stale %s cycle %s for %s — "
                             "thermostat ambient %.1f°F contradicts restored mode "
                             "(targets min=%.1f max=%.1f). Next tick starts fresh.",
-                            to_restore.mode, to_restore.id, self.thermostat_entity_id,
-                            ambient_now, min(all_targets), max(all_targets),
+                            to_restore.mode,
+                            to_restore.id,
+                            self.thermostat_entity_id,
+                            ambient_now,
+                            min(all_targets),
+                            max(all_targets),
                         )
                         if self._logger:
                             await self._logger.log(
-                                "warning", "engine",
+                                "warning",
+                                "engine",
                                 f"Restore: discarding stale {to_restore.mode} cycle for "
                                 f"{self.thermostat_entity_id} — thermostat ambient "
                                 f"{ambient_now:.1f}°F contradicts restored mode. "
@@ -1191,17 +1349,25 @@ class CycleEngine:
         room_names = [ar.room.name for ar in self._active_rooms.values()]
         log.info(
             "Restored cycle %s for %s (mode=%s, rooms=%s%s)",
-            to_restore.id, self.thermostat_entity_id, to_restore.mode, room_names,
+            to_restore.id,
+            self.thermostat_entity_id,
+            to_restore.mode,
+            room_names,
             f", skipped {skipped} deleted rooms" if skipped else "",
         )
         if self._logger:
             await self._logger.log(
-                "info", "engine",
+                "info",
+                "engine",
                 f"Restored cycle {to_restore.id} for {self.thermostat_entity_id} "
                 f"from DB on startup (mode={to_restore.mode}, rooms={room_names})",
-                {"thermostat": self.thermostat_entity_id, "cycle_id": to_restore.id,
-                 "mode": to_restore.mode, "rooms": room_names,
-                 "rooms_skipped": skipped},
+                {
+                    "thermostat": self.thermostat_entity_id,
+                    "cycle_id": to_restore.id,
+                    "mode": to_restore.mode,
+                    "rooms": room_names,
+                    "rooms_skipped": skipped,
+                },
             )
 
     async def _maybe_broadcast(self) -> None:

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -69,12 +69,8 @@ class CycleEngine:
 
         self._state = CycleState.IDLE
         self._cycle_log: CycleLog | None = None
-        self._cycle_mode: str | None = (
-            None  # mode locked at cycle start; used for monitoring
-        )
-        self._cycle_ha_mode: str | None = (
-            None  # 'heat' or 'cool' — explicit HA mode sent
-        )
+        self._cycle_mode: str | None = None  # mode locked at cycle start; used for monitoring
+        self._cycle_ha_mode: str | None = None  # 'heat' or 'cool' — explicit HA mode sent
         self._active_rooms: dict[str, ActiveRoom] = {}  # room_id → ActiveRoom
         self._room_cycle_states: dict[str, RoomCycleState] = {}  # room_id → state
         self._room_vents: dict[str, list[RoomVent]] = {}  # room_id → vents
@@ -112,9 +108,7 @@ class CycleEngine:
         """Return a snapshot of the current zone status (no DB call needed)."""
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
-            hvac_action = thermo_state.get("attributes", {}).get(
-                "hvac_action", "unknown"
-            )
+            hvac_action = thermo_state.get("attributes", {}).get("hvac_action", "unknown")
             hvac_mode = thermo_state.get("state", "unknown")
             current_temp = thermo_state.get("attributes", {}).get("current_temperature")
             setpoint = thermo_state.get("attributes", {}).get("temperature")
@@ -196,17 +190,13 @@ class CycleEngine:
             if self._state != CycleState.IDLE:
                 await self._abort_cycle(conn, reason="system disabled")
             else:
-                log.debug(
-                    "System disabled — skipping tick for %s", self.thermostat_entity_id
-                )
+                log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
             return
 
         # Detect HVAC mode
         hvac_mode = self._read_hvac_mode()
         if hvac_mode == "unknown":
-            log.warning(
-                "Thermostat %s mode unknown — skipping tick", self.thermostat_entity_id
-            )
+            log.warning("Thermostat %s mode unknown — skipping tick", self.thermostat_entity_id)
             return
         if (
             hvac_mode == "off"
@@ -232,9 +222,7 @@ class CycleEngine:
                 if inferred == "off":
                     # All rooms within deadband — reset setpoint to ambient so the HVAC
                     # goes idle, then skip starting a new cycle.
-                    ambient = thermo_state.get("attributes", {}).get(
-                        "current_temperature"
-                    )
+                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
                     if ambient is not None:
                         ambient_f = float(ambient)
                         try:
@@ -412,15 +400,11 @@ class CycleEngine:
                 # VentController safety check (issue #26 Bug 3).
                 vents = self._room_vents.get(room_id, [])
                 if vents:
-                    all_zone_vents_now = [
-                        v for vl in self._room_vents.values() for v in vl
-                    ]
+                    all_zone_vents_now = [v for vl in self._room_vents.values() for v in vl]
                     can_close = True
                     if tc.min_open_vents > 0:
                         open_count = self._vent._count_open_vents(all_zone_vents_now)
-                        would_close = sum(
-                            1 for v in vents if self._vent._is_open(v.entity_id)
-                        )
+                        would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
                         if open_count - would_close < tc.min_open_vents:
                             can_close = False
                             log.warning(
@@ -487,9 +471,7 @@ class CycleEngine:
             # drift (e.g. a room that overcools by 3°F gets offset=+3 so its vent
             # closes 3°F before the actual target, and it drifts to target).
             effective_avg = avg + ar.room.temp_offset
-            at_target = _is_at_target(
-                effective_avg, rcs.target_temp, hvac_mode, tc.deadband
-            )
+            at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode, tc.deadband)
 
             if at_target and rcs.vent_closed_at is None:
                 # Try to close the vent.
@@ -500,18 +482,12 @@ class CycleEngine:
                 # zones where all other rooms have already had their vents closed.
                 vents = self._room_vents.get(room_id, [])
                 is_last_vent_to_close = (
-                    sum(
-                        1
-                        for r in self._room_cycle_states.values()
-                        if r.vent_closed_at is None
-                    )
+                    sum(1 for r in self._room_cycle_states.values() if r.vent_closed_at is None)
                     == 1
                 )
                 if is_last_vent_to_close and tc.min_open_vents > 0:
                     open_count = self._vent._count_open_vents(all_zone_vents)
-                    would_close = sum(
-                        1 for v in vents if self._vent._is_open(v.entity_id)
-                    )
+                    would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
                     if open_count - would_close < tc.min_open_vents:
                         log.warning(
                             "Room %s is last vent needing close — bypassing min_open_vents to terminate",
@@ -546,9 +522,7 @@ class CycleEngine:
                         rcs.reached_at = datetime.utcnow()
                     await db.upsert_room_cycle_state(conn, rcs)
                     offset_note = (
-                        f", offset={ar.room.temp_offset:+.1f}°F"
-                        if ar.room.temp_offset != 0
-                        else ""
+                        f", offset={ar.room.temp_offset:+.1f}°F" if ar.room.temp_offset != 0 else ""
                     )
                     log.info(
                         "Room %s hit target %.1f°F (avg=%.1f, effective=%.1f%s) — vent closed",
@@ -582,9 +556,7 @@ class CycleEngine:
             await self._terminate_cycle(conn)
 
     async def _terminate_cycle(self, conn: aiosqlite.Connection) -> None:
-        log.info(
-            "All rooms at target for %s — terminating cycle", self.thermostat_entity_id
-        )
+        log.info("All rooms at target for %s — terminating cycle", self.thermostat_entity_id)
         self._state = CycleState.TERMINATING
 
         # Set thermostat setpoint to its own current ambient → HVAC shuts off.
@@ -612,9 +584,7 @@ class CycleEngine:
                                 "thermostat": self.thermostat_entity_id,
                                 "setpoint": ambient_f,
                                 "hvac_mode": self._cycle_ha_mode,
-                                "cycle_id": self._cycle_log.id
-                                if self._cycle_log
-                                else None,
+                                "cycle_id": self._cycle_log.id if self._cycle_log else None,
                             },
                         )
                 except Exception as exc:
@@ -909,9 +879,7 @@ class CycleEngine:
             return None
         return sum(readings) / len(readings)
 
-    async def _set_thermostat_setpoint(
-        self, tc: ThermostatConfig, hvac_mode: str
-    ) -> None:
+    async def _set_thermostat_setpoint(self, tc: ThermostatConfig, hvac_mode: str) -> None:
         targets = [ar.target_temp for ar in self._active_rooms.values()]
         if not targets:
             return
@@ -933,9 +901,7 @@ class CycleEngine:
             )
             # Track what we last commanded so reconciliation can detect external drift.
             self._last_setpoint_sent = setpoint
-            self._cycle_ha_mode = (
-                ha_mode  # track the mode we locked the thermostat into
-            )
+            self._cycle_ha_mode = ha_mode  # track the mode we locked the thermostat into
             if self._logger:
                 await self._logger.log(
                     "info",
@@ -967,9 +933,7 @@ class CycleEngine:
             await self._reconcile_state(conn, tc)
             self._last_reconciled_at = now
 
-    async def _reconcile_state(
-        self, conn: aiosqlite.Connection, tc: ThermostatConfig
-    ) -> None:
+    async def _reconcile_state(self, conn: aiosqlite.Connection, tc: ThermostatConfig) -> None:
         """
         Verify actual vent and thermostat state matches engine intent; correct any drift.
 
@@ -1107,9 +1071,7 @@ class CycleEngine:
 
                     # Re-assert setpoint if it drifted externally.
                     if self._last_setpoint_sent is not None:
-                        current_sp = thermo_state.get("attributes", {}).get(
-                            "temperature"
-                        )
+                        current_sp = thermo_state.get("attributes", {}).get("temperature")
                         if current_sp is not None:
                             drift = abs(float(current_sp) - self._last_setpoint_sent)
                             if drift > 0.1:  # tolerance for float rounding in HA
@@ -1142,9 +1104,7 @@ class CycleEngine:
                                 hvac_mode=self._cycle_ha_mode,
                             )
                         except Exception as exc:
-                            log.error(
-                                "Reconcile: failed to re-assert mode+setpoint: %s", exc
-                            )
+                            log.error("Reconcile: failed to re-assert mode+setpoint: %s", exc)
 
         else:
             # IDLE — all zone vents should be open; load fresh from DB.
@@ -1272,9 +1232,7 @@ class CycleEngine:
                 continue
             target = float(snap.get("target", 0.0))
             source = snap.get("source", "schedule")
-            self._active_rooms[room_id] = ActiveRoom(
-                room=room, target_temp=target, source=source
-            )
+            self._active_rooms[room_id] = ActiveRoom(room=room, target_temp=target, source=source)
             self._room_vents[room_id] = await db.get_room_vents(conn, room_id)
 
         # Sanity check: verify the restored mode still makes sense given the
@@ -1295,9 +1253,7 @@ class CycleEngine:
                     all_targets = [ar.target_temp for ar in self._active_rooms.values()]
                     contradicts = (
                         to_restore.mode == "heating" and ambient_now > max(all_targets)
-                    ) or (
-                        to_restore.mode == "cooling" and ambient_now < min(all_targets)
-                    )
+                    ) or (to_restore.mode == "cooling" and ambient_now < min(all_targets))
                     if contradicts:
                         await db.close_cycle_log(conn, to_restore.id, datetime.utcnow())
                         log.warning(
@@ -1397,9 +1353,7 @@ class CycleEngine:
             self._sensor_map: dict[str, list[str]] = {}
         return self._sensor_map
 
-    async def load_room_sensors(
-        self, conn: aiosqlite.Connection, room_ids: list[str]
-    ) -> None:
+    async def load_room_sensors(self, conn: aiosqlite.Connection, room_ids: list[str]) -> None:
         """Load and cache sensor entity IDs for a set of rooms."""
         if not hasattr(self, "_sensor_map"):
             self._sensor_map: dict[str, list[str]] = {}
@@ -1408,9 +1362,7 @@ class CycleEngine:
             self._sensor_map[room_id] = [s.entity_id for s in sensors]
 
 
-def _is_at_target(
-    avg_temp: float, target_temp: float, hvac_mode: str, deadband: float
-) -> bool:
+def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str, deadband: float) -> bool:
     if hvac_mode == "cooling":
         return avg_temp <= target_temp + deadband
     else:  # heating

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -48,9 +48,7 @@ async def get_active_rooms(
 
     active: list[ActiveRoom] = []
     for room in rooms:
-        result = await _resolve_room(
-            conn, room, schedules_by_room.get(room.id, []), now
-        )
+        result = await _resolve_room(conn, room, schedules_by_room.get(room.id, []), now)
         if result.source != "idle":
             active.append(result)
     return active
@@ -65,9 +63,7 @@ async def _resolve_room(
     # 1. Override
     override = await db.get_room_override(conn, room.id)
     if override and override.expires_at > now:
-        return ActiveRoom(
-            room=room, target_temp=override.target_temp, source="override"
-        )
+        return ActiveRoom(room=room, target_temp=override.target_temp, source="override")
 
     # 2. Schedule
     match = _find_matching_schedule(schedules, now)
@@ -84,9 +80,7 @@ async def _resolve_room(
                 tc = await db.get_thermostat_config(conn, room.thermostat_entity_id)
                 presence_temp = tc.default_temp
             if presence_temp is not None:
-                return ActiveRoom(
-                    room=room, target_temp=presence_temp, source="presence"
-                )
+                return ActiveRoom(room=room, target_temp=presence_temp, source="presence")
             else:
                 log.debug(
                     "Room %s has presence holdover but no presence temp configured "
@@ -111,24 +105,18 @@ def _schedule_active(s: Schedule, current_day: int, current_time: time) -> bool:
 
     if not is_overnight:
         # Normal daytime block: active on days in days_of_week during [start, end)
-        return (
-            current_day in s.days_of_week and s.start_time <= current_time < s.end_time
-        )
+        return current_day in s.days_of_week and s.start_time <= current_time < s.end_time
     else:
         # Overnight block spans midnight:
         # - First portion: [start, 24:00) on the scheduled day
         # - Second portion: [00:00, end) on the NEXT day
         yesterday = (current_day - 1) % 7
-        in_first_portion = (
-            current_day in s.days_of_week and current_time >= s.start_time
-        )
+        in_first_portion = current_day in s.days_of_week and current_time >= s.start_time
         in_second_portion = yesterday in s.days_of_week and current_time < s.end_time
         return in_first_portion or in_second_portion
 
 
-def _find_matching_schedule(
-    schedules: list[Schedule], now: datetime
-) -> Schedule | None:
+def _find_matching_schedule(schedules: list[Schedule], now: datetime) -> Schedule | None:
     """Return the best matching schedule block for the current moment, or None."""
     current_day = now.weekday()  # 0=Monday
     current_time = now.time().replace(second=0, microsecond=0)

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -7,17 +7,17 @@ and at what target temperature, applying priority order:
   3. Presence holdover active (expires_at > now)
   4. Idle
 """
+
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, date, time
-from typing import Optional
+from datetime import datetime, time, timedelta
 
 import aiosqlite
 
-from ..models import Room, RoomOverride, PresenceHoldoverState, Schedule
 from .. import db
+from ..models import PresenceHoldoverState, Room, Schedule
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class ActiveRoom:
 async def get_active_rooms(
     conn: aiosqlite.Connection,
     thermostat_entity_id: str,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> list[ActiveRoom]:
     """Return all rooms for the given thermostat that should be active right now."""
     if now is None:
@@ -48,7 +48,9 @@ async def get_active_rooms(
 
     active: list[ActiveRoom] = []
     for room in rooms:
-        result = await _resolve_room(conn, room, schedules_by_room.get(room.id, []), now)
+        result = await _resolve_room(
+            conn, room, schedules_by_room.get(room.id, []), now
+        )
         if result.source != "idle":
             active.append(result)
     return active
@@ -63,7 +65,9 @@ async def _resolve_room(
     # 1. Override
     override = await db.get_room_override(conn, room.id)
     if override and override.expires_at > now:
-        return ActiveRoom(room=room, target_temp=override.target_temp, source="override")
+        return ActiveRoom(
+            room=room, target_temp=override.target_temp, source="override"
+        )
 
     # 2. Schedule
     match = _find_matching_schedule(schedules, now)
@@ -80,7 +84,9 @@ async def _resolve_room(
                 tc = await db.get_thermostat_config(conn, room.thermostat_entity_id)
                 presence_temp = tc.default_temp
             if presence_temp is not None:
-                return ActiveRoom(room=room, target_temp=presence_temp, source="presence")
+                return ActiveRoom(
+                    room=room, target_temp=presence_temp, source="presence"
+                )
             else:
                 log.debug(
                     "Room %s has presence holdover but no presence temp configured "
@@ -95,6 +101,7 @@ async def _resolve_room(
 # Schedule matching helpers (handle overnight blocks)
 # ---------------------------------------------------------------------------
 
+
 def _schedule_active(s: Schedule, current_day: int, current_time: time) -> bool:
     """
     Return True if the schedule is active at the given (weekday, time).
@@ -104,21 +111,24 @@ def _schedule_active(s: Schedule, current_day: int, current_time: time) -> bool:
 
     if not is_overnight:
         # Normal daytime block: active on days in days_of_week during [start, end)
-        return (current_day in s.days_of_week
-                and s.start_time <= current_time < s.end_time)
+        return (
+            current_day in s.days_of_week and s.start_time <= current_time < s.end_time
+        )
     else:
         # Overnight block spans midnight:
         # - First portion: [start, 24:00) on the scheduled day
         # - Second portion: [00:00, end) on the NEXT day
         yesterday = (current_day - 1) % 7
-        in_first_portion = (current_day in s.days_of_week
-                            and current_time >= s.start_time)
-        in_second_portion = (yesterday in s.days_of_week
-                             and current_time < s.end_time)
+        in_first_portion = (
+            current_day in s.days_of_week and current_time >= s.start_time
+        )
+        in_second_portion = yesterday in s.days_of_week and current_time < s.end_time
         return in_first_portion or in_second_portion
 
 
-def _find_matching_schedule(schedules: list[Schedule], now: datetime) -> Optional[Schedule]:
+def _find_matching_schedule(
+    schedules: list[Schedule], now: datetime
+) -> Schedule | None:
     """Return the best matching schedule block for the current moment, or None."""
     current_day = now.weekday()  # 0=Monday
     current_time = now.time().replace(second=0, microsecond=0)
@@ -131,7 +141,7 @@ def _find_matching_schedule(schedules: list[Schedule], now: datetime) -> Optiona
     return matches[0]
 
 
-def _matching_schedule(schedules: list[Schedule], now: datetime) -> Optional[float]:
+def _matching_schedule(schedules: list[Schedule], now: datetime) -> float | None:
     """Return target_temp of the first matching schedule block, or None."""
     match = _find_matching_schedule(schedules, now)
     return match.target_temp if match else None
@@ -140,6 +150,7 @@ def _matching_schedule(schedules: list[Schedule], now: datetime) -> Optional[flo
 # ---------------------------------------------------------------------------
 # Schedule interval overlap
 # ---------------------------------------------------------------------------
+
 
 def _schedule_intervals(s: Schedule) -> list[tuple[int, int, int]]:
     """
@@ -156,8 +167,8 @@ def _schedule_intervals(s: Schedule) -> list[tuple[int, int, int]]:
         if not is_overnight:
             intervals.append((d, sm, em))
         else:
-            intervals.append((d, sm, 1440))          # start → midnight
-            intervals.append(((d + 1) % 7, 0, em))   # midnight → end (next day)
+            intervals.append((d, sm, 1440))  # start → midnight
+            intervals.append(((d + 1) % 7, 0, em))  # midnight → end (next day)
     return intervals
 
 
@@ -165,8 +176,8 @@ def schedules_overlap(a: Schedule, b: Schedule) -> bool:
     """Return True if two schedules share any (day, time) slot."""
     a_intervals = _schedule_intervals(a)
     b_intervals = _schedule_intervals(b)
-    for (ad, as_, ae) in a_intervals:
-        for (bd, bs, be) in b_intervals:
+    for ad, as_, ae in a_intervals:
+        for bd, bs, be in b_intervals:
             if ad == bd and as_ < be and bs < ae:
                 return True
     return False
@@ -175,6 +186,7 @@ def schedules_overlap(a: Schedule, b: Schedule) -> bool:
 # ---------------------------------------------------------------------------
 # Detailed room status (for UI)
 # ---------------------------------------------------------------------------
+
 
 def _seconds_until_schedule_end(s: Schedule, now: datetime) -> float:
     """Return seconds until the currently-active block of schedule s ends."""
@@ -198,8 +210,8 @@ def _seconds_until_schedule_end(s: Schedule, now: datetime) -> float:
 def _next_schedule_start(
     schedules: list[Schedule],
     now: datetime,
-    exclude_id: Optional[str] = None,
-) -> Optional[tuple[int, float, str]]:
+    exclude_id: str | None = None,
+) -> tuple[int, float, str] | None:
     """
     Find the soonest upcoming schedule start across all schedules (excluding
     the one with id==exclude_id).
@@ -245,7 +257,7 @@ async def get_room_active_status(
     conn: aiosqlite.Connection,
     room: Room,
     schedules: list[Schedule],
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> dict:
     """
     Return detailed active status for a single room, suitable for the UI.
@@ -266,8 +278,8 @@ async def get_room_active_status(
 
     resolved = await _resolve_room(conn, room, schedules, now)
 
-    ends_in_seconds: Optional[int] = None
-    current_schedule_id: Optional[str] = None
+    ends_in_seconds: int | None = None
+    current_schedule_id: str | None = None
 
     if resolved.source == "override":
         override = await db.get_room_override(conn, room.id)
@@ -303,10 +315,11 @@ async def get_room_active_status(
 # Presence handling
 # ---------------------------------------------------------------------------
 
+
 async def handle_presence_event(
     conn: aiosqlite.Connection,
     room: Room,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> bool:
     """
     Called when a presence sensor fires for a room.
@@ -330,14 +343,15 @@ async def handle_presence_event(
     await db.upsert_holdover_state(conn, state)
     log.debug(
         "Presence holdover reset for room %s — expires %s",
-        room.name, expires_at.isoformat()
+        room.name,
+        expires_at.isoformat(),
     )
     return not was_active
 
 
 async def expire_holdovers(
     conn: aiosqlite.Connection,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> list[str]:
     """
     Remove expired holdover states. Returns list of room IDs that were removed.

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -5,24 +5,24 @@ Safety rules enforced here:
 - min_open_vents: never drop total open vent count below this threshold
 - max_vent_closed_min: opt-in safety valve — reopen a vent closed too long (0 = disabled, the default)
 """
+
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import Optional
 
 import aiosqlite
 
-from ..ha_client import HAClient
-from ..models import RoomCycleState, ThermostatConfig, RoomVent
-from ..event_logger import EventLogger
 from .. import db
+from ..event_logger import EventLogger
+from ..ha_client import HAClient
+from ..models import RoomCycleState, RoomVent, ThermostatConfig
 
 log = logging.getLogger(__name__)
 
 
 class VentController:
-    def __init__(self, ha: HAClient, event_logger: Optional[EventLogger] = None) -> None:
+    def __init__(self, ha: HAClient, event_logger: EventLogger | None = None) -> None:
         self._ha = ha
         self._logger = event_logger
 
@@ -40,7 +40,8 @@ class VentController:
                 await self._ha.open_cover(vent.entity_id)
                 if self._logger:
                     await self._logger.log(
-                        "info", "engine",
+                        "info",
+                        "engine",
                         f"Opened vent {vent.entity_id}",
                         {"entity_id": vent.entity_id},
                     )
@@ -51,7 +52,7 @@ class VentController:
         all_zone_vents: list[RoomVent],
         tc: ThermostatConfig,
         cycle_states: dict[str, RoomCycleState],
-        now: Optional[datetime] = None,
+        now: datetime | None = None,
     ) -> bool:
         """
         Attempt to close all vents for a room.
@@ -72,11 +73,16 @@ class VentController:
                 if self._logger:
                     vent_ids = [v.entity_id for v in vents]
                     await self._logger.log(
-                        "warning", "engine",
+                        "warning",
+                        "engine",
                         f"Vent close deferred — would drop to {currently_open - would_close} open "
                         f"(min_open_vents={tc.min_open_vents}): {vent_ids}",
-                        {"entity_ids": vent_ids, "currently_open": currently_open,
-                         "would_close": would_close, "min_open_vents": tc.min_open_vents},
+                        {
+                            "entity_ids": vent_ids,
+                            "currently_open": currently_open,
+                            "would_close": would_close,
+                            "min_open_vents": tc.min_open_vents,
+                        },
                     )
                 return False
 
@@ -85,7 +91,8 @@ class VentController:
                 await self._ha.close_cover(vent.entity_id)
                 if self._logger:
                     await self._logger.log(
-                        "info", "engine",
+                        "info",
+                        "engine",
                         f"Closed vent {vent.entity_id} (room at target)",
                         {"entity_id": vent.entity_id},
                     )
@@ -98,7 +105,7 @@ class VentController:
         room_vents: dict[str, list[RoomVent]],  # room_id → vents
         cycle_states: dict[str, RoomCycleState],
         tc: ThermostatConfig,
-        now: Optional[datetime] = None,
+        now: datetime | None = None,
     ) -> list[str]:
         """
         Reopen vents that have been closed longer than max_vent_closed_min.
@@ -122,16 +129,23 @@ class VentController:
                     vent_ids = [v.entity_id for v in vents]
                     log.warning(
                         "Room %s vents %s closed %.1f min (max=%d) — reopening for safety",
-                        room_id, vent_ids, duration_min, tc.max_vent_closed_min,
+                        room_id,
+                        vent_ids,
+                        duration_min,
+                        tc.max_vent_closed_min,
                     )
                     if self._logger:
                         await self._logger.log(
-                            "warning", "engine",
+                            "warning",
+                            "engine",
                             f"Force-reopening vents for room {room_id} — "
                             f"closed {duration_min:.1f}min (max={tc.max_vent_closed_min}min): {vent_ids}",
-                            {"room_id": room_id, "entity_ids": vent_ids,
-                             "duration_closed_min": round(duration_min, 1),
-                             "max_vent_closed_min": tc.max_vent_closed_min},
+                            {
+                                "room_id": room_id,
+                                "entity_ids": vent_ids,
+                                "duration_closed_min": round(duration_min, 1),
+                                "max_vent_closed_min": tc.max_vent_closed_min,
+                            },
                         )
                     await self.open_room_vents(vents)
                     # Reset vent_closed_at so the timer restarts
@@ -147,7 +161,8 @@ class VentController:
                 await self._ha.close_cover(vent.entity_id)
                 if self._logger:
                     await self._logger.log(
-                        "warning", "engine",
+                        "warning",
+                        "engine",
                         f"Emergency closed vent {vent.entity_id}",
                         {"entity_id": vent.entity_id},
                     )

--- a/smart_vent/backend/event_logger.py
+++ b/smart_vent/backend/event_logger.py
@@ -6,12 +6,13 @@ Usage:
     logger.set_conn(db_conn)           # call after DB is initialised
     await logger.log("info", "engine", "Cycle started", {"thermostat": "climate.upstairs"})
 """
+
 from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Callable, Coroutine
 from datetime import datetime
-from typing import Callable, Coroutine, Optional
 
 import aiosqlite
 
@@ -23,19 +24,19 @@ BroadcastFn = Callable[[str, dict], Coroutine]
 
 
 class EventLogger:
-    def __init__(self, broadcast: Optional[BroadcastFn] = None) -> None:
+    def __init__(self, broadcast: BroadcastFn | None = None) -> None:
         self._broadcast = broadcast
-        self._conn: Optional[aiosqlite.Connection] = None
+        self._conn: aiosqlite.Connection | None = None
 
     def set_conn(self, conn: aiosqlite.Connection) -> None:
         self._conn = conn
 
     async def log(
         self,
-        level: str,          # 'info' | 'warning' | 'error'
-        category: str,       # 'system' | 'api' | 'engine' | 'presence' | 'ha'
+        level: str,  # 'info' | 'warning' | 'error'
+        category: str,  # 'system' | 'api' | 'engine' | 'presence' | 'ha'
         message: str,
-        details: Optional[dict] = None,
+        details: dict | None = None,
     ) -> None:
         """Write an event to the DB and push it over WebSocket. Never raises."""
         timestamp = datetime.utcnow().isoformat()
@@ -66,5 +67,7 @@ class EventLogger:
             log.debug("EventLogger broadcast failed: %s", exc)
 
         # Also emit to Python log so the server console is useful
-        py_log = getattr(log, level if level in ("info", "warning", "error") else "info")
+        py_log = getattr(
+            log, level if level in ("info", "warning", "error") else "info"
+        )
         py_log("[%s] %s", category.upper(), message)

--- a/smart_vent/backend/event_logger.py
+++ b/smart_vent/backend/event_logger.py
@@ -67,7 +67,5 @@ class EventLogger:
             log.debug("EventLogger broadcast failed: %s", exc)
 
         # Also emit to Python log so the server console is useful
-        py_log = getattr(
-            log, level if level in ("info", "warning", "error") else "info"
-        )
+        py_log = getattr(log, level if level in ("info", "warning", "error") else "info")
         py_log("[%s] %s", category.upper(), message)

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -8,6 +8,7 @@ Responsibilities:
 - Fetch current entity state on demand
 - Handle reconnection with exponential backoff
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -16,12 +17,14 @@ import logging
 import os
 import ssl
 from collections import defaultdict
-from typing import Any, Callable, Coroutine, Optional
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 import aiohttp
 
 try:
     import certifi
+
     _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 except ImportError:
     _SSL_CONTEXT = None  # fall back to system default
@@ -38,11 +41,11 @@ class HAClient:
         self._ha_url = ha_url.rstrip("/")
         self._token = token
         self._ssl_verify = ssl_verify
-        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
-        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session: aiohttp.ClientSession | None = None
         self._msg_id = 0
         self._pending: dict[int, asyncio.Future] = {}
-        self._sub_id: Optional[int] = None
+        self._sub_id: int | None = None
         # entity_id → list of callbacks
         self._listeners: dict[str, list[StateCallback]] = defaultdict(list)
         self._wildcard_listeners: list[StateCallback] = []
@@ -52,7 +55,7 @@ class HAClient:
         self._state_cache: dict[str, dict] = {}
         # Developer mode: intercept all HA writes and log instead
         self.dev_mode: bool = False
-        self._dev_logger: Optional[Any] = None  # EventLogger, set externally
+        self._dev_logger: Any | None = None  # EventLogger, set externally
 
     # ------------------------------------------------------------------
     # Public API
@@ -93,17 +96,19 @@ class HAClient:
         """Register a callback for ALL entity state changes."""
         self._wildcard_listeners.append(callback)
 
-    def get_state(self, entity_id: str) -> Optional[dict]:
+    def get_state(self, entity_id: str) -> dict | None:
         """Return the cached state dict for an entity, or None."""
         return self._state_cache.get(entity_id)
 
-    def get_state_attr(self, entity_id: str, attribute: str, default: Any = None) -> Any:
+    def get_state_attr(
+        self, entity_id: str, attribute: str, default: Any = None
+    ) -> Any:
         state = self._state_cache.get(entity_id)
         if state is None:
             return default
         return state.get("attributes", {}).get(attribute, default)
 
-    def get_numeric_state(self, entity_id: str) -> Optional[float]:
+    def get_numeric_state(self, entity_id: str) -> float | None:
         """Return entity state as float, handling °C→°F conversion."""
         state = self._state_cache.get(entity_id)
         if state is None:
@@ -134,7 +139,7 @@ class HAClient:
         self,
         domain: str,
         service: str,
-        service_data: Optional[dict] = None,
+        service_data: dict | None = None,
     ) -> dict:
         """Call a HA service and await its response."""
         msg = {
@@ -150,22 +155,38 @@ class HAClient:
         self,
         entity_id: str,
         temperature: float,
-        hvac_mode: Optional[str] = None,
+        hvac_mode: str | None = None,
     ) -> None:
         service_data: dict = {"entity_id": entity_id, "temperature": temperature}
         if hvac_mode is not None:
             service_data["hvac_mode"] = hvac_mode
         if self.dev_mode:
             mode_note = f", hvac_mode={hvac_mode}" if hvac_mode else ""
-            log.info("[DEV] Would set thermostat %s → %.1f°F%s", entity_id, temperature, mode_note)
+            log.info(
+                "[DEV] Would set thermostat %s → %.1f°F%s",
+                entity_id,
+                temperature,
+                mode_note,
+            )
             if self._dev_logger:
-                await self._dev_logger.log("info", "dev",
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
                     f"Would set thermostat → {temperature:.1f}°F{mode_note}",
-                    {"entity_id": entity_id, "temperature": temperature,
-                     "hvac_mode": hvac_mode, "action": "set_thermostat"})
+                    {
+                        "entity_id": entity_id,
+                        "temperature": temperature,
+                        "hvac_mode": hvac_mode,
+                        "action": "set_thermostat",
+                    },
+                )
             return
-        log.info("Setting %s setpoint → %.1f°F%s", entity_id, temperature,
-                 f", hvac_mode={hvac_mode}" if hvac_mode else "")
+        log.info(
+            "Setting %s setpoint → %.1f°F%s",
+            entity_id,
+            temperature,
+            f", hvac_mode={hvac_mode}" if hvac_mode else "",
+        )
         await self.call_service("climate", "set_temperature", service_data)
 
     async def open_cover(self, entity_id: str) -> None:
@@ -173,9 +194,12 @@ class HAClient:
             msg = f"[DEV] Would open vent {entity_id}"
             log.info(msg)
             if self._dev_logger:
-                await self._dev_logger.log("info", "dev",
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
                     f"Would open vent {entity_id}",
-                    {"entity_id": entity_id, "action": "open_vent"})
+                    {"entity_id": entity_id, "action": "open_vent"},
+                )
             return
         log.info("Opening vent %s", entity_id)
         await self.call_service("cover", "open_cover", {"entity_id": entity_id})
@@ -185,9 +209,12 @@ class HAClient:
             msg = f"[DEV] Would close vent {entity_id}"
             log.info(msg)
             if self._dev_logger:
-                await self._dev_logger.log("info", "dev",
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
                     f"Would close vent {entity_id}",
-                    {"entity_id": entity_id, "action": "close_vent"})
+                    {"entity_id": entity_id, "action": "close_vent"},
+                )
             return
         log.info("Closing vent %s", entity_id)
         await self.call_service("cover", "close_cover", {"entity_id": entity_id})
@@ -196,8 +223,7 @@ class HAClient:
         """Return all cached states for a given domain."""
         await self._connected.wait()
         return [
-            s for eid, s in self._state_cache.items()
-            if eid.startswith(f"{domain}.")
+            s for eid, s in self._state_cache.items() if eid.startswith(f"{domain}.")
         ]
 
     # ------------------------------------------------------------------
@@ -206,9 +232,7 @@ class HAClient:
 
     async def _connect(self) -> None:
         ws_url = (
-            self._ha_url
-            .replace("http://", "ws://")
-            .replace("https://", "wss://")
+            self._ha_url.replace("http://", "ws://").replace("https://", "wss://")
         ) + "/api/websocket"
         log.info("Connecting to %s", ws_url)
         async with self._session.ws_connect(ws_url) as ws:
@@ -236,11 +260,13 @@ class HAClient:
     async def _subscribe_state_changed(self) -> None:
         self._msg_id += 1
         sub_id = self._msg_id
-        await self._ws.send_json({
-            "id": sub_id,
-            "type": "subscribe_events",
-            "event_type": "state_changed",
-        })
+        await self._ws.send_json(
+            {
+                "id": sub_id,
+                "type": "subscribe_events",
+                "event_type": "state_changed",
+            }
+        )
         resp = await self._ws.receive_json()
         assert resp.get("success"), f"Subscribe failed: {resp}"
         self._sub_id = sub_id
@@ -330,10 +356,18 @@ def build_ha_client() -> HAClient:
             token_source = "empty — no token available"
 
     log.info("Resolved — URL: %s (source: %s)", ha_url, url_source)
-    log.info("Resolved — token: %s (source: %s)", "present" if token else "MISSING", token_source)
+    log.info(
+        "Resolved — token: %s (source: %s)",
+        "present" if token else "MISSING",
+        token_source,
+    )
 
     use_wss = os.environ.get("HA_USE_WSS", "false").lower() in ("1", "true", "yes")
-    ssl_verify = os.environ.get("HA_SSL_VERIFY", "true").lower() not in ("0", "false", "no")
+    ssl_verify = os.environ.get("HA_SSL_VERIFY", "true").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
 
     log.info("Options — use_wss: %s | ssl_verify: %s", use_wss, ssl_verify)
 

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -100,9 +100,7 @@ class HAClient:
         """Return the cached state dict for an entity, or None."""
         return self._state_cache.get(entity_id)
 
-    def get_state_attr(
-        self, entity_id: str, attribute: str, default: Any = None
-    ) -> Any:
+    def get_state_attr(self, entity_id: str, attribute: str, default: Any = None) -> Any:
         state = self._state_cache.get(entity_id)
         if state is None:
             return default
@@ -222,9 +220,7 @@ class HAClient:
     async def get_entities_by_domain(self, domain: str) -> list[dict]:
         """Return all cached states for a given domain."""
         await self._connected.wait()
-        return [
-            s for eid, s in self._state_cache.items() if eid.startswith(f"{domain}.")
-        ]
+        return [s for eid, s in self._state_cache.items() if eid.startswith(f"{domain}.")]
 
     # ------------------------------------------------------------------
     # Internal connection lifecycle

--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -6,6 +6,7 @@ Starts:
 - Scheduler (background task, 60s ticks)
 - aiohttp server (REST API + WebSocket + static frontend)
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -15,11 +16,11 @@ from pathlib import Path
 
 from aiohttp import web
 
-from .ha_client import build_ha_client
-from .scheduler import Scheduler
-from .event_logger import EventLogger
 from .api.routes import routes
 from .api.ws_handler import WSManager
+from .event_logger import EventLogger
+from .ha_client import build_ha_client
+from .scheduler import Scheduler
 
 logging.basicConfig(
     level=logging.INFO,
@@ -43,7 +44,9 @@ async def main() -> None:
         await ws_manager.broadcast(event_type, payload)
 
     event_logger = EventLogger(broadcast=broadcast)
-    scheduler = Scheduler(ha=ha, db_path=DB_PATH, broadcast=broadcast, event_logger=event_logger)
+    scheduler = Scheduler(
+        ha=ha, db_path=DB_PATH, broadcast=broadcast, event_logger=event_logger
+    )
 
     app = web.Application()
     app["ha"] = ha
@@ -82,13 +85,21 @@ async def main() -> None:
         app["ha_task"] = asyncio.create_task(ha.start())
         # Start scheduler (sets up DB connection, starts tick loop)
         await scheduler.start()
+
         # Fire-and-forget: log HA connection state once it resolves
         async def _log_ha_state() -> None:
             try:
                 await ha.wait_connected(timeout=60)
-                await event_logger.log("info", "ha", "Connected to Home Assistant WebSocket")
-            except asyncio.TimeoutError:
-                await event_logger.log("warning", "ha", "HA WebSocket not yet connected — retrying in background")
+                await event_logger.log(
+                    "info", "ha", "Connected to Home Assistant WebSocket"
+                )
+            except TimeoutError:
+                await event_logger.log(
+                    "warning",
+                    "ha",
+                    "HA WebSocket not yet connected — retrying in background",
+                )
+
         asyncio.create_task(_log_ha_state())
 
     async def on_shutdown(app: web.Application) -> None:
@@ -117,6 +128,7 @@ async def main() -> None:
 if __name__ == "__main__":
     try:
         import uvloop
+
         uvloop.run(main())
     except ImportError:
         asyncio.run(main())

--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -44,9 +44,7 @@ async def main() -> None:
         await ws_manager.broadcast(event_type, payload)
 
     event_logger = EventLogger(broadcast=broadcast)
-    scheduler = Scheduler(
-        ha=ha, db_path=DB_PATH, broadcast=broadcast, event_logger=event_logger
-    )
+    scheduler = Scheduler(ha=ha, db_path=DB_PATH, broadcast=broadcast, event_logger=event_logger)
 
     app = web.Application()
     app["ha"] = ha
@@ -90,9 +88,7 @@ async def main() -> None:
         async def _log_ha_state() -> None:
             try:
                 await ha.wait_connected(timeout=60)
-                await event_logger.log(
-                    "info", "ha", "Connected to Home Assistant WebSocket"
-                )
+                await event_logger.log("info", "ha", "Connected to Home Assistant WebSocket")
             except TimeoutError:
                 await event_logger.log(
                     "warning",

--- a/smart_vent/backend/mcp_server.py
+++ b/smart_vent/backend/mcp_server.py
@@ -19,6 +19,7 @@ Usage (Claude Code mcp config):
     }
   }
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -27,10 +28,9 @@ import os
 import aiosqlite
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent
 
 from . import db
-from .mcp_tools import rooms, schedules, thermostats, status, ha_entities
+from .mcp_tools import ha_entities, rooms, schedules, status, thermostats
 
 DATA_DIR = os.environ.get("DATA_DIR", "/data")
 DB_PATH = os.path.join(DATA_DIR, "flair.db")
@@ -49,7 +49,9 @@ async def main() -> None:
         module.register(server, conn)
 
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
+        await server.run(
+            read_stream, write_stream, server.create_initialization_options()
+        )
 
     await conn.close()
 

--- a/smart_vent/backend/mcp_server.py
+++ b/smart_vent/backend/mcp_server.py
@@ -49,9 +49,7 @@ async def main() -> None:
         module.register(server, conn)
 
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream, write_stream, server.create_initialization_options()
-        )
+        await server.run(read_stream, write_stream, server.create_initialization_options())
 
     await conn.close()
 

--- a/smart_vent/backend/mcp_tools/ha_entities.py
+++ b/smart_vent/backend/mcp_tools/ha_entities.py
@@ -48,9 +48,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             {
                 "entity_id": s["entity_id"],
                 "state": s.get("state"),
-                "friendly_name": s.get("attributes", {}).get(
-                    "friendly_name", s["entity_id"]
-                ),
+                "friendly_name": s.get("attributes", {}).get("friendly_name", s["entity_id"]),
             }
             for s in states
             if s["entity_id"].startswith(f"{domain}.")

--- a/smart_vent/backend/mcp_tools/ha_entities.py
+++ b/smart_vent/backend/mcp_tools/ha_entities.py
@@ -1,9 +1,9 @@
 """MCP tools: HA entity discovery (requires live HA connection via REST)."""
+
 from __future__ import annotations
 
 import json
 import os
-
 import ssl
 
 import aiohttp
@@ -11,6 +11,7 @@ import aiosqlite
 
 try:
     import certifi
+
     _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 except ImportError:
     _SSL_CONTEXT = None
@@ -34,12 +35,12 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
 
         try:
             connector = aiohttp.TCPConnector(ssl=_SSL_CONTEXT)
-            async with aiohttp.ClientSession(connector=connector) as session:
-                async with session.get(
-                    f"{ha_url}/api/states", headers=headers
-                ) as resp:
-                    resp.raise_for_status()
-                    states = await resp.json()
+            async with (
+                aiohttp.ClientSession(connector=connector) as session,
+                session.get(f"{ha_url}/api/states", headers=headers) as resp,
+            ):
+                resp.raise_for_status()
+                states = await resp.json()
         except Exception as exc:
             return [TextContent(type="text", text=f"Error fetching HA entities: {exc}")]
 
@@ -47,14 +48,18 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             {
                 "entity_id": s["entity_id"],
                 "state": s.get("state"),
-                "friendly_name": s.get("attributes", {}).get("friendly_name", s["entity_id"]),
+                "friendly_name": s.get("attributes", {}).get(
+                    "friendly_name", s["entity_id"]
+                ),
             }
             for s in states
             if s["entity_id"].startswith(f"{domain}.")
         ]
         filtered.sort(key=lambda x: x["entity_id"])
-        return [TextContent(
-            type="text",
-            text=f"Found {len(filtered)} entities in domain '{domain}':\n"
-                 + json.dumps(filtered, indent=2)
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Found {len(filtered)} entities in domain '{domain}':\n"
+                + json.dumps(filtered, indent=2),
+            )
+        ]

--- a/smart_vent/backend/mcp_tools/rooms.py
+++ b/smart_vent/backend/mcp_tools/rooms.py
@@ -81,9 +81,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             notes=notes,
         )
         await db.upsert_room(conn, room)
-        return [
-            TextContent(type="text", text=f"Created room '{name}' with id={room.id}")
-        ]
+        return [TextContent(type="text", text=f"Created room '{name}' with id={room.id}")]
 
     @server.tool()
     async def update_room(
@@ -125,9 +123,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         """Add a temperature sensor to a room."""
         s = RoomSensor.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_sensor(conn, s)
-        return [
-            TextContent(type="text", text=f"Added sensor {entity_id} to room {room_id}")
-        ]
+        return [TextContent(type="text", text=f"Added sensor {entity_id} to room {room_id}")]
 
     @server.tool()
     async def remove_sensor(room_id: str, entity_id: str) -> list[TextContent]:
@@ -140,9 +136,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         """Add a Flair vent (cover entity) to a room."""
         v = RoomVent.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_vent(conn, v)
-        return [
-            TextContent(type="text", text=f"Added vent {entity_id} to room {room_id}")
-        ]
+        return [TextContent(type="text", text=f"Added vent {entity_id} to room {room_id}")]
 
     @server.tool()
     async def remove_vent(room_id: str, entity_id: str) -> list[TextContent]:
@@ -156,9 +150,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         p = RoomPresenceSensor.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_presence_sensor(conn, p)
         return [
-            TextContent(
-                type="text", text=f"Added presence sensor {entity_id} to room {room_id}"
-            )
+            TextContent(type="text", text=f"Added presence sensor {entity_id} to room {room_id}")
         ]
 
     @server.tool()

--- a/smart_vent/backend/mcp_tools/rooms.py
+++ b/smart_vent/backend/mcp_tools/rooms.py
@@ -1,4 +1,5 @@
 """MCP tools: room + sensor/vent/presence management."""
+
 from __future__ import annotations
 
 import json
@@ -6,7 +7,7 @@ from datetime import datetime, timedelta
 
 import aiosqlite
 from mcp.server import Server
-from mcp.types import Tool, TextContent
+from mcp.types import TextContent
 
 from .. import db
 from ..models import Room, RoomOverride, RoomPresenceSensor, RoomSensor, RoomVent
@@ -23,12 +24,14 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             sensors = await db.get_room_sensors(conn, r.id)
             vents = await db.get_room_vents(conn, r.id)
             presence = await db.get_room_presence_sensors(conn, r.id)
-            result.append({
-                **r.__dict__,
-                "sensor_count": len(sensors),
-                "vent_count": len(vents),
-                "presence_sensor_count": len(presence),
-            })
+            result.append(
+                {
+                    **r.__dict__,
+                    "sensor_count": len(sensors),
+                    "vent_count": len(vents),
+                    "presence_sensor_count": len(presence),
+                }
+            )
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     @server.tool()
@@ -78,7 +81,9 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             notes=notes,
         )
         await db.upsert_room(conn, room)
-        return [TextContent(type="text", text=f"Created room '{name}' with id={room.id}")]
+        return [
+            TextContent(type="text", text=f"Created room '{name}' with id={room.id}")
+        ]
 
     @server.tool()
     async def update_room(
@@ -120,7 +125,9 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         """Add a temperature sensor to a room."""
         s = RoomSensor.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_sensor(conn, s)
-        return [TextContent(type="text", text=f"Added sensor {entity_id} to room {room_id}")]
+        return [
+            TextContent(type="text", text=f"Added sensor {entity_id} to room {room_id}")
+        ]
 
     @server.tool()
     async def remove_sensor(room_id: str, entity_id: str) -> list[TextContent]:
@@ -133,7 +140,9 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         """Add a Flair vent (cover entity) to a room."""
         v = RoomVent.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_vent(conn, v)
-        return [TextContent(type="text", text=f"Added vent {entity_id} to room {room_id}")]
+        return [
+            TextContent(type="text", text=f"Added vent {entity_id} to room {room_id}")
+        ]
 
     @server.tool()
     async def remove_vent(room_id: str, entity_id: str) -> list[TextContent]:
@@ -146,7 +155,11 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         """Add a presence/motion sensor (binary_sensor.*) to a room."""
         p = RoomPresenceSensor.create(room_id=room_id, entity_id=entity_id)
         await db.add_room_presence_sensor(conn, p)
-        return [TextContent(type="text", text=f"Added presence sensor {entity_id} to room {room_id}")]
+        return [
+            TextContent(
+                type="text", text=f"Added presence sensor {entity_id} to room {room_id}"
+            )
+        ]
 
     @server.tool()
     async def remove_presence_sensor(room_id: str, entity_id: str) -> list[TextContent]:
@@ -165,11 +178,13 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             expires_at=datetime.utcnow() + timedelta(hours=duration_hours),
         )
         await db.set_room_override(conn, override)
-        return [TextContent(
-            type="text",
-            text=f"Override set: room {room_id} → {target_temp}°F for {duration_hours}h "
-                 f"(expires {override.expires_at.isoformat()})"
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Override set: room {room_id} → {target_temp}°F for {duration_hours}h "
+                f"(expires {override.expires_at.isoformat()})",
+            )
+        ]
 
     @server.tool()
     async def clear_room_override(room_id: str) -> list[TextContent]:

--- a/smart_vent/backend/mcp_tools/schedules.py
+++ b/smart_vent/backend/mcp_tools/schedules.py
@@ -1,4 +1,5 @@
 """MCP tools: schedule management."""
+
 from __future__ import annotations
 
 import json
@@ -53,11 +54,13 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             target_temp=target_temp,
         )
         await db.upsert_schedule(conn, s)
-        return [TextContent(
-            type="text",
-            text=f"Created schedule {s.id} for room {room_id}: "
-                 f"days={days_of_week} {start_time}–{end_time} @ {target_temp}°F"
-        )]
+        return [
+            TextContent(
+                type="text",
+                text=f"Created schedule {s.id} for room {room_id}: "
+                f"days={days_of_week} {start_time}–{end_time} @ {target_temp}°F",
+            )
+        ]
 
     @server.tool()
     async def update_schedule(

--- a/smart_vent/backend/mcp_tools/status.py
+++ b/smart_vent/backend/mcp_tools/status.py
@@ -1,4 +1,5 @@
 """MCP tools: system status (read-only)."""
+
 from __future__ import annotations
 
 import json
@@ -27,22 +28,28 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
             override = await db.get_room_override(conn, room.id)
             holdover = await db.get_holdover_state(conn, room.id)
             schedules = await db.get_schedules_for_room(conn, room.id)
-            result.append({
-                "room_id": room.id,
-                "name": room.name,
-                "thermostat_entity_id": room.thermostat_entity_id,
-                "system_wide_temp": room.system_wide_temp,
-                "presence_holdover_hours": room.presence_holdover_hours,
-                "active_override": {
-                    "target_temp": override.target_temp,
-                    "expires_at": override.expires_at.isoformat(),
-                } if override else None,
-                "presence_holdover": {
-                    "last_detected_at": holdover.last_detected_at.isoformat(),
-                    "expires_at": holdover.expires_at.isoformat(),
-                } if holdover else None,
-                "schedule_count": len(schedules),
-            })
+            result.append(
+                {
+                    "room_id": room.id,
+                    "name": room.name,
+                    "thermostat_entity_id": room.thermostat_entity_id,
+                    "system_wide_temp": room.system_wide_temp,
+                    "presence_holdover_hours": room.presence_holdover_hours,
+                    "active_override": {
+                        "target_temp": override.target_temp,
+                        "expires_at": override.expires_at.isoformat(),
+                    }
+                    if override
+                    else None,
+                    "presence_holdover": {
+                        "last_detected_at": holdover.last_detected_at.isoformat(),
+                        "expires_at": holdover.expires_at.isoformat(),
+                    }
+                    if holdover
+                    else None,
+                    "schedule_count": len(schedules),
+                }
+            )
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
     @server.tool()
@@ -51,13 +58,15 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         logs = await db.get_cycle_logs(conn, limit=limit)
         data = [
             {
-                "id": l.id,
-                "thermostat_entity_id": l.thermostat_entity_id,
-                "started_at": l.started_at.isoformat(),
-                "ended_at": l.ended_at.isoformat() if l.ended_at else None,
-                "mode": l.mode,
-                "rooms": json.loads(l.rooms_json),
+                "id": log_entry.id,
+                "thermostat_entity_id": log_entry.thermostat_entity_id,
+                "started_at": log_entry.started_at.isoformat(),
+                "ended_at": log_entry.ended_at.isoformat()
+                if log_entry.ended_at
+                else None,
+                "mode": log_entry.mode,
+                "rooms": json.loads(log_entry.rooms_json),
             }
-            for l in logs
+            for log_entry in logs
         ]
         return [TextContent(type="text", text=json.dumps(data, indent=2))]

--- a/smart_vent/backend/mcp_tools/status.py
+++ b/smart_vent/backend/mcp_tools/status.py
@@ -61,9 +61,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
                 "id": log_entry.id,
                 "thermostat_entity_id": log_entry.thermostat_entity_id,
                 "started_at": log_entry.started_at.isoformat(),
-                "ended_at": log_entry.ended_at.isoformat()
-                if log_entry.ended_at
-                else None,
+                "ended_at": log_entry.ended_at.isoformat() if log_entry.ended_at else None,
                 "mode": log_entry.mode,
                 "rooms": json.loads(log_entry.rooms_json),
             }

--- a/smart_vent/backend/mcp_tools/thermostats.py
+++ b/smart_vent/backend/mcp_tools/thermostats.py
@@ -17,11 +17,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
     async def list_thermostat_configs() -> list[TextContent]:
         """List all thermostat safety configurations."""
         configs = await db.get_all_thermostat_configs(conn)
-        return [
-            TextContent(
-                type="text", text=json.dumps([c.__dict__ for c in configs], indent=2)
-            )
-        ]
+        return [TextContent(type="text", text=json.dumps([c.__dict__ for c in configs], indent=2))]
 
     @server.tool()
     async def set_thermostat_config(

--- a/smart_vent/backend/mcp_tools/thermostats.py
+++ b/smart_vent/backend/mcp_tools/thermostats.py
@@ -1,4 +1,5 @@
 """MCP tools: thermostat configuration."""
+
 from __future__ import annotations
 
 import json
@@ -8,7 +9,6 @@ from mcp.server import Server
 from mcp.types import TextContent
 
 from .. import db
-from ..models import ThermostatConfig
 
 
 def register(server: Server, conn: aiosqlite.Connection) -> None:
@@ -17,7 +17,11 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
     async def list_thermostat_configs() -> list[TextContent]:
         """List all thermostat safety configurations."""
         configs = await db.get_all_thermostat_configs(conn)
-        return [TextContent(type="text", text=json.dumps([c.__dict__ for c in configs], indent=2))]
+        return [
+            TextContent(
+                type="text", text=json.dumps([c.__dict__ for c in configs], indent=2)
+            )
+        ]
 
     @server.tool()
     async def set_thermostat_config(
@@ -56,4 +60,9 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         if cycle_timeout_hours is not None:
             tc.cycle_timeout_hours = cycle_timeout_hours
         await db.upsert_thermostat_config(conn, tc)
-        return [TextContent(type="text", text=f"Updated config for {thermostat_entity_id}: {tc.__dict__}")]
+        return [
+            TextContent(
+                type="text",
+                text=f"Updated config for {thermostat_entity_id}: {tc.__dict__}",
+            )
+        ]

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -2,12 +2,12 @@
 Dataclasses for all domain entities.
 All temperatures in °F internally. Conversion happens at HA ingestion.
 """
+
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, time
-from typing import Optional
 
 
 def new_id() -> str:
@@ -18,20 +18,23 @@ def new_id() -> str:
 # Configuration entities
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class Room:
     id: str
     name: str
     thermostat_entity_id: str
     include_thermostat_sensor: bool = False
-    system_wide_temp: Optional[float] = None
+    system_wide_temp: float | None = None
     presence_holdover_hours: float = 2.0
     notes: str = ""
     temp_offset: float = 0.0  # °F added to measured avg before comparing to target
 
     @classmethod
-    def create(cls, name: str, thermostat_entity_id: str, **kwargs) -> "Room":
-        return cls(id=new_id(), name=name, thermostat_entity_id=thermostat_entity_id, **kwargs)
+    def create(cls, name: str, thermostat_entity_id: str, **kwargs) -> Room:
+        return cls(
+            id=new_id(), name=name, thermostat_entity_id=thermostat_entity_id, **kwargs
+        )
 
 
 @dataclass
@@ -41,7 +44,7 @@ class RoomSensor:
     entity_id: str  # sensor.*
 
     @classmethod
-    def create(cls, room_id: str, entity_id: str) -> "RoomSensor":
+    def create(cls, room_id: str, entity_id: str) -> RoomSensor:
         return cls(id=new_id(), room_id=room_id, entity_id=entity_id)
 
 
@@ -52,7 +55,7 @@ class RoomVent:
     entity_id: str  # cover.*
 
     @classmethod
-    def create(cls, room_id: str, entity_id: str) -> "RoomVent":
+    def create(cls, room_id: str, entity_id: str) -> RoomVent:
         return cls(id=new_id(), room_id=room_id, entity_id=entity_id)
 
 
@@ -63,7 +66,7 @@ class RoomPresenceSensor:
     entity_id: str  # binary_sensor.*
 
     @classmethod
-    def create(cls, room_id: str, entity_id: str) -> "RoomPresenceSensor":
+    def create(cls, room_id: str, entity_id: str) -> RoomPresenceSensor:
         return cls(id=new_id(), room_id=room_id, entity_id=entity_id)
 
 
@@ -72,9 +75,9 @@ class Schedule:
     id: str
     room_id: str
     days_of_week: list[int]  # 0=Monday … 6=Sunday
-    start_time: time          # local time
+    start_time: time  # local time
     end_time: time
-    target_temp: float        # °F
+    target_temp: float  # °F
 
     @classmethod
     def create(
@@ -84,7 +87,7 @@ class Schedule:
         start_time: time,
         end_time: time,
         target_temp: float,
-    ) -> "Schedule":
+    ) -> Schedule:
         return cls(
             id=new_id(),
             room_id=room_id,
@@ -98,11 +101,13 @@ class Schedule:
 @dataclass
 class ThermostatConfig:
     thermostat_entity_id: str  # PK — HA climate entity
-    name: str = ""             # friendly display name, e.g. "Upstairs HVAC"
-    default_temp: Optional[float] = None  # thermostat-level fallback for presence activation
+    name: str = ""  # friendly display name, e.g. "Upstairs HVAC"
+    default_temp: float | None = (
+        None  # thermostat-level fallback for presence activation
+    )
     min_setpoint: float = 60.0
     max_setpoint: float = 85.0
-    deadband: float = 0.5       # ±°F
+    deadband: float = 0.5  # ±°F
     max_vent_closed_min: int = 0  # minutes before a closed vent is force-reopened; 0 = no limit (feature off by default)
     min_open_vents: int = 1
     overshoot_delta: float = 2.0
@@ -124,6 +129,7 @@ class RoomOverride:
 # Runtime / persisted state
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class PresenceHoldoverState:
     room_id: str  # PK
@@ -135,17 +141,18 @@ class PresenceHoldoverState:
 # Cycle tracking
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class CycleLog:
     id: str
     thermostat_entity_id: str
     started_at: datetime
-    mode: str               # 'heating' | 'cooling'
-    rooms_json: str         # JSON snapshot
-    ended_at: Optional[datetime] = None
+    mode: str  # 'heating' | 'cooling'
+    rooms_json: str  # JSON snapshot
+    ended_at: datetime | None = None
 
     @classmethod
-    def create(cls, thermostat_entity_id: str, mode: str, rooms_json: str) -> "CycleLog":
+    def create(cls, thermostat_entity_id: str, mode: str, rooms_json: str) -> CycleLog:
         return cls(
             id=new_id(),
             thermostat_entity_id=thermostat_entity_id,
@@ -160,34 +167,37 @@ class RoomCycleState:
     cycle_id: str
     room_id: str
     target_temp: float
-    reached_at: Optional[datetime] = None
-    vent_closed_at: Optional[datetime] = None
+    reached_at: datetime | None = None
+    vent_closed_at: datetime | None = None
 
 
 # ---------------------------------------------------------------------------
 # Runtime-only (not persisted to DB)
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class RoomLiveState:
     """In-memory snapshot of a room's current sensor readings."""
+
     room_id: str
-    avg_temp: Optional[float]         # None if all sensors unavailable
+    avg_temp: float | None  # None if all sensors unavailable
     sensor_count: int
     available_sensor_count: int
-    vent_states: dict[str, str]       # entity_id → 'open'|'closed'|'unknown'
+    vent_states: dict[str, str]  # entity_id → 'open'|'closed'|'unknown'
     presence_active: bool
-    holdover_expires_at: Optional[datetime]
+    holdover_expires_at: datetime | None
 
 
 @dataclass
 class ZoneStatus:
     """Summarised status for one thermostat zone (all rooms sharing that thermostat)."""
+
     thermostat_entity_id: str
-    hvac_mode: str              # 'heating'|'cooling'|'off'|'unknown'
+    hvac_mode: str  # 'heating'|'cooling'|'off'|'unknown'
     hvac_action: str
-    current_temp: Optional[float]
-    setpoint: Optional[float]
-    cycle_id: Optional[str]
-    cycle_started_at: Optional[datetime]
+    current_temp: float | None
+    setpoint: float | None
+    cycle_id: str | None
+    cycle_started_at: datetime | None
     rooms: list[RoomLiveState] = field(default_factory=list)

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -32,9 +32,7 @@ class Room:
 
     @classmethod
     def create(cls, name: str, thermostat_entity_id: str, **kwargs) -> Room:
-        return cls(
-            id=new_id(), name=name, thermostat_entity_id=thermostat_entity_id, **kwargs
-        )
+        return cls(id=new_id(), name=name, thermostat_entity_id=thermostat_entity_id, **kwargs)
 
 
 @dataclass
@@ -102,13 +100,13 @@ class Schedule:
 class ThermostatConfig:
     thermostat_entity_id: str  # PK — HA climate entity
     name: str = ""  # friendly display name, e.g. "Upstairs HVAC"
-    default_temp: float | None = (
-        None  # thermostat-level fallback for presence activation
-    )
+    default_temp: float | None = None  # thermostat-level fallback for presence activation
     min_setpoint: float = 60.0
     max_setpoint: float = 85.0
     deadband: float = 0.5  # ±°F
-    max_vent_closed_min: int = 0  # minutes before a closed vent is force-reopened; 0 = no limit (feature off by default)
+    max_vent_closed_min: int = (
+        0  # minutes before a closed vent is force-reopened; 0 = no limit (feature off by default)
+    )
     min_open_vents: int = 1
     overshoot_delta: float = 2.0
     cycle_timeout_hours: float = 3.0

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -147,9 +147,7 @@ class Scheduler:
 
     async def set_system_enabled(self, enabled: bool) -> None:
         self._system_enabled = enabled
-        await db.set_system_setting(
-            self._db_conn, "system_enabled", "1" if enabled else "0"
-        )
+        await db.set_system_setting(self._db_conn, "system_enabled", "1" if enabled else "0")
         log.info("System %s", "enabled" if enabled else "disabled")
         if not enabled:
             # Abort any running cycles immediately — don't wait for the next 60s tick.
@@ -165,9 +163,7 @@ class Scheduler:
     async def set_dev_mode(self, enabled: bool) -> None:
         self._dev_mode = enabled
         self._ha.dev_mode = enabled
-        await db.set_system_setting(
-            self._db_conn, "developer_mode", "1" if enabled else "0"
-        )
+        await db.set_system_setting(self._db_conn, "developer_mode", "1" if enabled else "0")
         log.info("Developer mode %s", "enabled" if enabled else "disabled")
         if self._event_logger:
             await self._event_logger.log(
@@ -265,9 +261,7 @@ class Scheduler:
     async def _handle_presence_event(self, presence_entity_id: str) -> None:
         rooms = await db.get_all_rooms(self._db_conn)
         for room in rooms:
-            presence_sensors = await db.get_room_presence_sensors(
-                self._db_conn, room.id
-            )
+            presence_sensors = await db.get_room_presence_sensors(self._db_conn, room.id)
             for ps in presence_sensors:
                 if ps.entity_id == presence_entity_id:
                     if self._event_logger:
@@ -304,9 +298,7 @@ class Scheduler:
             "current_temp": s.current_temp,
             "setpoint": s.setpoint,
             "cycle_id": s.cycle_id,
-            "cycle_started_at": s.cycle_started_at.isoformat()
-            if s.cycle_started_at
-            else None,
+            "cycle_started_at": s.cycle_started_at.isoformat() if s.cycle_started_at else None,
             "rooms": [
                 {
                     "room_id": r.room_id,

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -6,21 +6,21 @@ Central scheduler.
 - Manages the mapping of thermostats → CycleEngine instances
 - Owns the system_enabled flag (persisted to DB)
 """
+
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
-from typing import Callable, Coroutine, Optional
+from collections.abc import Callable, Coroutine
 
 import aiosqlite
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from .ha_client import HAClient
+from . import db
 from .engine.cycle_engine import CycleEngine
 from .engine.vent_controller import VentController
 from .event_logger import EventLogger
-from . import db
+from .ha_client import HAClient
 
 log = logging.getLogger(__name__)
 
@@ -32,17 +32,17 @@ class Scheduler:
         self,
         ha: HAClient,
         db_path: str,
-        broadcast: Optional[BroadcastFn] = None,
-        event_logger: Optional[EventLogger] = None,
+        broadcast: BroadcastFn | None = None,
+        event_logger: EventLogger | None = None,
     ) -> None:
         self._ha = ha
         self._db_path = db_path
         self._broadcast = broadcast
         self._event_logger = event_logger
-        self._vent_ctrl: Optional[VentController] = None
+        self._vent_ctrl: VentController | None = None
         self._engines: dict[str, CycleEngine] = {}
         self._apscheduler = AsyncIOScheduler()
-        self._db_conn: Optional[aiosqlite.Connection] = None
+        self._db_conn: aiosqlite.Connection | None = None
         self._system_enabled: bool = True
         self._dev_mode: bool = False
 
@@ -65,7 +65,8 @@ class Scheduler:
         if self._event_logger:
             self._event_logger.set_conn(self._db_conn)
             await self._event_logger.log(
-                "info", "system",
+                "info",
+                "system",
                 f"Scheduler started (system {'enabled' if self._system_enabled else 'disabled'}"
                 f"{', dev mode ON' if self._dev_mode else ''})",
             )
@@ -127,7 +128,11 @@ class Scheduler:
         self._ha.dev_mode = self._dev_mode
         self._ha._dev_logger = self._event_logger
         await self._sync_engines()
-        log.info("Scheduler DB reloaded (system_enabled=%s, dev_mode=%s)", self._system_enabled, self._dev_mode)
+        log.info(
+            "Scheduler DB reloaded (system_enabled=%s, dev_mode=%s)",
+            self._system_enabled,
+            self._dev_mode,
+        )
         await self._event_logger.log("info", "system", "Database restored and reloaded")
 
     async def get_db(self) -> aiosqlite.Connection:
@@ -142,7 +147,9 @@ class Scheduler:
 
     async def set_system_enabled(self, enabled: bool) -> None:
         self._system_enabled = enabled
-        await db.set_system_setting(self._db_conn, "system_enabled", "1" if enabled else "0")
+        await db.set_system_setting(
+            self._db_conn, "system_enabled", "1" if enabled else "0"
+        )
         log.info("System %s", "enabled" if enabled else "disabled")
         if not enabled:
             # Abort any running cycles immediately — don't wait for the next 60s tick.
@@ -158,11 +165,14 @@ class Scheduler:
     async def set_dev_mode(self, enabled: bool) -> None:
         self._dev_mode = enabled
         self._ha.dev_mode = enabled
-        await db.set_system_setting(self._db_conn, "developer_mode", "1" if enabled else "0")
+        await db.set_system_setting(
+            self._db_conn, "developer_mode", "1" if enabled else "0"
+        )
         log.info("Developer mode %s", "enabled" if enabled else "disabled")
         if self._event_logger:
             await self._event_logger.log(
-                "info", "system",
+                "info",
+                "system",
                 f"Developer mode {'enabled' if enabled else 'disabled'}",
             )
         if self._broadcast:
@@ -207,18 +217,21 @@ class Scheduler:
 
     async def _purge_old_logs(self) -> None:
         """Delete event and cycle logs older than their configured retention periods."""
-        event_days = int(await db.get_system_setting(
-            self._db_conn, "event_log_retention_days", "7"
-        ))
-        cycle_days = int(await db.get_system_setting(
-            self._db_conn, "cycle_log_retention_days", "30"
-        ))
+        event_days = int(
+            await db.get_system_setting(self._db_conn, "event_log_retention_days", "7")
+        )
+        cycle_days = int(
+            await db.get_system_setting(self._db_conn, "cycle_log_retention_days", "30")
+        )
         ev_count = await db.purge_event_logs(self._db_conn, event_days)
         cy_count = await db.purge_cycle_logs(self._db_conn, cycle_days)
         if ev_count or cy_count:
             log.info(
                 "Log purge complete — removed %d event rows (>%dd), %d cycle rows (>%dd)",
-                ev_count, event_days, cy_count, cycle_days,
+                ev_count,
+                event_days,
+                cy_count,
+                cycle_days,
             )
 
     # ------------------------------------------------------------------
@@ -252,12 +265,15 @@ class Scheduler:
     async def _handle_presence_event(self, presence_entity_id: str) -> None:
         rooms = await db.get_all_rooms(self._db_conn)
         for room in rooms:
-            presence_sensors = await db.get_room_presence_sensors(self._db_conn, room.id)
+            presence_sensors = await db.get_room_presence_sensors(
+                self._db_conn, room.id
+            )
             for ps in presence_sensors:
                 if ps.entity_id == presence_entity_id:
                     if self._event_logger:
                         await self._event_logger.log(
-                            "info", "presence",
+                            "info",
+                            "presence",
                             f"Presence detected in {room.name} via {presence_entity_id}",
                             {"room_id": room.id, "sensor": presence_entity_id},
                         )
@@ -288,7 +304,9 @@ class Scheduler:
             "current_temp": s.current_temp,
             "setpoint": s.setpoint,
             "cycle_id": s.cycle_id,
-            "cycle_started_at": s.cycle_started_at.isoformat() if s.cycle_started_at else None,
+            "cycle_started_at": s.cycle_started_at.isoformat()
+            if s.cycle_started_at
+            else None,
             "rooms": [
                 {
                     "room_id": r.room_id,

--- a/smart_vent/pyproject.toml
+++ b/smart_vent/pyproject.toml
@@ -21,8 +21,31 @@ dev = [
     "pytest>=8",
     "pytest-asyncio>=0.23",
     "aioresponses>=0.7",
+    "ruff>=0.4",
 ]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["backend/tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+  "E",   # pycodestyle errors
+  "W",   # pycodestyle warnings
+  "F",   # pyflakes (undefined names, unused imports)
+  "I",   # isort (import ordering)
+  "B",   # flake8-bugbear (common bugs and anti-patterns)
+  "UP",  # pyupgrade (modernise syntax)
+  "C4",  # flake8-comprehensions
+  "SIM", # flake8-simplify
+]
+ignore = [
+  "E501",  # line length handled by formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"backend/tests/**" = ["S101"]  # allow assert in tests


### PR DESCRIPTION
## Summary

Closes #10

- Add `.github/workflows/lint.yml` — CI job that runs `ruff check` and `ruff format --check` on every push/PR to main, blocking merge on failure
- Add ruff config to `smart_vent/pyproject.toml` (E/W/F/I/B/UP/C4/SIM rules, line-length=100, S101 ignored in tests)
- Add `ruff>=0.4` to `[project.optional-dependencies] dev`
- Fix all 119 existing violations across the backend so CI passes immediately on merge

## Violations fixed

**110 auto-fixed (`ruff check --fix` + `ruff format`):**
- `UP045` (66) — `Optional[X]` → `X | None` throughout (PEP 604)
- `F401` (10) — unused imports removed (`asyncio`, `Optional`, `ThermostatConfig`, etc.)
- `I001` (10) — unsorted import blocks reorganised
- `UP037` (7) — unnecessary quoted annotations removed
- `UP035` (4) — deprecated `typing.Callable`/`Coroutine` → `collections.abc`
- `UP041` (1) — `TimeoutError` alias modernised

**9 fixed manually:**
- `E741` — ambiguous loop var `l` → `log_entry` in `routes.py` and `mcp_tools/status.py`
- `F841` — removed unused `expired =` in `cycle_engine._do_tick`
- `SIM102` — collapsed nested `if` into a single `if … and …` in `cycle_engine._do_tick`
- `B007` (×2) — loops over `.items()` that only used the key switched to `for room_id in self._active_rooms`
- `SIM105` (×2) — `try/except/pass` → `contextlib.suppress(ValueError, TypeError)` in `cycle_engine`
- `SIM117` — nested `async with` → single parenthesised form in `mcp_tools/ha_entities.py`

## Test plan

- [ ] `ruff check smart_vent/backend/` passes with no errors
- [ ] `ruff format --check smart_vent/backend/` passes with no reformats needed
- [ ] `lint.yml` CI job is green on this PR
- [ ] No behaviour changes — all fixes are style/import/syntax only