### PR TITLE
ci: enforce frontend linting and formatting with ESLint and Prettier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,20 @@ jobs:
         working-directory: smart_vent
       - run: ruff format --check backend/
         working-directory: smart_vent
+
+  frontend-lint:
+    name: Frontend (ESLint + Prettier)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: smart_vent/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: smart_vent/frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check

--- a/smart_vent/frontend/.prettierrc
+++ b/smart_vent/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/smart_vent/frontend/eslint.config.js
+++ b/smart_vent/frontend/eslint.config.js
@@ -1,0 +1,25 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import prettierConfig from "eslint-config-prettier";
+
+export default tseslint.config(
+  { ignores: ["dist"] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+    },
+  },
+  prettierConfig,
+);

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -13,10 +13,17 @@
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
+        "@eslint/js": "^9.0.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-react-refresh": "^0.4.0",
+        "prettier": "^3.3.0",
         "typescript": "^5.5.3",
+        "typescript-eslint": "^8.0.0",
         "vite": "^5.4.2"
       }
     },
@@ -693,6 +700,202 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -851,9 +1054,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -868,9 +1068,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -885,9 +1082,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -902,9 +1096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -919,9 +1110,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,9 +1124,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -953,9 +1138,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +1152,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,9 +1166,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,9 +1180,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,9 +1194,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,9 +1208,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1055,9 +1222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,6 +1364,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1228,6 +1399,301 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1249,6 +1715,76 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
@@ -1260,6 +1796,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -1296,6 +1843,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -1317,12 +1874,71 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1348,6 +1964,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.334",
@@ -1405,6 +2028,299 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1430,11 +2346,127 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1449,6 +2481,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1461,6 +2514,53 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1482,6 +2582,19 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1510,6 +2623,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -1517,12 +2637,108 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.9",
@@ -1551,6 +2767,42 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1620,6 +2872,16 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -1684,6 +2946,29 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1692,6 +2977,75 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {
@@ -1706,6 +3060,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1737,6 +3115,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -1799,12 +3187,51 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/smart_vent/frontend/package.json
+++ b/smart_vent/frontend/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -14,10 +18,17 @@
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.0",
+    "prettier": "^3.3.0",
     "typescript": "^5.5.3",
+    "typescript-eslint": "^8.0.0",
     "vite": "^5.4.2"
   }
 }

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -17,9 +17,21 @@ export interface Room {
   schedules?: Schedule[];
 }
 
-export interface RoomSensor { id: string; room_id: string; entity_id: string; }
-export interface RoomVent { id: string; room_id: string; entity_id: string; }
-export interface RoomPresenceSensor { id: string; room_id: string; entity_id: string; }
+export interface RoomSensor {
+  id: string;
+  room_id: string;
+  entity_id: string;
+}
+export interface RoomVent {
+  id: string;
+  room_id: string;
+  entity_id: string;
+}
+export interface RoomPresenceSensor {
+  id: string;
+  room_id: string;
+  entity_id: string;
+}
 
 export interface Schedule {
   id: string;
@@ -138,7 +150,8 @@ export const deleteRoom = (id: string) =>
 // Sensors
 export const addSensor = (room_id: string, entity_id: string) =>
   api<RoomSensor>(`/api/rooms/${room_id}/sensors`, {
-    method: "POST", body: JSON.stringify({ entity_id }),
+    method: "POST",
+    body: JSON.stringify({ entity_id }),
   });
 export const removeSensor = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/sensors/${entity_id}`, { method: "DELETE" });
@@ -146,7 +159,8 @@ export const removeSensor = (room_id: string, entity_id: string) =>
 // Vents
 export const addVent = (room_id: string, entity_id: string) =>
   api<RoomVent>(`/api/rooms/${room_id}/vents`, {
-    method: "POST", body: JSON.stringify({ entity_id }),
+    method: "POST",
+    body: JSON.stringify({ entity_id }),
   });
 export const removeVent = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/vents/${entity_id}`, { method: "DELETE" });
@@ -154,7 +168,8 @@ export const removeVent = (room_id: string, entity_id: string) =>
 // Presence sensors
 export const addPresence = (room_id: string, entity_id: string) =>
   api<RoomPresenceSensor>(`/api/rooms/${room_id}/presence`, {
-    method: "POST", body: JSON.stringify({ entity_id }),
+    method: "POST",
+    body: JSON.stringify({ entity_id }),
   });
 export const removePresence = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/presence/${entity_id}`, { method: "DELETE" });
@@ -162,7 +177,8 @@ export const removePresence = (room_id: string, entity_id: string) =>
 // Overrides
 export const setOverride = (room_id: string, target_temp: number, duration_hours = 2) =>
   api<unknown>(`/api/rooms/${room_id}/override`, {
-    method: "POST", body: JSON.stringify({ target_temp, duration_hours }),
+    method: "POST",
+    body: JSON.stringify({ target_temp, duration_hours }),
   });
 export const clearOverride = (room_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/override`, { method: "DELETE" });
@@ -171,15 +187,16 @@ export const clearOverride = (room_id: string) =>
 // Schedules
 // ---------------------------------------------------------------------------
 
-export const getSchedules = (room_id: string) =>
-  api<Schedule[]>(`/api/rooms/${room_id}/schedules`);
+export const getSchedules = (room_id: string) => api<Schedule[]>(`/api/rooms/${room_id}/schedules`);
 export const createSchedule = (room_id: string, data: Omit<Schedule, "id" | "room_id">) =>
   api<Schedule>(`/api/rooms/${room_id}/schedules`, {
-    method: "POST", body: JSON.stringify(data),
+    method: "POST",
+    body: JSON.stringify(data),
   });
 export const updateSchedule = (room_id: string, schedule_id: string, data: Partial<Schedule>) =>
   api<Schedule>(`/api/rooms/${room_id}/schedules/${schedule_id}`, {
-    method: "PUT", body: JSON.stringify(data),
+    method: "PUT",
+    body: JSON.stringify(data),
   });
 export const deleteSchedule = (room_id: string, schedule_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/schedules/${schedule_id}`, { method: "DELETE" });
@@ -189,11 +206,13 @@ export const deleteSchedule = (room_id: string, schedule_id: string) =>
 // ---------------------------------------------------------------------------
 
 export const getThermostats = () => api<ThermostatConfig[]>("/api/thermostats");
-export const createThermostat = (data: { thermostat_entity_id: string } & Partial<ThermostatConfig>) =>
-  api<ThermostatConfig>("/api/thermostats", { method: "POST", body: JSON.stringify(data) });
+export const createThermostat = (
+  data: { thermostat_entity_id: string } & Partial<ThermostatConfig>
+) => api<ThermostatConfig>("/api/thermostats", { method: "POST", body: JSON.stringify(data) });
 export const updateThermostat = (entity_id: string, data: Partial<ThermostatConfig>) =>
   api<ThermostatConfig>(`/api/thermostats/${entity_id}`, {
-    method: "PUT", body: JSON.stringify(data),
+    method: "PUT",
+    body: JSON.stringify(data),
   });
 export const deleteThermostat = (entity_id: string) =>
   api<{ deleted: string }>(`/api/thermostats/${entity_id}`, { method: "DELETE" });
@@ -248,12 +267,12 @@ export const getEventLogs = (params: EventLogParams = {}) => {
 export const clearEventLogs = () =>
   api<{ cleared: boolean }>("/api/logs/events", { method: "DELETE" });
 
-export const getLogRetention = () =>
-  api<LogRetentionSettings>("/api/settings/log-retention");
+export const getLogRetention = () => api<LogRetentionSettings>("/api/settings/log-retention");
 
 export const setLogRetention = (data: Partial<LogRetentionSettings>) =>
   api<LogRetentionSettings>("/api/settings/log-retention", {
-    method: "POST", body: JSON.stringify(data),
+    method: "POST",
+    body: JSON.stringify(data),
   });
 
 export const getSystemStatus = () => api<SystemStatus>("/api/system/status");
@@ -261,7 +280,10 @@ export const setSystemEnabled = (enabled: boolean) =>
   api<SystemStatus>("/api/system/enabled", { method: "POST", body: JSON.stringify({ enabled }) });
 export const getDevMode = () => api<{ dev_mode: boolean }>("/api/system/dev-mode");
 export const setDevModeApi = (dev_mode: boolean) =>
-  api<{ dev_mode: boolean }>("/api/system/dev-mode", { method: "POST", body: JSON.stringify({ dev_mode }) });
+  api<{ dev_mode: boolean }>("/api/system/dev-mode", {
+    method: "POST",
+    body: JSON.stringify({ dev_mode }),
+  });
 export const getDevLogs = (limit = 200) =>
   api<EventLogEntry[]>(`/api/logs/events?limit=${limit}&category=dev`);
 

--- a/smart_vent/frontend/src/components/EntityPicker.tsx
+++ b/smart_vent/frontend/src/components/EntityPicker.tsx
@@ -9,20 +9,31 @@ interface Props {
   onSelect: (entityId: string) => void;
 }
 
-export default function EntityPicker({ domain, placeholder, hasAttribute, excludeIcon, onSelect }: Props) {
+export default function EntityPicker({
+  domain,
+  placeholder,
+  hasAttribute,
+  excludeIcon,
+  onSelect,
+}: Props) {
   const [query, setQuery] = useState("");
   const [entities, setEntities] = useState<HAEntity[]>([]);
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    getHAEntities(domain, { hasAttribute, excludeIcon }).then(setEntities).catch(() => {});
+    getHAEntities(domain, { hasAttribute, excludeIcon })
+      .then(setEntities)
+      .catch(() => {});
   }, [domain, hasAttribute, excludeIcon]);
 
-  const filtered = entities.filter(e =>
-    e.entity_id.toLowerCase().includes(query.toLowerCase()) ||
-    e.friendly_name.toLowerCase().includes(query.toLowerCase())
-  ).slice(0, 30);
+  const filtered = entities
+    .filter(
+      (e) =>
+        e.entity_id.toLowerCase().includes(query.toLowerCase()) ||
+        e.friendly_name.toLowerCase().includes(query.toLowerCase())
+    )
+    .slice(0, 30);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -38,12 +49,15 @@ export default function EntityPicker({ domain, placeholder, hasAttribute, exclud
         className="form-control"
         placeholder={placeholder ?? `Search ${domain} entities…`}
         value={query}
-        onChange={e => { setQuery(e.target.value); setOpen(true); }}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
         onFocus={() => setOpen(true)}
       />
       {open && filtered.length > 0 && (
         <div className="entity-dropdown">
-          {filtered.map(e => (
+          {filtered.map((e) => (
             <div
               key={e.entity_id}
               className="entity-option"

--- a/smart_vent/frontend/src/main.tsx
+++ b/smart_vent/frontend/src/main.tsx
@@ -54,10 +54,12 @@ function AppRoot({ children }: { children: React.ReactNode }) {
 
   // Seed from API on mount
   useEffect(() => {
-    getSystemStatus().then(s => {
-      setEnabled(s.enabled);
-      setDevMode(s.dev_mode ?? false);
-    }).catch(() => {});
+    getSystemStatus()
+      .then((s) => {
+        setEnabled(s.enabled);
+        setDevMode(s.dev_mode ?? false);
+      })
+      .catch(() => {});
   }, []);
 
   // Subscribe to real-time updates
@@ -132,7 +134,11 @@ function DevModeToggle() {
     <button
       className={`dev-mode-toggle ${devMode ? "active" : ""}`}
       onClick={toggleDevMode}
-      title={devMode ? "Developer mode ON — engine runs but no HA changes. Click to disable." : "Click to enable developer mode"}
+      title={
+        devMode
+          ? "Developer mode ON — engine runs but no HA changes. Click to disable."
+          : "Click to enable developer mode"
+      }
     >
       🛠 {devMode ? "Dev On" : "Dev Off"}
     </button>
@@ -150,20 +156,40 @@ function Nav() {
       <NavLink to="/" end className="nav-brand" style={{ textDecoration: "none" }}>
         <span className="nav-icon">🌡</span>
         Flair Replacement
-        <span style={{ fontSize: ".65rem", opacity: 0.45, marginLeft: ".4rem", fontWeight: 400, letterSpacing: 0 }}>
+        <span
+          style={{
+            fontSize: ".65rem",
+            opacity: 0.45,
+            marginLeft: ".4rem",
+            fontWeight: 400,
+            letterSpacing: 0,
+          }}
+        >
           v{import.meta.env.VITE_APP_VERSION ?? "dev"}
         </span>
       </NavLink>
 
       {/* Desktop links */}
       <div className="nav-links nav-links-desktop">
-        <NavLink to="/" end onClick={close}>Dashboard</NavLink>
-        <NavLink to="/rooms" onClick={close}>Rooms</NavLink>
-        <NavLink to="/schedules" onClick={close}>Schedules</NavLink>
-        <NavLink to="/thermostats" onClick={close}>Thermostats</NavLink>
-        <NavLink to="/logs" onClick={close}>Logs</NavLink>
+        <NavLink to="/" end onClick={close}>
+          Dashboard
+        </NavLink>
+        <NavLink to="/rooms" onClick={close}>
+          Rooms
+        </NavLink>
+        <NavLink to="/schedules" onClick={close}>
+          Schedules
+        </NavLink>
+        <NavLink to="/thermostats" onClick={close}>
+          Thermostats
+        </NavLink>
+        <NavLink to="/logs" onClick={close}>
+          Logs
+        </NavLink>
         {devMode && (
-          <NavLink to="/dev" onClick={close} className="nav-dev-link">🛠 Dev Mode</NavLink>
+          <NavLink to="/dev" onClick={close} className="nav-dev-link">
+            🛠 Dev Mode
+          </NavLink>
         )}
       </div>
 
@@ -173,7 +199,7 @@ function Nav() {
         {/* Hamburger — mobile only */}
         <button
           className="nav-hamburger"
-          onClick={() => setOpen(o => !o)}
+          onClick={() => setOpen((o) => !o)}
           aria-label="Toggle menu"
         >
           <span className={`hamburger-icon ${open ? "open" : ""}`} />
@@ -183,12 +209,26 @@ function Nav() {
       {/* Mobile dropdown */}
       {open && (
         <div className="nav-mobile-menu">
-          <NavLink to="/" end onClick={close}>Dashboard</NavLink>
-          <NavLink to="/rooms" onClick={close}>Rooms</NavLink>
-          <NavLink to="/schedules" onClick={close}>Schedules</NavLink>
-          <NavLink to="/thermostats" onClick={close}>Thermostats</NavLink>
-          <NavLink to="/logs" onClick={close}>Logs</NavLink>
-          {devMode && <NavLink to="/dev" onClick={close}>🛠 Dev Mode</NavLink>}
+          <NavLink to="/" end onClick={close}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/rooms" onClick={close}>
+            Rooms
+          </NavLink>
+          <NavLink to="/schedules" onClick={close}>
+            Schedules
+          </NavLink>
+          <NavLink to="/thermostats" onClick={close}>
+            Thermostats
+          </NavLink>
+          <NavLink to="/logs" onClick={close}>
+            Logs
+          </NavLink>
+          {devMode && (
+            <NavLink to="/dev" onClick={close}>
+              🛠 Dev Mode
+            </NavLink>
+          )}
         </div>
       )}
     </nav>

--- a/smart_vent/frontend/src/pages/Dashboard.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
-import { getStatus, getRooms, getThermostats, connectWS, type ZoneStatus, type Room, type ThermostatConfig } from "../api";
-
-const DAY_LABELS = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"];
+import {
+  getStatus,
+  getRooms,
+  getThermostats,
+  connectWS,
+  type ZoneStatus,
+  type Room,
+  type ThermostatConfig,
+} from "../api";
 
 function modeColor(mode: string): string {
   if (mode === "cooling") return "blue";
@@ -18,16 +24,23 @@ function modeLabel(action: string, state: string): string {
 }
 
 function RoomRow({ r, rooms }: { r: ZoneStatus["rooms"][number]; rooms: Room[] }) {
-  const room = rooms.find(x => x.id === r.room_id);
+  const room = rooms.find((x) => x.id === r.room_id);
   const ventEntries = Object.entries(r.vent_states);
   const openCount = ventEntries.filter(([, s]) => s === "open").length;
 
   return (
-    <div className="stat-row" style={{ flexDirection: "column", alignItems: "flex-start", gap: ".4rem" }}>
+    <div
+      className="stat-row"
+      style={{ flexDirection: "column", alignItems: "flex-start", gap: ".4rem" }}
+    >
       <div className="flex-between" style={{ width: "100%" }}>
         <span className="stat-label" style={{ fontWeight: 600, color: "var(--gray-900)" }}>
           {room?.name ?? r.room_id}
-          {r.presence_active && <span className="badge badge-green" style={{ marginLeft: ".5rem" }}>Presence</span>}
+          {r.presence_active && (
+            <span className="badge badge-green" style={{ marginLeft: ".5rem" }}>
+              Presence
+            </span>
+          )}
         </span>
         <span className="stat-value">
           {r.avg_temp != null ? `${r.avg_temp.toFixed(1)}°F` : "—"}
@@ -41,22 +54,32 @@ function RoomRow({ r, rooms }: { r: ZoneStatus["rooms"][number]; rooms: Room[] }
               {eid.split(".").pop()} · {state}
             </span>
           ))}
-          <span className="text-sm text-muted">{openCount}/{ventEntries.length} open</span>
+          <span className="text-sm text-muted">
+            {openCount}/{ventEntries.length} open
+          </span>
         </div>
       )}
     </div>
   );
 }
 
-function ZoneCard({ zone, rooms, thermostats }: { zone: ZoneStatus; rooms: Room[]; thermostats: ThermostatConfig[] }) {
+function ZoneCard({
+  zone,
+  rooms,
+  thermostats,
+}: {
+  zone: ZoneStatus;
+  rooms: Room[];
+  thermostats: ThermostatConfig[];
+}) {
   const colorClass = modeColor(zone.hvac_action);
   const label = modeLabel(zone.hvac_action, zone.hvac_mode);
   const badgeClass = `badge badge-${colorClass}`;
-  const zoneRooms = rooms.filter(r => r.thermostat_entity_id === zone.thermostat_entity_id);
+  const zoneRooms = rooms.filter((r) => r.thermostat_entity_id === zone.thermostat_entity_id);
   const totalRooms = zoneRooms.length;
   const activeRooms = zone.rooms.length;
-  const doneRooms = zone.rooms.filter(r =>
-    Object.values(r.vent_states).every(s => s === "closed")
+  const doneRooms = zone.rooms.filter((r) =>
+    Object.values(r.vent_states).every((s) => s === "closed")
   ).length;
   const progress = activeRooms > 0 ? doneRooms / activeRooms : 0;
 
@@ -65,8 +88,8 @@ function ZoneCard({ zone, rooms, thermostats }: { zone: ZoneStatus; rooms: Room[
       <div className="flex-between" style={{ marginBottom: ".75rem" }}>
         <div>
           <div className="card-title" style={{ marginBottom: 0 }}>
-            {thermostats.find(t => t.thermostat_entity_id === zone.thermostat_entity_id)?.name
-              || zone.thermostat_entity_id.split(".").pop()?.replace(/_/g, " ")}
+            {thermostats.find((t) => t.thermostat_entity_id === zone.thermostat_entity_id)?.name ||
+              zone.thermostat_entity_id.split(".").pop()?.replace(/_/g, " ")}
           </div>
           <div className="card-subtitle font-mono" style={{ marginBottom: 0, fontSize: ".75rem" }}>
             {zone.thermostat_entity_id}
@@ -95,7 +118,9 @@ function ZoneCard({ zone, rooms, thermostats }: { zone: ZoneStatus; rooms: Room[
       </div>
       <div className="stat-row">
         <span className="stat-label">Active rooms</span>
-        <span className="stat-value">{activeRooms} / {totalRooms}</span>
+        <span className="stat-value">
+          {activeRooms} / {totalRooms}
+        </span>
       </div>
 
       {zone.cycle_state === "running" && activeRooms > 0 && (
@@ -114,10 +139,15 @@ function ZoneCard({ zone, rooms, thermostats }: { zone: ZoneStatus; rooms: Room[
 
       {zone.rooms.length > 0 && (
         <div style={{ marginTop: "1rem" }}>
-          <div className="text-sm" style={{ fontWeight: 600, marginBottom: ".5rem", color: "var(--gray-700)" }}>
+          <div
+            className="text-sm"
+            style={{ fontWeight: 600, marginBottom: ".5rem", color: "var(--gray-700)" }}
+          >
             Active rooms
           </div>
-          {zone.rooms.map(r => <RoomRow key={r.room_id} r={r} rooms={rooms} />)}
+          {zone.rooms.map((r) => (
+            <RoomRow key={r.room_id} r={r} rooms={rooms} />
+          ))}
         </div>
       )}
     </div>
@@ -148,10 +178,18 @@ export default function Dashboard() {
       }
     });
     const interval = setInterval(load, 30000);
-    return () => { cancel(); clearInterval(interval); };
+    return () => {
+      cancel();
+      clearInterval(interval);
+    };
   }, []);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading dashboard…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading dashboard…
+      </div>
+    );
 
   return (
     <div>
@@ -163,19 +201,30 @@ export default function Dashboard() {
             {lastUpdate && ` · Updated ${lastUpdate.toLocaleTimeString()}`}
           </div>
         </div>
-        <button className="btn btn-secondary" onClick={load}>↻ Refresh</button>
+        <button className="btn btn-secondary" onClick={load}>
+          ↻ Refresh
+        </button>
       </div>
 
       {zones.length === 0 ? (
         <div className="card">
           <div className="empty-state">
             <p>No thermostat zones configured yet.</p>
-            <p style={{ marginTop: ".5rem" }}>Go to <strong>Rooms</strong> to add your first room.</p>
+            <p style={{ marginTop: ".5rem" }}>
+              Go to <strong>Rooms</strong> to add your first room.
+            </p>
           </div>
         </div>
       ) : (
         <div className="card-grid">
-          {zones.map(z => <ZoneCard key={z.thermostat_entity_id} zone={z} rooms={rooms} thermostats={thermostats} />)}
+          {zones.map((z) => (
+            <ZoneCard
+              key={z.thermostat_entity_id}
+              zone={z}
+              rooms={rooms}
+              thermostats={thermostats}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/smart_vent/frontend/src/pages/DevMode.tsx
+++ b/smart_vent/frontend/src/pages/DevMode.tsx
@@ -52,7 +52,8 @@ function ActionFeed({ entries }: { entries: EventLogEntry[] }) {
       <div className="dev-feed-empty">
         <p>No dev actions logged yet.</p>
         <p style={{ marginTop: ".5rem", color: "var(--gray-400)" }}>
-          The engine is running — actions will appear here as schedules/presence trigger cycle events.
+          The engine is running — actions will appear here as schedules/presence trigger cycle
+          events.
         </p>
       </div>
     );
@@ -60,7 +61,7 @@ function ActionFeed({ entries }: { entries: EventLogEntry[] }) {
 
   return (
     <div className="dev-feed">
-      {entries.map(e => (
+      {entries.map((e) => (
         <div key={e.id} className="dev-feed-row">
           <span className="dev-feed-time">{fmtTime(e.timestamp)}</span>
           <span className="dev-feed-icon" style={{ color: actionColor(e.details) }}>
@@ -90,11 +91,14 @@ function ZonePanel({ zones }: { zones: ZoneStatus[] }) {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-      {zones.map(zone => (
+      {zones.map((zone) => (
         <div key={zone.thermostat_entity_id} className="card">
           <div className="card-title">
             {zone.thermostat_entity_id}
-            <span className="badge badge-gray" style={{ marginLeft: ".5rem", textTransform: "capitalize" }}>
+            <span
+              className="badge badge-gray"
+              style={{ marginLeft: ".5rem", textTransform: "capitalize" }}
+            >
               {zone.cycle_state}
             </span>
             <span className="badge badge-blue" style={{ marginLeft: ".35rem" }}>
@@ -118,16 +122,31 @@ function ZonePanel({ zones }: { zones: ZoneStatus[] }) {
                   </tr>
                 </thead>
                 <tbody>
-                  {zone.rooms.map(r => (
+                  {zone.rooms.map((r) => (
                     <tr key={r.room_id}>
-                      <td className="font-mono" style={{ fontSize: ".78rem" }}>{r.room_id.slice(0, 8)}</td>
+                      <td className="font-mono" style={{ fontSize: ".78rem" }}>
+                        {r.room_id.slice(0, 8)}
+                      </td>
                       <td>{r.avg_temp != null ? `${r.avg_temp}°F` : "—"}</td>
-                      <td>{r.presence_active ? <span style={{ color: "var(--green)" }}>●</span> : <span style={{ color: "var(--gray-400)" }}>○</span>}</td>
+                      <td>
+                        {r.presence_active ? (
+                          <span style={{ color: "var(--green)" }}>●</span>
+                        ) : (
+                          <span style={{ color: "var(--gray-400)" }}>○</span>
+                        )}
+                      </td>
                       <td>
                         {Object.entries(r.vent_states).map(([eid, state]) => (
-                          <span key={eid} className="room-vent-pill" title={eid}
-                            style={{ background: state === "open" ? "var(--green-light)" : "var(--gray-200)",
-                                     color: state === "open" ? "#15803d" : "var(--gray-700)" }}>
+                          <span
+                            key={eid}
+                            className="room-vent-pill"
+                            title={eid}
+                            style={{
+                              background:
+                                state === "open" ? "var(--green-light)" : "var(--gray-200)",
+                              color: state === "open" ? "#15803d" : "var(--gray-700)",
+                            }}
+                          >
                             {state}
                           </span>
                         ))}
@@ -152,27 +171,33 @@ export default function DevModePage() {
   const [entries, setEntries] = useState<EventLogEntry[]>([]);
   const [zones, setZones] = useState<ZoneStatus[]>([]);
   const [loading, setLoading] = useState(true);
-  const [autoScroll, setAutoScroll] = useState(true);
 
   const fetchLogs = async () => {
     try {
       const logs = await getDevLogs(500);
       setEntries(logs.slice().reverse()); // oldest first for the feed
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   };
 
   const fetchZones = async () => {
     try {
       const z = await getStatus();
       setZones(z);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   };
 
   useEffect(() => {
     Promise.all([fetchLogs(), fetchZones()]).finally(() => setLoading(false));
     const logsInterval = setInterval(fetchLogs, 3000);
     const zonesInterval = setInterval(fetchZones, 5000);
-    return () => { clearInterval(logsInterval); clearInterval(zonesInterval); };
+    return () => {
+      clearInterval(logsInterval);
+      clearInterval(zonesInterval);
+    };
   }, []);
 
   if (!devMode) {
@@ -181,31 +206,48 @@ export default function DevModePage() {
         <div className="page-header">
           <div>
             <div className="page-title">Developer Mode</div>
-            <div className="page-subtitle">Engine runs, but no changes are sent to Home Assistant</div>
+            <div className="page-subtitle">
+              Engine runs, but no changes are sent to Home Assistant
+            </div>
           </div>
         </div>
         <div className="card" style={{ textAlign: "center", padding: "3rem 2rem" }}>
           <div style={{ fontSize: "3rem", marginBottom: "1rem" }}>🛠</div>
-          <p style={{ fontWeight: 600, fontSize: "1.1rem", marginBottom: ".75rem" }}>Developer mode is off</p>
-          <p className="text-muted" style={{ marginBottom: "1.5rem" }}>
-            Enable it to run the cycle engine without making any real changes to thermostats or vents.
-            All actions are logged here instead.
+          <p style={{ fontWeight: 600, fontSize: "1.1rem", marginBottom: ".75rem" }}>
+            Developer mode is off
           </p>
-          <button className="btn btn-primary" onClick={toggleDevMode}>Enable Developer Mode</button>
+          <p className="text-muted" style={{ marginBottom: "1.5rem" }}>
+            Enable it to run the cycle engine without making any real changes to thermostats or
+            vents. All actions are logged here instead.
+          </p>
+          <button className="btn btn-primary" onClick={toggleDevMode}>
+            Enable Developer Mode
+          </button>
         </div>
       </div>
     );
   }
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading…
+      </div>
+    );
 
   return (
     <div>
       <div className="page-header">
         <div>
-          <div className="page-title" style={{ display: "flex", alignItems: "center", gap: ".75rem" }}>
+          <div
+            className="page-title"
+            style={{ display: "flex", alignItems: "center", gap: ".75rem" }}
+          >
             🛠 Developer Mode
-            <span className="badge" style={{ background: "#fef3c7", color: "#92400e", fontSize: ".75rem" }}>
+            <span
+              className="badge"
+              style={{ background: "#fef3c7", color: "#92400e", fontSize: ".75rem" }}
+            >
               ACTIVE — no HA changes
             </span>
           </div>
@@ -213,7 +255,9 @@ export default function DevModePage() {
             Engine is running. All thermostat and vent actions are intercepted and logged below.
           </div>
         </div>
-        <button className="btn btn-secondary" onClick={toggleDevMode}>Disable Dev Mode</button>
+        <button className="btn btn-secondary" onClick={toggleDevMode}>
+          Disable Dev Mode
+        </button>
       </div>
 
       <div className="dev-layout">
@@ -221,8 +265,12 @@ export default function DevModePage() {
         <div className="dev-feed-panel">
           <div className="dev-panel-header">
             <span style={{ fontWeight: 600 }}>Action Log</span>
-            <span className="text-muted text-sm">auto-refreshes every 3s · {entries.length} entries</span>
-            <button className="btn btn-secondary btn-sm" onClick={() => setEntries([])}>Clear</button>
+            <span className="text-muted text-sm">
+              auto-refreshes every 3s · {entries.length} entries
+            </span>
+            <button className="btn btn-secondary btn-sm" onClick={() => setEntries([])}>
+              Clear
+            </button>
           </div>
           <ActionFeed entries={entries} />
         </div>

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  getLogs, getEventLogs, clearEventLogs, getLogRetention, setLogRetention,
+  getLogs,
+  getEventLogs,
+  clearEventLogs,
+  getLogRetention,
+  setLogRetention,
   connectWS,
-  type CycleLog, type EventLogEntry, type LogRetentionSettings,
+  type CycleLog,
+  type EventLogEntry,
+  type LogRetentionSettings,
 } from "../api";
 
 // ---------------------------------------------------------------------------
@@ -12,10 +18,10 @@ import {
 type TimePreset = "1h" | "6h" | "24h" | "7d" | "custom";
 
 const PRESETS: { label: string; value: TimePreset }[] = [
-  { label: "1h",  value: "1h"  },
-  { label: "6h",  value: "6h"  },
+  { label: "1h", value: "1h" },
+  { label: "6h", value: "6h" },
   { label: "24h", value: "24h" },
-  { label: "7d",  value: "7d"  },
+  { label: "7d", value: "7d" },
   { label: "Custom", value: "custom" },
 ];
 
@@ -45,13 +51,17 @@ function ConfirmModal({
   onCancel: () => void;
 }) {
   return (
-    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onCancel()}>
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onCancel()}>
       <div className="modal" style={{ maxWidth: 440 }}>
         <div className="modal-title">{title}</div>
         <p style={{ color: "var(--gray-700)", marginBottom: "1.5rem" }}>{message}</p>
         <div className="modal-footer">
-          <button className="btn btn-secondary" onClick={onCancel}>Cancel</button>
-          <button className="btn btn-danger" onClick={onConfirm}>{confirmLabel}</button>
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-danger" onClick={onConfirm}>
+            {confirmLabel}
+          </button>
         </div>
       </div>
     </div>
@@ -79,8 +89,10 @@ function TimeWindowControls({
 }) {
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: ".4rem", alignItems: "center" }}>
-      <span className="text-sm text-muted" style={{ marginRight: ".25rem" }}>Window:</span>
-      {PRESETS.map(p => (
+      <span className="text-sm text-muted" style={{ marginRight: ".25rem" }}>
+        Window:
+      </span>
+      {PRESETS.map((p) => (
         <button
           key={p.value}
           className={`btn btn-sm ${preset === p.value ? "btn-primary" : "btn-secondary"}`}
@@ -96,7 +108,7 @@ function TimeWindowControls({
             className="form-control form-control-sm"
             style={{ width: "auto" }}
             value={customFrom}
-            onChange={e => onCustomFrom(e.target.value)}
+            onChange={(e) => onCustomFrom(e.target.value)}
           />
           <span className="text-sm text-muted">to</span>
           <input
@@ -104,7 +116,7 @@ function TimeWindowControls({
             className="form-control form-control-sm"
             style={{ width: "auto" }}
             value={customTo}
-            onChange={e => onCustomTo(e.target.value)}
+            onChange={(e) => onCustomTo(e.target.value)}
           />
         </>
       )}
@@ -130,14 +142,26 @@ function LogRow({ log }: { log: CycleLog }) {
 
   return (
     <>
-      <tr style={{ cursor: "pointer" }} onClick={() => setExpanded(e => !e)}>
-        <td className="font-mono" style={{ fontSize: ".75rem" }}>{log.id.slice(0, 8)}…</td>
-        <td className="font-mono" style={{ fontSize: ".8rem" }}>{log.thermostat_entity_id}</td>
+      <tr style={{ cursor: "pointer" }} onClick={() => setExpanded((e) => !e)}>
+        <td className="font-mono" style={{ fontSize: ".75rem" }}>
+          {log.id.slice(0, 8)}…
+        </td>
+        <td className="font-mono" style={{ fontSize: ".8rem" }}>
+          {log.thermostat_entity_id}
+        </td>
         <td>
-          <span className={`badge badge-${log.mode === "cooling" ? "blue" : "orange"}`}>{log.mode}</span>
+          <span className={`badge badge-${log.mode === "cooling" ? "blue" : "orange"}`}>
+            {log.mode}
+          </span>
         </td>
         <td>{new Date(log.started_at + "Z").toLocaleString()}</td>
-        <td>{log.ended_at ? new Date(log.ended_at + "Z").toLocaleString() : <span className="badge badge-green">Active</span>}</td>
+        <td>
+          {log.ended_at ? (
+            new Date(log.ended_at + "Z").toLocaleString()
+          ) : (
+            <span className="badge badge-green">Active</span>
+          )}
+        </td>
         <td>{duration(log.started_at, log.ended_at)}</td>
         <td>{rooms.length}</td>
         <td>{expanded ? "▲" : "▼"}</td>
@@ -145,7 +169,13 @@ function LogRow({ log }: { log: CycleLog }) {
       {expanded && (
         <tr>
           <td colSpan={8} style={{ background: "var(--gray-50)", padding: ".75rem 1rem" }}>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: ".5rem" }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+                gap: ".5rem",
+              }}
+            >
               {rooms.map((r, i) => (
                 <div key={i} className="card" style={{ padding: ".75rem" }}>
                   <div style={{ fontWeight: 600, marginBottom: ".25rem" }}>{r.name}</div>
@@ -174,7 +204,12 @@ function CycleHistory() {
   const [customTo, setCustomTo] = useState("");
 
   const buildParams = (currentOffset: number) => {
-    const since = preset !== "custom" ? presetToSince(preset) : (customFrom ? new Date(customFrom).toISOString() : undefined);
+    const since =
+      preset !== "custom"
+        ? presetToSince(preset)
+        : customFrom
+          ? new Date(customFrom).toISOString()
+          : undefined;
     const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
     return { limit: PAGE_SIZE, offset: currentOffset, since, until };
   };
@@ -187,49 +222,83 @@ function CycleHistory() {
       setLogs(rows);
       setOffset(rows.length);
     } else {
-      setLogs(prev => [...prev, ...rows]);
-      setOffset(prev => prev + rows.length);
+      setLogs((prev) => [...prev, ...rows]);
+      setOffset((prev) => prev + rows.length);
     }
     setHasMore(rows.length === PAGE_SIZE);
     setLoading(false);
   };
 
-  useEffect(() => { load(true); }, [preset, customFrom, customTo]);
+  useEffect(() => {
+    load(true);
+  }, [preset, customFrom, customTo]);
 
   return (
     <div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: "1rem", alignItems: "center" }}>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: ".5rem",
+          marginBottom: "1rem",
+          alignItems: "center",
+        }}
+      >
         <TimeWindowControls
-          preset={preset} customFrom={customFrom} customTo={customTo}
-          onPreset={p => { setPreset(p); }}
+          preset={preset}
+          customFrom={customFrom}
+          customTo={customTo}
+          onPreset={(p) => {
+            setPreset(p);
+          }}
           onCustomFrom={setCustomFrom}
           onCustomTo={setCustomTo}
         />
-        <button className="btn btn-secondary btn-sm" onClick={() => load(true)}>↻ Refresh</button>
+        <button className="btn btn-secondary btn-sm" onClick={() => load(true)}>
+          ↻ Refresh
+        </button>
       </div>
 
       {loading && logs.length === 0 ? (
-        <div className="loading"><div className="spinner" /> Loading logs…</div>
+        <div className="loading">
+          <div className="spinner" /> Loading logs…
+        </div>
       ) : logs.length === 0 ? (
-        <div className="card"><div className="empty-state"><p>No cycle logs in this time window.</p></div></div>
+        <div className="card">
+          <div className="empty-state">
+            <p>No cycle logs in this time window.</p>
+          </div>
+        </div>
       ) : (
         <div className="card">
           <div className="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th>ID</th><th>Thermostat</th><th>Mode</th>
-                  <th>Started</th><th>Ended</th><th>Duration</th><th>Rooms</th><th></th>
+                  <th>ID</th>
+                  <th>Thermostat</th>
+                  <th>Mode</th>
+                  <th>Started</th>
+                  <th>Ended</th>
+                  <th>Duration</th>
+                  <th>Rooms</th>
+                  <th></th>
                 </tr>
               </thead>
               <tbody>
-                {logs.map(l => <LogRow key={l.id} log={l} />)}
+                {logs.map((l) => (
+                  <LogRow key={l.id} log={l} />
+                ))}
               </tbody>
             </table>
           </div>
           {hasMore && (
             <div style={{ padding: ".75rem 1rem", borderTop: "1px solid var(--gray-200)" }}>
-              <button className="btn btn-secondary btn-sm" onClick={() => load(false)} disabled={loading}>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={() => load(false)}
+                disabled={loading}
+              >
                 {loading ? "Loading…" : "Load more"}
               </button>
             </div>
@@ -261,11 +330,13 @@ function EventEntry({ entry }: { entry: EventLogEntry }) {
   return (
     <div
       className="event-entry"
-      onClick={() => entry.details && setExpanded(e => !e)}
+      onClick={() => entry.details && setExpanded((e) => !e)}
       style={{ cursor: entry.details ? "pointer" : "default" }}
     >
       <span className="event-ts">{ts}</span>
-      <span className="event-level" style={{ color }}>{entry.level.toUpperCase()}</span>
+      <span className="event-level" style={{ color }}>
+        {entry.level.toUpperCase()}
+      </span>
       <span className="event-category">[{entry.category}]</span>
       <span className="event-msg">{entry.message}</span>
       {entry.details && <span className="event-expand">{expanded ? "▲" : "▼"}</span>}
@@ -296,7 +367,12 @@ function LiveFeed() {
   pausedRef.current = paused;
 
   const buildParams = (currentOffset: number) => {
-    const since = preset !== "custom" ? presetToSince(preset) : (customFrom ? new Date(customFrom).toISOString() : undefined);
+    const since =
+      preset !== "custom"
+        ? presetToSince(preset)
+        : customFrom
+          ? new Date(customFrom).toISOString()
+          : undefined;
     const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
     return {
       limit: PAGE_SIZE,
@@ -319,14 +395,16 @@ function LiveFeed() {
       setOffset(rows.length);
     } else {
       // Load more appends older entries at the top
-      setEntries(prev => [...ordered, ...prev]);
-      setOffset(prev => prev + rows.length);
+      setEntries((prev) => [...ordered, ...prev]);
+      setOffset((prev) => prev + rows.length);
     }
     setHasMore(rows.length === PAGE_SIZE);
     setLoading(false);
   };
 
-  useEffect(() => { load(true); }, [category, levels, preset, customFrom, customTo]);
+  useEffect(() => {
+    load(true);
+  }, [category, levels, preset, customFrom, customTo]);
 
   // WebSocket: append new events in real time (unless paused or filtered out)
   useEffect(() => {
@@ -336,7 +414,7 @@ function LiveFeed() {
         const catOk = category === "all" || entry.category === category;
         const lvlOk = levels.includes(entry.level);
         if (catOk && lvlOk) {
-          setEntries(prev => [...prev.slice(-499), entry]);
+          setEntries((prev) => [...prev.slice(-499), entry]);
         }
       }
     });
@@ -349,7 +427,7 @@ function LiveFeed() {
   }, [entries, paused]);
 
   const toggleLevel = (lv: string) =>
-    setLevels(prev => prev.includes(lv) ? prev.filter(l => l !== lv) : [...prev, lv]);
+    setLevels((prev) => (prev.includes(lv) ? prev.filter((l) => l !== lv) : [...prev, lv]));
 
   const handleClear = async () => {
     setClearing(true);
@@ -365,33 +443,61 @@ function LiveFeed() {
   };
 
   if (loading && entries.length === 0) {
-    return <div className="loading"><div className="spinner" /> Loading events…</div>;
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading events…
+      </div>
+    );
   }
 
   return (
     <div>
       {/* Filter bar */}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: ".75rem", alignItems: "center" }}>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: ".5rem",
+          marginBottom: ".75rem",
+          alignItems: "center",
+        }}
+      >
         <TimeWindowControls
-          preset={preset} customFrom={customFrom} customTo={customTo}
-          onPreset={p => { setPreset(p); }}
+          preset={preset}
+          customFrom={customFrom}
+          customTo={customTo}
+          onPreset={(p) => {
+            setPreset(p);
+          }}
           onCustomFrom={setCustomFrom}
           onCustomTo={setCustomTo}
         />
       </div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: ".5rem", marginBottom: ".75rem", alignItems: "center" }}>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: ".5rem",
+          marginBottom: ".75rem",
+          alignItems: "center",
+        }}
+      >
         {/* Category */}
         <select
           className="form-control form-control-sm"
           value={category}
-          onChange={e => setCategory(e.target.value)}
+          onChange={(e) => setCategory(e.target.value)}
         >
-          {CATEGORIES.map(c => <option key={c} value={c}>{c === "all" ? "All categories" : c}</option>)}
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c === "all" ? "All categories" : c}
+            </option>
+          ))}
         </select>
 
         {/* Level toggles */}
         <span className="text-sm text-muted">Levels:</span>
-        {ALL_LEVELS.map(lv => (
+        {ALL_LEVELS.map((lv) => (
           <button
             key={lv}
             className={`btn btn-sm ${levels.includes(lv) ? "btn-primary" : "btn-secondary"}`}
@@ -406,7 +512,7 @@ function LiveFeed() {
           <span className="text-sm text-muted">{entries.length} events</span>
           <button
             className={`btn btn-sm ${paused ? "btn-primary" : "btn-secondary"}`}
-            onClick={() => setPaused(p => !p)}
+            onClick={() => setPaused((p) => !p)}
           >
             {paused ? "▶ Resume" : "⏸ Pause"}
           </button>
@@ -423,7 +529,11 @@ function LiveFeed() {
       {/* Load more (older entries) */}
       {hasMore && (
         <div style={{ marginBottom: ".5rem" }}>
-          <button className="btn btn-secondary btn-sm" onClick={() => load(false)} disabled={loading}>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => load(false)}
+            disabled={loading}
+          >
             {loading ? "Loading…" : "Load older entries"}
           </button>
         </div>
@@ -431,7 +541,9 @@ function LiveFeed() {
 
       <div className="card event-feed">
         {entries.length === 0 ? (
-          <div className="empty-state"><p>No events in this time window.</p></div>
+          <div className="empty-state">
+            <p>No events in this time window.</p>
+          </div>
         ) : (
           entries.map((e, i) => <EventEntry key={e.id ?? i} entry={e} />)
         )}
@@ -466,7 +578,12 @@ function RetentionSettings() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    getLogRetention().then(data => { setForm(data); setLoading(false); }).catch(() => setLoading(false));
+    getLogRetention()
+      .then((data) => {
+        setForm(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
   }, []);
 
   const save = async () => {
@@ -484,16 +601,27 @@ function RetentionSettings() {
     }
   };
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading settings…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading settings…
+      </div>
+    );
 
   return (
     <div className="card" style={{ maxWidth: 560 }}>
-      <div className="card-title" style={{ marginBottom: ".25rem" }}>Log Retention</div>
+      <div className="card-title" style={{ marginBottom: ".25rem" }}>
+        Log Retention
+      </div>
       <p className="text-sm text-muted" style={{ marginBottom: "1.5rem" }}>
         Configure how long log data is kept. The scheduler runs a purge daily and on each startup.
       </p>
 
-      {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+      {error && (
+        <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+          {error}
+        </div>
+      )}
 
       <div className="form-group">
         <label className="form-label">Event log retention (days)</label>
@@ -502,7 +630,12 @@ function RetentionSettings() {
           type="number"
           min="1"
           value={form.event_log_retention_days}
-          onChange={e => setForm(f => ({ ...f, event_log_retention_days: Math.max(1, parseInt(e.target.value) || 1) }))}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              event_log_retention_days: Math.max(1, parseInt(e.target.value) || 1),
+            }))
+          }
         />
         <div className="form-hint">
           Event logs capture every engine action, vent movement, presence event, and state change.
@@ -517,11 +650,16 @@ function RetentionSettings() {
           type="number"
           min="1"
           value={form.cycle_log_retention_days}
-          onChange={e => setForm(f => ({ ...f, cycle_log_retention_days: Math.max(1, parseInt(e.target.value) || 1) }))}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              cycle_log_retention_days: Math.max(1, parseInt(e.target.value) || 1),
+            }))
+          }
         />
         <div className="form-hint">
-          Cycle history records one entry per HVAC cycle (start/stop, rooms, duration).
-          Much lower volume than event logs — safe to keep for 30+ days.
+          Cycle history records one entry per HVAC cycle (start/stop, rooms, duration). Much lower
+          volume than event logs — safe to keep for 30+ days.
         </div>
       </div>
 
@@ -547,16 +685,27 @@ export default function Logs() {
       <div className="page-header">
         <div>
           <div className="page-title">Logs</div>
-          <div className="page-subtitle">Cycle history, live event feed, and retention settings</div>
+          <div className="page-subtitle">
+            Cycle history, live event feed, and retention settings
+          </div>
         </div>
         <div className="tab-bar">
-          <button className={`tab-btn ${tab === "feed" ? "active" : ""}`} onClick={() => setTab("feed")}>
+          <button
+            className={`tab-btn ${tab === "feed" ? "active" : ""}`}
+            onClick={() => setTab("feed")}
+          >
             Live Feed
           </button>
-          <button className={`tab-btn ${tab === "history" ? "active" : ""}`} onClick={() => setTab("history")}>
+          <button
+            className={`tab-btn ${tab === "history" ? "active" : ""}`}
+            onClick={() => setTab("history")}
+          >
             Cycle History
           </button>
-          <button className={`tab-btn ${tab === "retention" ? "active" : ""}`} onClick={() => setTab("retention")}>
+          <button
+            className={`tab-btn ${tab === "retention" ? "active" : ""}`}
+            onClick={() => setTab("retention")}
+          >
             Retention
           </button>
         </div>

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  getRooms, getRoom, createRoom, updateRoom, deleteRoom,
-  addSensor, removeSensor, addVent, removeVent,
-  addPresence, removePresence,
-  getThermostats, getEntityStates, getRoomActiveStatuses,
-  type Room, type ThermostatConfig, type EntityState, type RoomActiveStatus,
+  getRooms,
+  getRoom,
+  createRoom,
+  updateRoom,
+  deleteRoom,
+  addSensor,
+  removeSensor,
+  addVent,
+  removeVent,
+  addPresence,
+  removePresence,
+  getThermostats,
+  getEntityStates,
+  getRoomActiveStatuses,
+  type Room,
+  type ThermostatConfig,
+  type EntityState,
+  type RoomActiveStatus,
 } from "../api";
 import { useSystem } from "../main";
 import EntityPicker from "../components/EntityPicker";
@@ -27,15 +40,23 @@ function RoomModal({
   const [thermostat, setThermostat] = useState(room?.thermostat_entity_id ?? "");
   const [sysTemp, setSysTemp] = useState(room?.system_wide_temp?.toString() ?? "");
   const [holdover, setHoldover] = useState(room?.presence_holdover_hours?.toString() ?? "2");
-  const [includeThermoSensor, setIncludeThermoSensor] = useState(room?.include_thermostat_sensor ?? false);
+  const [includeThermoSensor, setIncludeThermoSensor] = useState(
+    room?.include_thermostat_sensor ?? false
+  );
   const [tempOffset, setTempOffset] = useState(room?.temp_offset?.toString() ?? "0");
   const [notes, setNotes] = useState(room?.notes ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
   const save = async () => {
-    if (!name.trim()) { setError("Room name is required"); return; }
-    if (!thermostat.trim()) { setError("Thermostat is required"); return; }
+    if (!name.trim()) {
+      setError("Room name is required");
+      return;
+    }
+    if (!thermostat.trim()) {
+      setError("Thermostat is required");
+      return;
+    }
     setSaving(true);
     setError("");
     try {
@@ -58,32 +79,41 @@ function RoomModal({
   };
 
   return (
-    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onClose()}>
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div className="modal">
         <div className="modal-title">{room ? "Edit Room" : "New Room"}</div>
-        {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+        {error && (
+          <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+            {error}
+          </div>
+        )}
 
         <div className="form-group">
           <label className="form-label">Room name *</label>
-          <input className="form-control" value={name} onChange={e => setName(e.target.value)}
-            placeholder="e.g. Master Bedroom" autoFocus />
+          <input
+            className="form-control"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Master Bedroom"
+            autoFocus
+          />
         </div>
 
         <div className="form-group">
           <label className="form-label">Thermostat *</label>
           {thermostats.length === 0 ? (
             <div className="form-hint" style={{ color: "var(--orange)" }}>
-              No thermostats registered yet. Go to the <strong>Thermostats</strong> page first
-              to register and name your thermostats.
+              No thermostats registered yet. Go to the <strong>Thermostats</strong> page first to
+              register and name your thermostats.
             </div>
           ) : (
             <select
               className="form-control"
               value={thermostat}
-              onChange={e => setThermostat(e.target.value)}
+              onChange={(e) => setThermostat(e.target.value)}
             >
               <option value="">— select a thermostat —</option>
-              {thermostats.map(tc => (
+              {thermostats.map((tc) => (
                 <option key={tc.thermostat_entity_id} value={tc.thermostat_entity_id}>
                   {tc.name} ({tc.thermostat_entity_id})
                 </option>
@@ -101,8 +131,14 @@ function RoomModal({
               — used when motion/presence detected, no active schedule
             </span>
           </label>
-          <input className="form-control" type="number" step="0.5"
-            value={sysTemp} onChange={e => setSysTemp(e.target.value)} placeholder="e.g. 72" />
+          <input
+            className="form-control"
+            type="number"
+            step="0.5"
+            value={sysTemp}
+            onChange={(e) => setSysTemp(e.target.value)}
+            placeholder="e.g. 72"
+          />
         </div>
 
         <div className="form-group">
@@ -112,50 +148,63 @@ function RoomModal({
               — keep room active this long after last motion; 0 = disabled
             </span>
           </label>
-          <input className="form-control" type="number" step="0.5" min="0"
-            value={holdover} onChange={e => setHoldover(e.target.value)} />
+          <input
+            className="form-control"
+            type="number"
+            step="0.5"
+            min="0"
+            value={holdover}
+            onChange={(e) => setHoldover(e.target.value)}
+          />
         </div>
 
         <div className="form-group">
           <label style={{ display: "flex", alignItems: "center", gap: ".5rem", cursor: "pointer" }}>
-            <input type="checkbox" checked={includeThermoSensor}
-              onChange={e => setIncludeThermoSensor(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={includeThermoSensor}
+              onChange={(e) => setIncludeThermoSensor(e.target.checked)}
+            />
             <span>Include thermostat's built-in sensor in room temperature average</span>
           </label>
         </div>
 
         <div className="form-group">
-          <label className="form-label">
-            Temperature offset (°F)
-          </label>
+          <label className="form-label">Temperature offset (°F)</label>
           <input
             className="form-control"
             type="number"
             step="0.5"
             value={tempOffset}
-            onChange={e => setTempOffset(e.target.value)}
+            onChange={(e) => setTempOffset(e.target.value)}
           />
           <div className="form-hint">
             Compensates for temperature drift after the vent closes. The offset is added to the
-            room's measured temperature before comparing to the schedule target — so the vent
-            closes earlier, leaving room for drift.
+            room's measured temperature before comparing to the schedule target — so the vent closes
+            earlier, leaving room for drift.
             <br />
             <strong>Example:</strong> your schedule targets 70°F in cooling, but this room always
             ends up at 67°F even after the vent closes. Set offset to <strong>+3</strong> — the
-            system will now close the vent when the room reads 67°F (67 + 3 = 70, "at target"),
-            and the room drifts to ~70°F instead of 67°F. Leave at 0 if the room reaches its
-            target accurately.
+            system will now close the vent when the room reads 67°F (67 + 3 = 70, "at target"), and
+            the room drifts to ~70°F instead of 67°F. Leave at 0 if the room reaches its target
+            accurately.
           </div>
         </div>
 
         <div className="form-group">
           <label className="form-label">Notes</label>
-          <textarea className="form-control" rows={2} value={notes}
-            onChange={e => setNotes(e.target.value)} />
+          <textarea
+            className="form-control"
+            rows={2}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
         </div>
 
         <div className="modal-footer">
-          <button className="btn btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
           <button className="btn btn-primary" onClick={save} disabled={saving}>
             {saving ? "Saving…" : room ? "Save changes" : "Create room"}
           </button>
@@ -196,11 +245,11 @@ function EntitySection({
       <div style={{ display: "flex", alignItems: "center", gap: ".5rem", marginBottom: ".3rem" }}>
         <span style={{ fontSize: "1.2rem" }}>{icon}</span>
         <span style={{ fontWeight: 700, fontSize: "1rem" }}>{title}</span>
-        {items.length > 0 && (
-          <span className="badge badge-blue">{items.length}</span>
-        )}
+        {items.length > 0 && <span className="badge badge-blue">{items.length}</span>}
       </div>
-      <p className="text-sm text-muted" style={{ marginBottom: ".75rem" }}>{description}</p>
+      <p className="text-sm text-muted" style={{ marginBottom: ".75rem" }}>
+        {description}
+      </p>
 
       <EntityPicker
         domain={domain}
@@ -216,10 +265,12 @@ function EntitySection({
         </p>
       ) : (
         <div className="tag-list">
-          {items.map(id => (
+          {items.map((id) => (
             <span key={id} className="tag">
               <span className="font-mono">{id}</span>
-              <button className="tag-remove" title="Remove" onClick={() => onRemove(id)}>×</button>
+              <button className="tag-remove" title="Remove" onClick={() => onRemove(id)}>
+                ×
+              </button>
             </span>
           ))}
         </div>
@@ -245,9 +296,9 @@ function RoomConfigure({
   const [editOpen, setEditOpen] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
 
-  const sensors = room.sensors?.map(s => s.entity_id) ?? [];
-  const vents   = room.vents?.map(v => v.entity_id) ?? [];
-  const presence = room.presence_sensors?.map(p => p.entity_id) ?? [];
+  const sensors = room.sensors?.map((s) => s.entity_id) ?? [];
+  const vents = room.vents?.map((v) => v.entity_id) ?? [];
+  const presence = room.presence_sensors?.map((p) => p.entity_id) ?? [];
 
   const refresh = async () => {
     const updated = await getRoom(room.id);
@@ -256,24 +307,31 @@ function RoomConfigure({
 
   const wrap = (label: string, fn: (id: string) => Promise<unknown>) => async (id: string) => {
     setBusy(label);
-    try { await fn(id); await refresh(); }
-    finally { setBusy(null); }
+    try {
+      await fn(id);
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
   };
 
   return (
     <div>
       {/* Header */}
       <div style={{ marginBottom: "1.25rem" }}>
-        <button className="btn btn-secondary btn-sm" onClick={onBack} style={{ marginBottom: ".75rem" }}>
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={onBack}
+          style={{ marginBottom: ".75rem" }}
+        >
           ← All rooms
         </button>
         <div className="flex-between">
           <div>
             <div className="page-title">{room.name}</div>
             <div className="text-muted" style={{ marginTop: ".2rem", fontSize: ".85rem" }}>
-              {thermostats.find(t => t.thermostat_entity_id === room.thermostat_entity_id)?.name
-                || room.thermostat_entity_id}
-              {" "}
+              {thermostats.find((t) => t.thermostat_entity_id === room.thermostat_entity_id)
+                ?.name || room.thermostat_entity_id}{" "}
               <span className="font-mono" style={{ fontSize: ".75rem", color: "var(--gray-400)" }}>
                 ({room.thermostat_entity_id})
               </span>
@@ -289,27 +347,36 @@ function RoomConfigure({
       <div className="card" style={{ marginBottom: "1.25rem", padding: ".875rem 1.25rem" }}>
         <div className="flex gap-md" style={{ flexWrap: "wrap" }}>
           <span className="text-sm">
-            <strong>{sensors.length}</strong> <span className="text-muted">temp sensor{sensors.length !== 1 ? "s" : ""}</span>
+            <strong>{sensors.length}</strong>{" "}
+            <span className="text-muted">temp sensor{sensors.length !== 1 ? "s" : ""}</span>
           </span>
           <span className="text-muted">·</span>
           <span className="text-sm">
-            <strong>{vents.length}</strong> <span className="text-muted">vent{vents.length !== 1 ? "s" : ""}</span>
+            <strong>{vents.length}</strong>{" "}
+            <span className="text-muted">vent{vents.length !== 1 ? "s" : ""}</span>
           </span>
           <span className="text-muted">·</span>
           <span className="text-sm">
-            <strong>{presence.length}</strong> <span className="text-muted">presence sensor{presence.length !== 1 ? "s" : ""}</span>
+            <strong>{presence.length}</strong>{" "}
+            <span className="text-muted">presence sensor{presence.length !== 1 ? "s" : ""}</span>
           </span>
           {room.system_wide_temp != null && (
             <>
               <span className="text-muted">·</span>
-              <span className="text-sm text-muted">Presence temp: <strong>{room.system_wide_temp}°F</strong></span>
+              <span className="text-sm text-muted">
+                Presence temp: <strong>{room.system_wide_temp}°F</strong>
+              </span>
             </>
           )}
           {room.temp_offset !== 0 && (
             <>
               <span className="text-muted">·</span>
               <span className="text-sm text-muted">
-                Offset: <strong>{room.temp_offset > 0 ? "+" : ""}{room.temp_offset}°F</strong>
+                Offset:{" "}
+                <strong>
+                  {room.temp_offset > 0 ? "+" : ""}
+                  {room.temp_offset}°F
+                </strong>
               </span>
             </>
           )}
@@ -318,16 +385,28 @@ function RoomConfigure({
 
       {/* Warnings */}
       {sensors.length === 0 && (
-        <div className="card" style={{ marginBottom: "1rem", borderColor: "#f59e0b", background: "#fffbeb" }}>
+        <div
+          className="card"
+          style={{ marginBottom: "1rem", borderColor: "#f59e0b", background: "#fffbeb" }}
+        >
           <p className="text-sm" style={{ color: "#92400e" }}>
             ⚠ No temperature sensors — this room will be skipped during HVAC cycles.
           </p>
         </div>
       )}
       {vents.length === 0 && (
-        <div className="card" style={{ marginBottom: "1rem", borderColor: "var(--gray-200)", background: "var(--gray-50)" }}>
+        <div
+          className="card"
+          style={{
+            marginBottom: "1rem",
+            borderColor: "var(--gray-200)",
+            background: "var(--gray-50)",
+          }}
+        >
           <p className="text-sm text-muted">
-            ℹ Sensor-only room — no vents configured. This room still participates in schedules and presence-based HVAC control; its target temperature contributes to the thermostat setpoint. Only vent actuation is skipped.
+            ℹ Sensor-only room — no vents configured. This room still participates in schedules and
+            presence-based HVAC control; its target temperature contributes to the thermostat
+            setpoint. Only vent actuation is skipped.
           </p>
         </div>
       )}
@@ -348,8 +427,8 @@ function RoomConfigure({
           domain="sensor"
           pickerPlaceholder="Search temperature sensors (sensor.*)…"
           emptyHint="No sensors added yet — search above to add one."
-          onAdd={wrap("Adding sensor…", id => addSensor(room.id, id))}
-          onRemove={wrap("Removing sensor…", id => removeSensor(room.id, id))}
+          onAdd={wrap("Adding sensor…", (id) => addSensor(room.id, id))}
+          onRemove={wrap("Removing sensor…", (id) => removeSensor(room.id, id))}
         />
 
         <hr className="divider" />
@@ -386,7 +465,10 @@ function RoomConfigure({
           room={room}
           thermostats={thermostats}
           onClose={() => setEditOpen(false)}
-          onSave={async () => { setEditOpen(false); await refresh(); }}
+          onSave={async () => {
+            setEditOpen(false);
+            await refresh();
+          }}
         />
       )}
     </div>
@@ -409,16 +491,22 @@ function formatCountdown(totalSeconds: number): string {
 
 function sourceLabel(source: RoomActiveStatus["source"]): string {
   switch (source) {
-    case "schedule": return "Schedule";
-    case "presence": return "Presence";
-    case "override": return "Override";
-    default: return "—";
+    case "schedule":
+      return "Schedule";
+    case "presence":
+      return "Presence";
+    case "override":
+      return "Override";
+    default:
+      return "—";
   }
 }
 
 function ventLabel(state: EntityState): string {
   // Flair vents report current_tilt_position; standard covers use current_position
-  const pos = (state.attributes.current_tilt_position ?? state.attributes.current_position) as number | undefined;
+  const pos = (state.attributes.current_tilt_position ?? state.attributes.current_position) as
+    | number
+    | undefined;
   if (pos !== undefined) {
     if (pos === 100) return "Open";
     if (pos === 0) return "Closed";
@@ -446,51 +534,53 @@ function RoomCard({
   room: Room;
   thermostats: ThermostatConfig[];
   status: RoomActiveStatus | null;
-  statusFetchedAt: number;  // Date.now() when status was fetched
+  statusFetchedAt: number; // Date.now() when status was fetched
   onConfigure: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
   const { enabled: systemEnabled } = useSystem();
-  const sensorIds  = room.sensors?.map(s => s.entity_id) ?? [];
-  const ventIds    = room.vents?.map(v => v.entity_id) ?? [];
-  const presenceIds = room.presence_sensors?.map(p => p.entity_id) ?? [];
-  const tc = thermostats.find(t => t.thermostat_entity_id === room.thermostat_entity_id);
+  const sensorIds = room.sensors?.map((s) => s.entity_id) ?? [];
+  const ventIds = room.vents?.map((v) => v.entity_id) ?? [];
+  const presenceIds = room.presence_sensors?.map((p) => p.entity_id) ?? [];
+  const tc = thermostats.find((t) => t.thermostat_entity_id === room.thermostat_entity_id);
   const missing = sensorIds.length === 0 || ventIds.length === 0;
 
   const [states, setStates] = useState<Record<string, EntityState | null>>({});
   // Tick every second for live countdown
-  const [tick, setTick] = useState(0);
+  const [, setTick] = useState(0);
   useEffect(() => {
-    const t = setInterval(() => setTick(n => n + 1), 1000);
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
     return () => clearInterval(t);
   }, []);
 
   useEffect(() => {
     const allIds = [...sensorIds, ...ventIds, ...presenceIds];
     if (allIds.length === 0) return;
-    getEntityStates(allIds).then(setStates).catch(() => {});
+    getEntityStates(allIds)
+      .then(setStates)
+      .catch(() => {});
   }, [room.id]);
 
   // Derived live values
   const temps = sensorIds
-    .map(id => states[id]?.numeric)
+    .map((id) => states[id]?.numeric)
     .filter((v): v is number => v !== null && v !== undefined);
-  const avgTemp = temps.length > 0
-    ? (temps.reduce((a, b) => a + b, 0) / temps.length).toFixed(1)
-    : null;
+  const avgTemp =
+    temps.length > 0 ? (temps.reduce((a, b) => a + b, 0) / temps.length).toFixed(1) : null;
 
-  const occupied = presenceIds.some(id => states[id]?.state === "on");
-  const hasPresenceData = presenceIds.length > 0 && presenceIds.some(id => states[id] !== undefined);
+  const occupied = presenceIds.some((id) => states[id]?.state === "on");
+  const hasPresenceData =
+    presenceIds.length > 0 && presenceIds.some((id) => states[id] !== undefined);
 
   // Countdown: compute elapsed since status was fetched
   const elapsedSeconds = Math.floor((Date.now() - statusFetchedAt) / 1000);
-  const endsIn = status?.ends_in_seconds != null
-    ? Math.max(0, status.ends_in_seconds - elapsedSeconds)
-    : null;
-  const nextIn = status?.next_schedule_in_seconds != null
-    ? Math.max(0, status.next_schedule_in_seconds - elapsedSeconds)
-    : null;
+  const endsIn =
+    status?.ends_in_seconds != null ? Math.max(0, status.ends_in_seconds - elapsedSeconds) : null;
+  const nextIn =
+    status?.next_schedule_in_seconds != null
+      ? Math.max(0, status.next_schedule_in_seconds - elapsedSeconds)
+      : null;
 
   const isActive = status && status.source !== "idle";
   const isDisabled = !systemEnabled;
@@ -498,54 +588,59 @@ function RoomCard({
   return (
     <div className={`card ${isDisabled ? "room-card-disabled" : ""}`}>
       <div className="flex-between" style={{ marginBottom: ".5rem" }}>
-        <div className="card-title" style={{ marginBottom: 0 }}>{room.name}</div>
-        <button className="btn btn-danger btn-sm" onClick={onDelete}>Delete</button>
+        <div className="card-title" style={{ marginBottom: 0 }}>
+          {room.name}
+        </div>
+        <button className="btn btn-danger btn-sm" onClick={onDelete}>
+          Delete
+        </button>
       </div>
 
       <div className="text-muted" style={{ marginBottom: ".875rem", fontSize: ".82rem" }}>
-        {tc?.name
-          ? <>{tc.name} <span className="font-mono" style={{ fontSize: ".75rem" }}>({room.thermostat_entity_id})</span></>
-          : <span className="font-mono">{room.thermostat_entity_id}</span>
-        }
+        {tc?.name ? (
+          <>
+            {tc.name}{" "}
+            <span className="font-mono" style={{ fontSize: ".75rem" }}>
+              ({room.thermostat_entity_id})
+            </span>
+          </>
+        ) : (
+          <span className="font-mono">{room.thermostat_entity_id}</span>
+        )}
       </div>
 
       {/* Active status row */}
       <div className="room-status-row">
         {/* Global Off badge — shown alongside schedule info, not instead of it */}
-        {isDisabled && (
-          <span className="room-status-disabled">⏸ Global Off</span>
-        )}
+        {isDisabled && <span className="room-status-disabled">⏸ Global Off</span>}
 
         {status == null ? (
           <span className="room-status-loading">…</span>
         ) : (
           <>
             {/* Target temp — grayed out when system disabled */}
-            <span className={`room-status-target ${isActive && !isDisabled ? "room-status-active" : "room-status-idle"}`}>
+            <span
+              className={`room-status-target ${isActive && !isDisabled ? "room-status-active" : "room-status-idle"}`}
+            >
               {isActive ? `🎯 ${status.target_temp}°F` : "Not active"}
             </span>
 
             {/* Active via */}
-            {isActive && (
-              <span className="room-status-via">
-                via {sourceLabel(status.source)}
-              </span>
-            )}
+            {isActive && <span className="room-status-via">via {sourceLabel(status.source)}</span>}
 
             {/* Ends in countdown */}
             {isActive && endsIn != null && (
-              <span className="room-status-ends">
-                ends in {formatCountdown(endsIn)}
-              </span>
+              <span className="room-status-ends">ends in {formatCountdown(endsIn)}</span>
             )}
 
             {/* Next schedule */}
             {status.next_schedule_label && nextIn != null && (
               <span className="room-status-next">
-                {isActive ? "then" : "next"}{" "}
-                <strong>{status.next_schedule_target}°F</strong>{" "}
+                {isActive ? "then" : "next"} <strong>{status.next_schedule_target}°F</strong>{" "}
                 {status.next_schedule_label}
-                {nextIn > 0 && <span className="room-status-next-timer"> ({formatCountdown(nextIn)})</span>}
+                {nextIn > 0 && (
+                  <span className="room-status-next-timer"> ({formatCountdown(nextIn)})</span>
+                )}
               </span>
             )}
           </>
@@ -566,7 +661,9 @@ function RoomCard({
         {presenceIds.length > 0 && (
           <div className="room-live-item">
             <span className="room-live-label">🚶 Presence</span>
-            <span className={`room-live-value ${hasPresenceData ? (occupied ? "live-occupied" : "live-unoccupied") : ""}`}>
+            <span
+              className={`room-live-value ${hasPresenceData ? (occupied ? "live-occupied" : "live-unoccupied") : ""}`}
+            >
               {!hasPresenceData ? "…" : occupied ? "Occupied" : "Unoccupied"}
               {/* Holdover countdown when presence is the active source */}
               {occupied && status?.source === "presence" && endsIn != null && (
@@ -583,7 +680,7 @@ function RoomCard({
           <div className="room-live-item">
             <span className="room-live-label">💨 Vents</span>
             <div className="room-live-vents">
-              {ventIds.map(id => {
+              {ventIds.map((id) => {
                 const s = states[id];
                 return (
                   <span key={id} className="room-vent-pill" title={id}>
@@ -609,7 +706,8 @@ function RoomCard({
         </span>
         {room.temp_offset !== 0 && (
           <span className="badge badge-orange" title="Temperature offset active">
-            offset {room.temp_offset > 0 ? "+" : ""}{room.temp_offset}°F
+            offset {room.temp_offset > 0 ? "+" : ""}
+            {room.temp_offset}°F
           </span>
         )}
       </div>
@@ -649,7 +747,7 @@ export default function Rooms() {
   const fetchStatuses = async (roomList: Room[]) => {
     if (roomList.length === 0) return;
     try {
-      const s = await getRoomActiveStatuses(roomList.map(r => r.id));
+      const s = await getRoomActiveStatuses(roomList.map((r) => r.id));
       setStatuses(s);
       setStatusFetchedAt(Date.now());
     } catch {
@@ -659,7 +757,7 @@ export default function Rooms() {
 
   const load = async () => {
     const [list, tcs] = await Promise.all([getRooms(), getThermostats()]);
-    const detailed = await Promise.all(list.map(r => getRoom(r.id)));
+    const detailed = await Promise.all(list.map((r) => getRoom(r.id)));
     setRooms(detailed);
     roomsRef.current = detailed;
     setThermostats(tcs);
@@ -667,7 +765,9 @@ export default function Rooms() {
     await fetchStatuses(detailed);
   };
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
   // Re-fetch statuses every 30s
   useEffect(() => {
@@ -675,7 +775,12 @@ export default function Rooms() {
     return () => clearInterval(interval);
   }, []);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading rooms…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading rooms…
+      </div>
+    );
 
   // Configure view
   if (configRoom) {
@@ -683,8 +788,11 @@ export default function Rooms() {
       <RoomConfigure
         room={configRoom}
         thermostats={thermostats}
-        onBack={() => { setConfigRoom(null); load(); }}
-        onRoomUpdated={updated => setConfigRoom(updated)}
+        onBack={() => {
+          setConfigRoom(null);
+          load();
+        }}
+        onRoomUpdated={(updated) => setConfigRoom(updated)}
       />
     );
   }
@@ -699,7 +807,13 @@ export default function Rooms() {
             {rooms.length > 0 && ` · click "Configure sensors & vents" to set up a room`}
           </div>
         </div>
-        <button className="btn btn-primary" onClick={() => { setEditRoom(null); setShowModal(true); }}>
+        <button
+          className="btn btn-primary"
+          onClick={() => {
+            setEditRoom(null);
+            setShowModal(true);
+          }}
+        >
           + Add room
         </button>
       </div>
@@ -709,13 +823,14 @@ export default function Rooms() {
           <div className="empty-state">
             <p>No rooms yet.</p>
             <p style={{ marginTop: ".5rem" }}>
-              Click <strong>+ Add room</strong>, pick a thermostat, then configure its sensors and vents.
+              Click <strong>+ Add room</strong>, pick a thermostat, then configure its sensors and
+              vents.
             </p>
           </div>
         </div>
       ) : (
         <div className="card-grid">
-          {rooms.map(room => (
+          {rooms.map((room) => (
             <RoomCard
               key={room.id}
               room={room}
@@ -723,7 +838,10 @@ export default function Rooms() {
               status={statuses[room.id] ?? null}
               statusFetchedAt={statusFetchedAt}
               onConfigure={() => setConfigRoom(room)}
-              onEdit={() => { setEditRoom(room); setShowModal(true); }}
+              onEdit={() => {
+                setEditRoom(room);
+                setShowModal(true);
+              }}
               onDelete={async () => {
                 if (confirm(`Delete room "${room.name}"?`)) {
                   await deleteRoom(room.id);
@@ -740,7 +858,7 @@ export default function Rooms() {
           room={editRoom}
           thermostats={thermostats}
           onClose={() => setShowModal(false)}
-          onSave={async saved => {
+          onSave={async (saved) => {
             setShowModal(false);
             await load();
             // If creating new room, immediately go to configure view

--- a/smart_vent/frontend/src/pages/Schedules.tsx
+++ b/smart_vent/frontend/src/pages/Schedules.tsx
@@ -1,17 +1,36 @@
 import { useEffect, useState } from "react";
-import { getRooms, getSchedules, createSchedule, updateSchedule, deleteSchedule, type Room, type Schedule } from "../api";
+import {
+  getRooms,
+  getSchedules,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+  type Room,
+  type Schedule,
+} from "../api";
 
 const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-function DayPicker({ selected, onChange }: { selected: number[]; onChange: (days: number[]) => void }) {
+function DayPicker({
+  selected,
+  onChange,
+}: {
+  selected: number[];
+  onChange: (days: number[]) => void;
+}) {
   const toggle = (d: number) => {
-    if (selected.includes(d)) onChange(selected.filter(x => x !== d));
+    if (selected.includes(d)) onChange(selected.filter((x) => x !== d));
     else onChange([...selected, d].sort());
   };
   return (
     <div className="day-picker">
       {DAYS.map((label, i) => (
-        <button key={i} type="button" className={`day-btn${selected.includes(i) ? " selected" : ""}`} onClick={() => toggle(i)}>
+        <button
+          key={i}
+          type="button"
+          className={`day-btn${selected.includes(i) ? " selected" : ""}`}
+          onClick={() => toggle(i)}
+        >
           {label[0]}
         </button>
       ))}
@@ -23,8 +42,12 @@ function DayPicker({ selected, onChange }: { selected: number[]; onChange: (days
 // Overlap detection (mirrors backend logic)
 // ---------------------------------------------------------------------------
 function scheduleIntervals(days: number[], start: string, end: string): [number, number, number][] {
-  const toMin = (t: string) => { const [h, m] = t.split(":").map(Number); return h * 60 + (m || 0); };
-  const sm = toMin(start), em = toMin(end);
+  const toMin = (t: string) => {
+    const [h, m] = t.split(":").map(Number);
+    return h * 60 + (m || 0);
+  };
+  const sm = toMin(start),
+    em = toMin(end);
   const isOvernight = em <= sm;
   const result: [number, number, number][] = [];
   for (const d of days) {
@@ -40,7 +63,7 @@ function scheduleIntervals(days: number[], start: string, end: string): [number,
 
 function schedulesOverlap(
   a: { days: number[]; start: string; end: string },
-  b: { days: number[]; start: string; end: string },
+  b: { days: number[]; start: string; end: string }
 ): boolean {
   const aI = scheduleIntervals(a.days, a.start, a.end);
   const bI = scheduleIntervals(b.days, b.start, b.end);
@@ -73,16 +96,22 @@ function ScheduleModal({
   const [error, setError] = useState("");
 
   const save = async () => {
-    if (days.length === 0) { setError("Select at least one day"); return; }
-    if (!temp) { setError("Temperature required"); return; }
+    if (days.length === 0) {
+      setError("Select at least one day");
+      return;
+    }
+    if (!temp) {
+      setError("Temperature required");
+      return;
+    }
 
     // Client-side overlap check
     const candidate = { days, start, end };
     for (const e of existingSchedules) {
-      if (schedule && e.id === schedule.id) continue;  // skip self when editing
+      if (schedule && e.id === schedule.id) continue; // skip self when editing
       const existing = { days: e.days_of_week, start: e.start_time, end: e.end_time };
       if (schedulesOverlap(candidate, existing)) {
-        const daysStr = e.days_of_week.map(d => DAYS[d]).join(", ");
+        const daysStr = e.days_of_week.map((d) => DAYS[d]).join(", ");
         setError(`Overlaps with existing block on ${daysStr} ${e.start_time}–${e.end_time}`);
         return;
       }
@@ -90,48 +119,80 @@ function ScheduleModal({
 
     setSaving(true);
     try {
-      const payload = { days_of_week: days, start_time: start, end_time: end, target_temp: parseFloat(temp) };
+      const payload = {
+        days_of_week: days,
+        start_time: start,
+        end_time: end,
+        target_temp: parseFloat(temp),
+      };
       if (schedule) await updateSchedule(roomId, schedule.id, payload);
       else await createSchedule(roomId, payload);
       onSave();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Save failed");
-    } finally { setSaving(false); }
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
-    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onClose()}>
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div className="modal">
         <div className="modal-title">{schedule ? "Edit Schedule" : "New Schedule"}</div>
-        {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+        {error && (
+          <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+            {error}
+          </div>
+        )}
 
         <div className="form-group">
           <label className="form-label">Days of week</label>
           <DayPicker selected={days} onChange={setDays} />
           <div className="text-sm text-muted" style={{ marginTop: ".3rem" }}>
-            {days.map(d => DAYS[d]).join(", ") || "None selected"}
+            {days.map((d) => DAYS[d]).join(", ") || "None selected"}
           </div>
         </div>
 
         <div className="flex gap-md">
           <div className="form-group" style={{ flex: 1 }}>
             <label className="form-label">Start time</label>
-            <input className="form-control" type="time" value={start} onChange={e => setStart(e.target.value)} />
+            <input
+              className="form-control"
+              type="time"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+            />
           </div>
           <div className="form-group" style={{ flex: 1 }}>
             <label className="form-label">End time</label>
-            <input className="form-control" type="time" value={end} onChange={e => setEnd(e.target.value)} />
+            <input
+              className="form-control"
+              type="time"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+            />
           </div>
         </div>
 
         <div className="form-group">
           <label className="form-label">Target temperature (°F)</label>
-          <input className="form-control" type="number" step="0.5" value={temp} onChange={e => setTemp(e.target.value)} placeholder="e.g. 68" />
+          <input
+            className="form-control"
+            type="number"
+            step="0.5"
+            value={temp}
+            onChange={(e) => setTemp(e.target.value)}
+            placeholder="e.g. 68"
+          />
         </div>
 
         <div className="modal-footer">
-          <button className="btn btn-secondary" onClick={onClose}>Cancel</button>
-          <button className="btn btn-primary" onClick={save} disabled={saving}>{saving ? "Saving…" : "Save"}</button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={save} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </button>
         </div>
       </div>
     </div>
@@ -150,8 +211,12 @@ function RoomSchedules({ room }: { room: Room }) {
   };
 
   // Load on mount for the count badge, reload when expanded for fresh data
-  useEffect(() => { load(); }, []);
-  useEffect(() => { if (expanded) load(); }, [expanded]);
+  useEffect(() => {
+    load();
+  }, []);
+  useEffect(() => {
+    if (expanded) load();
+  }, [expanded]);
 
   const del = async (s: Schedule) => {
     if (confirm("Delete this schedule?")) {
@@ -162,10 +227,18 @@ function RoomSchedules({ room }: { room: Room }) {
 
   return (
     <div className="card" style={{ marginBottom: "1rem" }}>
-      <div className="flex-between" style={{ cursor: "pointer" }} onClick={() => setExpanded(e => !e)}>
+      <div
+        className="flex-between"
+        style={{ cursor: "pointer" }}
+        onClick={() => setExpanded((e) => !e)}
+      >
         <div>
-          <div className="card-title" style={{ marginBottom: 0 }}>{room.name}</div>
-          <div className="card-subtitle font-mono" style={{ marginBottom: 0 }}>{room.thermostat_entity_id}</div>
+          <div className="card-title" style={{ marginBottom: 0 }}>
+            {room.name}
+          </div>
+          <div className="card-subtitle font-mono" style={{ marginBottom: 0 }}>
+            {room.thermostat_entity_id}
+          </div>
         </div>
         <div className="flex gap-sm">
           <span className="badge badge-gray">{schedules.length} blocks</span>
@@ -190,16 +263,28 @@ function RoomSchedules({ room }: { room: Room }) {
                   </tr>
                 </thead>
                 <tbody>
-                  {schedules.map(s => (
+                  {schedules.map((s) => (
                     <tr key={s.id}>
-                      <td>{s.days_of_week.map(d => DAYS[d][0]).join("")}</td>
+                      <td>{s.days_of_week.map((d) => DAYS[d][0]).join("")}</td>
                       <td>{s.start_time}</td>
                       <td>{s.end_time}</td>
-                      <td><strong>{s.target_temp}°F</strong></td>
+                      <td>
+                        <strong>{s.target_temp}°F</strong>
+                      </td>
                       <td>
                         <div className="flex gap-sm">
-                          <button className="btn btn-secondary btn-sm" onClick={() => { setEditSchedule(s); setShowModal(true); }}>Edit</button>
-                          <button className="btn btn-danger btn-sm" onClick={() => del(s)}>Del</button>
+                          <button
+                            className="btn btn-secondary btn-sm"
+                            onClick={() => {
+                              setEditSchedule(s);
+                              setShowModal(true);
+                            }}
+                          >
+                            Edit
+                          </button>
+                          <button className="btn btn-danger btn-sm" onClick={() => del(s)}>
+                            Del
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -209,7 +294,13 @@ function RoomSchedules({ room }: { room: Room }) {
             </div>
           )}
           <div style={{ marginTop: ".75rem" }}>
-            <button className="btn btn-primary btn-sm" onClick={() => { setEditSchedule(null); setShowModal(true); }}>
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => {
+                setEditSchedule(null);
+                setShowModal(true);
+              }}
+            >
               + Add schedule block
             </button>
           </div>
@@ -222,7 +313,10 @@ function RoomSchedules({ room }: { room: Room }) {
           roomId={room.id}
           existingSchedules={schedules}
           onClose={() => setShowModal(false)}
-          onSave={() => { setShowModal(false); load(); }}
+          onSave={() => {
+            setShowModal(false);
+            load();
+          }}
         />
       )}
     </div>
@@ -234,10 +328,18 @@ export default function Schedules() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getRooms().then(r => { setRooms(r); setLoading(false); });
+    getRooms().then((r) => {
+      setRooms(r);
+      setLoading(false);
+    });
   }, []);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading…
+      </div>
+    );
 
   return (
     <div>
@@ -249,9 +351,15 @@ export default function Schedules() {
       </div>
 
       {rooms.length === 0 ? (
-        <div className="card"><div className="empty-state"><p>No rooms configured yet. Go to <strong>Rooms</strong> first.</p></div></div>
+        <div className="card">
+          <div className="empty-state">
+            <p>
+              No rooms configured yet. Go to <strong>Rooms</strong> first.
+            </p>
+          </div>
+        </div>
       ) : (
-        rooms.map(r => <RoomSchedules key={r.id} room={r} />)
+        rooms.map((r) => <RoomSchedules key={r.id} room={r} />)
       )}
     </div>
   );

--- a/smart_vent/frontend/src/pages/Settings.tsx
+++ b/smart_vent/frontend/src/pages/Settings.tsx
@@ -1,14 +1,62 @@
 import { useEffect, useState } from "react";
 import { getThermostats, updateThermostat, getRooms, type ThermostatConfig } from "../api";
 
-const FIELDS: { key: keyof ThermostatConfig; label: string; help: string; step: string; min: string }[] = [
-  { key: "min_setpoint", label: "Min setpoint (°F)", help: "Never set thermostat below this temperature", step: "0.5", min: "40" },
-  { key: "max_setpoint", label: "Max setpoint (°F)", help: "Never set thermostat above this temperature", step: "0.5", min: "40" },
-  { key: "deadband", label: "Deadband (°F)", help: "±tolerance to consider a room 'at target'. 0 = exact match. Prevents rapid cycling.", step: "0.1", min: "0" },
-  { key: "max_vent_closed_min", label: "Max vent closed (min)", help: "Reopen vents after this many minutes. 0 = disabled (use for bypass damper systems).", step: "1", min: "0" },
-  { key: "min_open_vents", label: "Min open vents", help: "Always keep at least this many vents open. 0 = allow all closed.", step: "1", min: "0" },
-  { key: "overshoot_delta", label: "Overshoot delta (°F)", help: "How far past target to set the thermostat to keep the HVAC running", step: "0.5", min: "0" },
-  { key: "cycle_timeout_hours", label: "Cycle timeout (hours)", help: "Abort a stuck cycle after this many hours", step: "0.5", min: "0.5" },
+const FIELDS: {
+  key: keyof ThermostatConfig;
+  label: string;
+  help: string;
+  step: string;
+  min: string;
+}[] = [
+  {
+    key: "min_setpoint",
+    label: "Min setpoint (°F)",
+    help: "Never set thermostat below this temperature",
+    step: "0.5",
+    min: "40",
+  },
+  {
+    key: "max_setpoint",
+    label: "Max setpoint (°F)",
+    help: "Never set thermostat above this temperature",
+    step: "0.5",
+    min: "40",
+  },
+  {
+    key: "deadband",
+    label: "Deadband (°F)",
+    help: "±tolerance to consider a room 'at target'. 0 = exact match. Prevents rapid cycling.",
+    step: "0.1",
+    min: "0",
+  },
+  {
+    key: "max_vent_closed_min",
+    label: "Max vent closed (min)",
+    help: "Reopen vents after this many minutes. 0 = disabled (use for bypass damper systems).",
+    step: "1",
+    min: "0",
+  },
+  {
+    key: "min_open_vents",
+    label: "Min open vents",
+    help: "Always keep at least this many vents open. 0 = allow all closed.",
+    step: "1",
+    min: "0",
+  },
+  {
+    key: "overshoot_delta",
+    label: "Overshoot delta (°F)",
+    help: "How far past target to set the thermostat to keep the HVAC running",
+    step: "0.5",
+    min: "0",
+  },
+  {
+    key: "cycle_timeout_hours",
+    label: "Cycle timeout (hours)",
+    help: "Abort a stuck cycle after this many hours",
+    step: "0.5",
+    min: "0.5",
+  },
 ];
 
 function ThermostatCard({ config }: { config: ThermostatConfig }) {
@@ -34,9 +82,19 @@ function ThermostatCard({ config }: { config: ThermostatConfig }) {
   return (
     <div className="card" style={{ marginBottom: "1rem" }}>
       <div className="card-title">{config.thermostat_entity_id}</div>
-      {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+      {error && (
+        <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+          {error}
+        </div>
+      )}
 
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: "1rem" }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+          gap: "1rem",
+        }}
+      >
         {FIELDS.map(({ key, label, help, step, min }) => (
           <div className="form-group" key={key} style={{ marginBottom: 0 }}>
             <label className="form-label">{label}</label>
@@ -46,9 +104,11 @@ function ThermostatCard({ config }: { config: ThermostatConfig }) {
               step={step}
               min={min}
               value={form[key] as number}
-              onChange={e => setForm(f => ({ ...f, [key]: parseFloat(e.target.value) || 0 }))}
+              onChange={(e) => setForm((f) => ({ ...f, [key]: parseFloat(e.target.value) || 0 }))}
             />
-            <div className="text-sm text-muted" style={{ marginTop: ".25rem" }}>{help}</div>
+            <div className="text-sm text-muted" style={{ marginTop: ".25rem" }}>
+              {help}
+            </div>
           </div>
         ))}
       </div>
@@ -71,12 +131,15 @@ export default function Settings() {
   useEffect(() => {
     Promise.all([getThermostats(), getRooms()]).then(([tc, rooms]) => {
       // Also create default configs for thermostats referenced by rooms but not yet configured
-      const knownIds = new Set(tc.map(c => c.thermostat_entity_id));
-      const roomThermoIds = [...new Set(rooms.map(r => r.thermostat_entity_id))];
-      const missing = roomThermoIds.filter(id => !knownIds.has(id));
+      const knownIds = new Set(tc.map((c) => c.thermostat_entity_id));
+      const roomThermoIds = [...new Set(rooms.map((r) => r.thermostat_entity_id))];
+      const missing = roomThermoIds.filter((id) => !knownIds.has(id));
       // Trigger save of defaults for missing ones
-      Promise.all(missing.map(id => updateThermostat(id, {}))).then(() => {
-        getThermostats().then(updated => { setConfigs(updated); setLoading(false); });
+      Promise.all(missing.map((id) => updateThermostat(id, {}))).then(() => {
+        getThermostats().then((updated) => {
+          setConfigs(updated);
+          setLoading(false);
+        });
       });
       if (rooms.length === 0) setNoRooms(true);
       setConfigs(tc);
@@ -84,7 +147,12 @@ export default function Settings() {
     });
   }, []);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading settings…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading settings…
+      </div>
+    );
 
   return (
     <div>
@@ -98,12 +166,16 @@ export default function Settings() {
       {noRooms && configs.length === 0 && (
         <div className="card">
           <div className="empty-state">
-            <p>No thermostats configured yet. Add rooms first — thermostat configs will appear here.</p>
+            <p>
+              No thermostats configured yet. Add rooms first — thermostat configs will appear here.
+            </p>
           </div>
         </div>
       )}
 
-      {configs.map(c => <ThermostatCard key={c.thermostat_entity_id} config={c} />)}
+      {configs.map((c) => (
+        <ThermostatCard key={c.thermostat_entity_id} config={c} />
+      ))}
     </div>
   );
 }

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  getThermostats, createThermostat, updateThermostat, deleteThermostat,
-  downloadBackup, restoreBackup,
+  getThermostats,
+  createThermostat,
+  updateThermostat,
+  deleteThermostat,
+  downloadBackup,
+  restoreBackup,
   type ThermostatConfig,
 } from "../api";
 import EntityPicker from "../components/EntityPicker";
@@ -17,13 +21,55 @@ const SAFETY_FIELDS: {
   step: string;
   min: string;
 }[] = [
-  { key: "min_setpoint", label: "Min setpoint (°F)", help: "Never set thermostat below this temperature", step: "0.5", min: "40" },
-  { key: "max_setpoint", label: "Max setpoint (°F)", help: "Never set thermostat above this temperature", step: "0.5", min: "40" },
-  { key: "deadband", label: "Deadband (°F)", help: "±tolerance to consider a room 'at target'. 0 = exact match.", step: "0.1", min: "0" },
-  { key: "overshoot_delta", label: "Overshoot delta (°F)", help: "How far past target to set the thermostat to keep the HVAC running", step: "0.5", min: "0" },
-  { key: "max_vent_closed_min", label: "Max vent closed (min)", help: "Reopen vents after this many minutes. 0 = disabled.", step: "1", min: "0" },
-  { key: "min_open_vents", label: "Min open vents", help: "Always keep at least this many vents open. 0 = allow all closed.", step: "1", min: "0" },
-  { key: "cycle_timeout_hours", label: "Cycle timeout (hours)", help: "Abort a stuck cycle after this many hours", step: "0.5", min: "0.5" },
+  {
+    key: "min_setpoint",
+    label: "Min setpoint (°F)",
+    help: "Never set thermostat below this temperature",
+    step: "0.5",
+    min: "40",
+  },
+  {
+    key: "max_setpoint",
+    label: "Max setpoint (°F)",
+    help: "Never set thermostat above this temperature",
+    step: "0.5",
+    min: "40",
+  },
+  {
+    key: "deadband",
+    label: "Deadband (°F)",
+    help: "±tolerance to consider a room 'at target'. 0 = exact match.",
+    step: "0.1",
+    min: "0",
+  },
+  {
+    key: "overshoot_delta",
+    label: "Overshoot delta (°F)",
+    help: "How far past target to set the thermostat to keep the HVAC running",
+    step: "0.5",
+    min: "0",
+  },
+  {
+    key: "max_vent_closed_min",
+    label: "Max vent closed (min)",
+    help: "Reopen vents after this many minutes. 0 = disabled.",
+    step: "1",
+    min: "0",
+  },
+  {
+    key: "min_open_vents",
+    label: "Min open vents",
+    help: "Always keep at least this many vents open. 0 = allow all closed.",
+    step: "1",
+    min: "0",
+  },
+  {
+    key: "cycle_timeout_hours",
+    label: "Cycle timeout (hours)",
+    help: "Abort a stuck cycle after this many hours",
+    step: "0.5",
+    min: "0.5",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -43,8 +89,14 @@ function AddThermostatModal({
   const [error, setError] = useState("");
 
   const save = async () => {
-    if (!entityId) { setError("Select a thermostat entity"); return; }
-    if (!name.trim()) { setError("Friendly name is required"); return; }
+    if (!entityId) {
+      setError("Select a thermostat entity");
+      return;
+    }
+    if (!name.trim()) {
+      setError("Friendly name is required");
+      return;
+    }
     setSaving(true);
     setError("");
     try {
@@ -58,22 +110,24 @@ function AddThermostatModal({
   };
 
   return (
-    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onClose()}>
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
       <div className="modal">
         <div className="modal-title">Register Thermostat</div>
-        {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+        {error && (
+          <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+            {error}
+          </div>
+        )}
 
         <div className="form-group">
           <label className="form-label">HA Thermostat Entity *</label>
-          <EntityPicker
-            domain="climate"
-            placeholder="Search thermostats…"
-            onSelect={setEntityId}
-          />
+          <EntityPicker domain="climate" placeholder="Search thermostats…" onSelect={setEntityId} />
           {entityId && (
             <div className="tag" style={{ marginTop: ".4rem" }}>
               ✓ <span className="font-mono">{entityId}</span>
-              <button className="tag-remove" onClick={() => setEntityId("")}>×</button>
+              <button className="tag-remove" onClick={() => setEntityId("")}>
+                ×
+              </button>
             </div>
           )}
         </div>
@@ -84,14 +138,18 @@ function AddThermostatModal({
             className="form-control"
             placeholder="e.g. Upstairs HVAC"
             value={name}
-            onChange={e => setName(e.target.value)}
+            onChange={(e) => setName(e.target.value)}
             autoFocus
           />
-          <div className="form-hint">This name appears on the Dashboard and in Room configuration.</div>
+          <div className="form-hint">
+            This name appears on the Dashboard and in Room configuration.
+          </div>
         </div>
 
         <div className="modal-footer">
-          <button className="btn btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
           <button className="btn btn-primary" onClick={save} disabled={saving}>
             {saving ? "Saving…" : "Register"}
           </button>
@@ -118,7 +176,10 @@ function ThermostatCard({
   const [error, setError] = useState("");
 
   const save = async () => {
-    if (!form.name.trim()) { setError("Friendly name is required"); return; }
+    if (!form.name.trim()) {
+      setError("Friendly name is required");
+      return;
+    }
     setSaving(true);
     setError("");
     try {
@@ -133,7 +194,12 @@ function ThermostatCard({
   };
 
   const remove = async () => {
-    if (!confirm(`Remove thermostat "${form.name || config.thermostat_entity_id}"?\n\nRooms already using this thermostat will keep their entity ID but the thermostat will no longer appear in the picker.`)) return;
+    if (
+      !confirm(
+        `Remove thermostat "${form.name || config.thermostat_entity_id}"?\n\nRooms already using this thermostat will keep their entity ID but the thermostat will no longer appear in the picker.`
+      )
+    )
+      return;
     try {
       await deleteThermostat(config.thermostat_entity_id);
       onDeleted();
@@ -154,19 +220,32 @@ function ThermostatCard({
             {config.thermostat_entity_id}
           </div>
         </div>
-        <button className="btn btn-danger btn-sm" onClick={remove}>Remove</button>
+        <button className="btn btn-danger btn-sm" onClick={remove}>
+          Remove
+        </button>
       </div>
 
-      {error && <div className="badge badge-red" style={{ marginBottom: "1rem" }}>{error}</div>}
+      {error && (
+        <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+          {error}
+        </div>
+      )}
 
       {/* Identity fields */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1rem" }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: "1rem",
+          marginBottom: "1rem",
+        }}
+      >
         <div className="form-group" style={{ marginBottom: 0 }}>
           <label className="form-label">Friendly name *</label>
           <input
             className="form-control"
             value={form.name}
-            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
             placeholder="e.g. Upstairs HVAC"
           />
         </div>
@@ -178,11 +257,16 @@ function ThermostatCard({
             step="0.5"
             value={form.default_temp ?? ""}
             placeholder="e.g. 72"
-            onChange={e => setForm(f => ({ ...f, default_temp: e.target.value ? parseFloat(e.target.value) : null }))}
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                default_temp: e.target.value ? parseFloat(e.target.value) : null,
+              }))
+            }
           />
           <div className="form-hint">
-            Target temperature when a room in this zone is activated by presence and has no room-level
-            presence temp set. Rooms can override this individually.
+            Target temperature when a room in this zone is activated by presence and has no
+            room-level presence temp set. Rooms can override this individually.
           </div>
         </div>
       </div>
@@ -190,10 +274,19 @@ function ThermostatCard({
       <hr className="divider" />
 
       {/* Safety settings */}
-      <div className="text-sm" style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}>
+      <div
+        className="text-sm"
+        style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}
+      >
         Safety &amp; cycle settings
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: "1rem" }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
+          gap: "1rem",
+        }}
+      >
         {SAFETY_FIELDS.map(({ key, label, help, step, min }) => (
           <div className="form-group" key={key} style={{ marginBottom: 0 }}>
             <label className="form-label">{label}</label>
@@ -202,8 +295,8 @@ function ThermostatCard({
               type="number"
               step={step}
               min={min}
-              value={form[key] as number ?? ""}
-              onChange={e => setForm(f => ({ ...f, [key]: parseFloat(e.target.value) || 0 }))}
+              value={(form[key] as number) ?? ""}
+              onChange={(e) => setForm((f) => ({ ...f, [key]: parseFloat(e.target.value) || 0 }))}
             />
             <div className="form-hint">{help}</div>
           </div>
@@ -213,7 +306,10 @@ function ThermostatCard({
       <hr className="divider" />
 
       {/* Drift correction — rendered separately because max depends on cycle_timeout_hours */}
-      <div className="text-sm" style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}>
+      <div
+        className="text-sm"
+        style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}
+      >
         Drift correction
       </div>
       <div className="form-group" style={{ maxWidth: 280 }}>
@@ -225,17 +321,17 @@ function ThermostatCard({
           min="0"
           max={Math.floor(form.cycle_timeout_hours * 60)}
           value={form.reconciliation_interval_min ?? 0}
-          onChange={e => {
+          onChange={(e) => {
             const val = parseInt(e.target.value) || 0;
             const maxVal = Math.floor(form.cycle_timeout_hours * 60);
-            setForm(f => ({ ...f, reconciliation_interval_min: Math.min(val, maxVal) }));
+            setForm((f) => ({ ...f, reconciliation_interval_min: Math.min(val, maxVal) }));
           }}
         />
         <div className="form-hint">
           How often (in minutes) the engine re-checks actual vent and thermostat state in Home
           Assistant and corrects any external changes (e.g. from the Flair app or manual HA
-          overrides). Set to <strong>0</strong> to disable. Cannot exceed the cycle timeout
-          ({Math.floor(form.cycle_timeout_hours * 60)} min).
+          overrides). Set to <strong>0</strong> to disable. Cannot exceed the cycle timeout (
+          {Math.floor(form.cycle_timeout_hours * 60)} min).
         </div>
       </div>
 
@@ -261,7 +357,9 @@ function BackupRestoreCard() {
   const handleRestore = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (!confirm("Restore this database? Current data will be replaced and the engine will restart.")) {
+    if (
+      !confirm("Restore this database? Current data will be replaced and the engine will restart.")
+    ) {
       e.target.value = "";
       return;
     }
@@ -280,7 +378,9 @@ function BackupRestoreCard() {
 
   return (
     <div className="card" style={{ marginTop: "2rem" }}>
-      <div className="card-title" style={{ marginBottom: ".25rem" }}>Backup &amp; Restore</div>
+      <div className="card-title" style={{ marginBottom: ".25rem" }}>
+        Backup &amp; Restore
+      </div>
       <div className="text-muted" style={{ fontSize: ".85rem", marginBottom: "1.25rem" }}>
         Download your configuration database or restore from a previous backup.
       </div>
@@ -288,7 +388,11 @@ function BackupRestoreCard() {
         <button className="btn btn-secondary" onClick={downloadBackup}>
           Download backup
         </button>
-        <button className="btn btn-secondary" onClick={() => fileRef.current?.click()} disabled={restoring}>
+        <button
+          className="btn btn-secondary"
+          onClick={() => fileRef.current?.click()}
+          disabled={restoring}
+        >
           {restoring ? "Restoring…" : "Restore from backup"}
         </button>
         <input
@@ -299,9 +403,7 @@ function BackupRestoreCard() {
           onChange={handleRestore}
         />
         {status && (
-          <span className={`badge ${status.ok ? "badge-green" : "badge-red"}`}>
-            {status.msg}
-          </span>
+          <span className={`badge ${status.ok ? "badge-green" : "badge-red"}`}>{status.msg}</span>
         )}
       </div>
     </div>
@@ -323,9 +425,16 @@ export default function Thermostats() {
     setLoading(false);
   };
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
-  if (loading) return <div className="loading"><div className="spinner" /> Loading thermostats…</div>;
+  if (loading)
+    return (
+      <div className="loading">
+        <div className="spinner" /> Loading thermostats…
+      </div>
+    );
 
   return (
     <div>
@@ -346,18 +455,14 @@ export default function Thermostats() {
           <div className="empty-state">
             <p>No thermostats registered yet.</p>
             <p style={{ marginTop: ".5rem" }}>
-              Click <strong>+ Register thermostat</strong> to add your first thermostat.
-              Once registered, it will appear in the Room configuration picker by its friendly name.
+              Click <strong>+ Register thermostat</strong> to add your first thermostat. Once
+              registered, it will appear in the Room configuration picker by its friendly name.
             </p>
           </div>
         </div>
       ) : (
-        configs.map(c => (
-          <ThermostatCard
-            key={c.thermostat_entity_id}
-            config={c}
-            onDeleted={load}
-          />
+        configs.map((c) => (
+          <ThermostatCard key={c.thermostat_entity_id} config={c} onDeleted={load} />
         ))
       )}
 
@@ -366,7 +471,10 @@ export default function Thermostats() {
       {showAdd && (
         <AddThermostatModal
           onClose={() => setShowAdd(false)}
-          onSave={() => { setShowAdd(false); load(); }}
+          onSave={() => {
+            setShowAdd(false);
+            load();
+          }}
         />
       )}
     </div>

--- a/smart_vent/frontend/src/styles.css
+++ b/smart_vent/frontend/src/styles.css
@@ -16,8 +16,8 @@
   --gray-700: #334155;
   --gray-900: #0f172a;
   --radius: 10px;
-  --shadow: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06);
-  --shadow-md: 0 4px 6px -1px rgba(0,0,0,.08), 0 2px 4px -2px rgba(0,0,0,.06);
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -2px rgba(0, 0, 0, 0.06);
 }
 
 /* ── Nav ── */
@@ -40,30 +40,43 @@
   color: var(--gray-900);
   display: flex;
   align-items: center;
-  gap: .5rem;
+  gap: 0.5rem;
 }
-.nav-icon { font-size: 1.3rem; }
+.nav-icon {
+  font-size: 1.3rem;
+}
 
 /* Right side: toggle + hamburger */
 .nav-right {
   display: flex;
   align-items: center;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 
 /* Desktop nav links */
-.nav-links { display: flex; gap: .25rem; }
+.nav-links {
+  display: flex;
+  gap: 0.25rem;
+}
 .nav-links a {
-  padding: .35rem .75rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 6px;
   text-decoration: none;
   color: var(--gray-600);
-  font-size: .9rem;
+  font-size: 0.9rem;
   font-weight: 500;
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
-.nav-links a:hover { background: var(--gray-100); color: var(--gray-900); }
-.nav-links a.active { background: var(--blue-light); color: var(--blue); }
+.nav-links a:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+}
+.nav-links a.active {
+  background: var(--blue-light);
+  color: var(--blue);
+}
 
 /* Hamburger button — hidden on desktop */
 .nav-hamburger {
@@ -78,7 +91,9 @@
   border-radius: 6px;
   padding: 0;
 }
-.nav-hamburger:hover { background: var(--gray-100); }
+.nav-hamburger:hover {
+  background: var(--gray-100);
+}
 
 /* Three-line icon using box-shadow trick */
 .hamburger-icon {
@@ -88,7 +103,7 @@
   height: 2px;
   background: var(--gray-700);
   border-radius: 2px;
-  transition: background .15s;
+  transition: background 0.15s;
 }
 .hamburger-icon::before,
 .hamburger-icon::after {
@@ -99,57 +114,87 @@
   height: 2px;
   background: var(--gray-700);
   border-radius: 2px;
-  transition: transform .2s;
+  transition: transform 0.2s;
 }
-.hamburger-icon::before { top: -5px; }
-.hamburger-icon::after  { top: 5px; }
+.hamburger-icon::before {
+  top: -5px;
+}
+.hamburger-icon::after {
+  top: 5px;
+}
 
 /* × when open */
-.hamburger-icon.open { background: transparent; }
-.hamburger-icon.open::before { transform: rotate(45deg) translate(3.5px, 3.5px); }
-.hamburger-icon.open::after  { transform: rotate(-45deg) translate(3.5px, -3.5px); }
+.hamburger-icon.open {
+  background: transparent;
+}
+.hamburger-icon.open::before {
+  transform: rotate(45deg) translate(3.5px, 3.5px);
+}
+.hamburger-icon.open::after {
+  transform: rotate(-45deg) translate(3.5px, -3.5px);
+}
 
 /* Mobile dropdown menu */
 .nav-mobile-menu {
   display: none;
   width: 100%;
   flex-direction: column;
-  padding: .5rem 0 .75rem;
+  padding: 0.5rem 0 0.75rem;
   border-top: 1px solid var(--gray-200);
 }
 .nav-mobile-menu a {
-  padding: .65rem 1rem;
+  padding: 0.65rem 1rem;
   text-decoration: none;
   color: var(--gray-600);
-  font-size: .95rem;
+  font-size: 0.95rem;
   font-weight: 500;
   border-radius: 6px;
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
-.nav-mobile-menu a:hover { background: var(--gray-100); color: var(--gray-900); }
-.nav-mobile-menu a.active { color: var(--blue); background: var(--blue-light); }
+.nav-mobile-menu a:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+}
+.nav-mobile-menu a.active {
+  color: var(--blue);
+  background: var(--blue-light);
+}
 
 /* ── Mobile breakpoint ── */
 @media (max-width: 640px) {
-  .nav { padding: 0 1rem; }
-  .nav-links-desktop { display: none; }
-  .nav-hamburger { display: flex; }
-  .nav-mobile-menu { display: flex; }
-  .main { padding: 1rem; }
+  .nav {
+    padding: 0 1rem;
+  }
+  .nav-links-desktop {
+    display: none;
+  }
+  .nav-hamburger {
+    display: flex;
+  }
+  .nav-mobile-menu {
+    display: flex;
+  }
+  .main {
+    padding: 1rem;
+  }
 }
 
 /* ── System toggle pill ── */
 .system-toggle {
   display: flex;
   align-items: center;
-  gap: .4rem;
-  padding: .3rem .75rem;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
   border-radius: 999px;
   border: none;
   cursor: pointer;
-  font-size: .85rem;
+  font-size: 0.85rem;
   font-weight: 600;
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
   white-space: nowrap;
 }
 .system-toggle.enabled {
@@ -165,33 +210,45 @@
   height: 8px;
   border-radius: 50%;
 }
-.system-toggle.enabled .system-toggle-dot { background: var(--green); }
-.system-toggle.disabled .system-toggle-dot { background: var(--red); }
+.system-toggle.enabled .system-toggle-dot {
+  background: var(--green);
+}
+.system-toggle.disabled .system-toggle-dot {
+  background: var(--red);
+}
 
 /* ── Dev mode toggle ── */
 .dev-mode-toggle {
   display: flex;
   align-items: center;
-  gap: .35rem;
-  padding: .3rem .65rem;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
   border-radius: 999px;
   border: 1.5px solid var(--gray-200);
   background: var(--gray-50);
   color: var(--gray-500);
   cursor: pointer;
-  font-size: .82rem;
+  font-size: 0.82rem;
   font-weight: 600;
-  transition: all .15s;
+  transition: all 0.15s;
   white-space: nowrap;
 }
-.dev-mode-toggle:hover { border-color: var(--orange); color: var(--orange); }
+.dev-mode-toggle:hover {
+  border-color: var(--orange);
+  color: var(--orange);
+}
 .dev-mode-toggle.active {
   background: #fffbeb;
   border-color: var(--orange);
   color: #b45309;
 }
-.nav-dev-link { color: #b45309 !important; }
-.nav-dev-link.active { background: #fff7ed !important; color: #b45309 !important; }
+.nav-dev-link {
+  color: #b45309 !important;
+}
+.nav-dev-link.active {
+  background: #fff7ed !important;
+  color: #b45309 !important;
+}
 
 /* ── Dev mode page ── */
 .dev-layout {
@@ -201,13 +258,15 @@
   align-items: start;
 }
 @media (max-width: 900px) {
-  .dev-layout { grid-template-columns: 1fr; }
+  .dev-layout {
+    grid-template-columns: 1fr;
+  }
 }
 .dev-panel-header {
   display: flex;
   align-items: center;
-  gap: .75rem;
-  margin-bottom: .75rem;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
   flex-wrap: wrap;
 }
 .dev-feed-panel {
@@ -222,36 +281,38 @@
 .dev-feed {
   display: flex;
   flex-direction: column;
-  gap: .3rem;
+  gap: 0.3rem;
   max-height: 600px;
   overflow-y: auto;
   font-family: ui-monospace, monospace;
-  font-size: .82rem;
+  font-size: 0.82rem;
 }
 .dev-feed-empty {
   padding: 2rem 1rem;
   text-align: center;
   color: var(--gray-400);
-  font-size: .88rem;
+  font-size: 0.88rem;
 }
 .dev-feed-row {
   display: flex;
   align-items: baseline;
-  gap: .5rem;
-  padding: .35rem .5rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
   border-radius: 5px;
   border-left: 3px solid transparent;
-  transition: background .1s;
+  transition: background 0.1s;
 }
-.dev-feed-row:hover { background: var(--gray-50); }
+.dev-feed-row:hover {
+  background: var(--gray-50);
+}
 .dev-feed-time {
   color: var(--gray-400);
-  font-size: .75rem;
+  font-size: 0.75rem;
   flex-shrink: 0;
   width: 7rem;
 }
 .dev-feed-icon {
-  font-size: .95rem;
+  font-size: 0.95rem;
   flex-shrink: 0;
   width: 1.5rem;
   text-align: center;
@@ -259,22 +320,26 @@
 .dev-feed-msg {
   flex: 1;
   color: var(--gray-700);
-  font-size: .82rem;
+  font-size: 0.82rem;
 }
 .dev-feed-entity {
   color: var(--gray-400);
-  font-size: .73rem;
+  font-size: 0.73rem;
   flex-shrink: 0;
 }
 .dev-feed-temp {
   color: var(--orange);
   font-weight: 700;
   flex-shrink: 0;
-  font-size: .82rem;
+  font-size: 0.82rem;
 }
 
 /* ── Main layout ── */
-.main { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+.main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
 
 /* ── Page header ── */
 .page-header {
@@ -283,8 +348,16 @@
   justify-content: space-between;
   margin-bottom: 1.25rem;
 }
-.page-title { font-size: 1.4rem; font-weight: 700; color: var(--gray-900); }
-.page-subtitle { font-size: .9rem; color: var(--gray-600); margin-top: .15rem; }
+.page-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+.page-subtitle {
+  font-size: 0.9rem;
+  color: var(--gray-600);
+  margin-top: 0.15rem;
+}
 
 /* ── Cards ── */
 .card {
@@ -305,83 +378,96 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: .4rem .65rem;
-  margin-bottom: .75rem;
-  font-size: .82rem;
+  gap: 0.4rem 0.65rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.82rem;
   min-height: 1.4rem;
 }
 .room-status-target {
   font-weight: 700;
-  font-size: .9rem;
+  font-size: 0.9rem;
 }
-.room-status-active { color: var(--blue); }
-.room-status-idle   { color: var(--gray-400); font-weight: 500; }
+.room-status-active {
+  color: var(--blue);
+}
+.room-status-idle {
+  color: var(--gray-400);
+  font-weight: 500;
+}
 .room-status-disabled {
   color: var(--gray-400);
   font-style: italic;
-  font-size: .82rem;
+  font-size: 0.82rem;
 }
-.room-status-loading { color: var(--gray-400); font-size: .82rem; }
+.room-status-loading {
+  color: var(--gray-400);
+  font-size: 0.82rem;
+}
 .room-status-via {
   color: var(--gray-600);
-  font-size: .78rem;
+  font-size: 0.78rem;
   background: var(--gray-100);
-  padding: .1rem .4rem;
+  padding: 0.1rem 0.4rem;
   border-radius: 4px;
 }
 .room-status-ends {
   color: var(--orange);
-  font-size: .78rem;
+  font-size: 0.78rem;
 }
 .room-status-next {
   color: var(--gray-600);
-  font-size: .78rem;
+  font-size: 0.78rem;
 }
 .room-status-next-timer {
   color: var(--gray-400);
 }
 .room-card-disabled {
-  opacity: .85;
+  opacity: 0.85;
 }
 
 /* ── Room live state strip ── */
 .room-live-strip {
   display: flex;
   flex-direction: column;
-  gap: .5rem;
+  gap: 0.5rem;
   background: var(--gray-50);
   border: 1px solid var(--gray-200);
   border-radius: 8px;
-  padding: .65rem .9rem;
-  margin-bottom: .875rem;
+  padding: 0.65rem 0.9rem;
+  margin-bottom: 0.875rem;
 }
 .room-live-item {
   display: flex;
   align-items: baseline;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 .room-live-label {
-  font-size: .75rem;
+  font-size: 0.75rem;
   color: var(--gray-600);
   width: 5.5rem;
   flex-shrink: 0;
 }
 .room-live-value {
-  font-size: .9rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--gray-900);
 }
-.live-occupied  { color: #16a34a; }
-.live-unoccupied { color: var(--gray-400); font-weight: 500; }
+.live-occupied {
+  color: #16a34a;
+}
+.live-unoccupied {
+  color: var(--gray-400);
+  font-weight: 500;
+}
 .room-live-vents {
   display: flex;
-  gap: .35rem;
+  gap: 0.35rem;
   flex-wrap: wrap;
 }
 .room-vent-pill {
-  font-size: .78rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  padding: .1rem .45rem;
+  padding: 0.1rem 0.45rem;
   border-radius: 4px;
   background: var(--gray-200);
   color: var(--gray-700);
@@ -390,101 +476,189 @@
   font-weight: 600;
   font-size: 1rem;
   color: var(--gray-900);
-  margin-bottom: .75rem;
+  margin-bottom: 0.75rem;
 }
 .card-subtitle {
-  font-size: .8rem;
+  font-size: 0.8rem;
   color: var(--gray-600);
-  margin-bottom: .75rem;
+  margin-bottom: 0.75rem;
 }
 
 /* ── Badges / pills ── */
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: .3rem;
-  padding: .2rem .6rem;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
   border-radius: 9999px;
-  font-size: .75rem;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: .02em;
+  letter-spacing: 0.02em;
 }
-.badge-green { background: var(--green-light); color: #15803d; }
-.badge-blue  { background: var(--blue-light);  color: #1d4ed8; }
-.badge-red   { background: var(--red-light);   color: #b91c1c; }
-.badge-gray  { background: var(--gray-100);    color: var(--gray-600); }
-.badge-orange { background: var(--orange-light); color: #c2410c; }
+.badge-green {
+  background: var(--green-light);
+  color: #15803d;
+}
+.badge-blue {
+  background: var(--blue-light);
+  color: #1d4ed8;
+}
+.badge-red {
+  background: var(--red-light);
+  color: #b91c1c;
+}
+.badge-gray {
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+.badge-orange {
+  background: var(--orange-light);
+  color: #c2410c;
+}
 
 /* ── Stat row ── */
 .stat-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: .5rem 0;
+  padding: 0.5rem 0;
   border-bottom: 1px solid var(--gray-100);
-  font-size: .875rem;
+  font-size: 0.875rem;
 }
-.stat-row:last-child { border-bottom: none; }
-.stat-label { color: var(--gray-600); }
-.stat-value { font-weight: 600; color: var(--gray-900); }
+.stat-row:last-child {
+  border-bottom: none;
+}
+.stat-label {
+  color: var(--gray-600);
+}
+.stat-value {
+  font-weight: 600;
+  color: var(--gray-900);
+}
 
 /* ── Buttons ── */
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: .4rem;
-  padding: .45rem 1rem;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
   border-radius: 7px;
   border: 1px solid transparent;
-  font-size: .875rem;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all .15s;
+  transition: all 0.15s;
 }
-.btn-primary { background: var(--blue); color: #fff; }
-.btn-primary:hover { background: #2563eb; }
-.btn-secondary { background: #fff; border-color: var(--gray-200); color: var(--gray-700); }
-.btn-secondary:hover { background: var(--gray-50); }
-.btn-danger { background: #fff; border-color: var(--red); color: var(--red); }
-.btn-danger:hover { background: var(--red-light); }
-.btn-sm { padding: .3rem .65rem; font-size: .8rem; }
+.btn-primary {
+  background: var(--blue);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: #2563eb;
+}
+.btn-secondary {
+  background: #fff;
+  border-color: var(--gray-200);
+  color: var(--gray-700);
+}
+.btn-secondary:hover {
+  background: var(--gray-50);
+}
+.btn-danger {
+  background: #fff;
+  border-color: var(--red);
+  color: var(--red);
+}
+.btn-danger:hover {
+  background: var(--red-light);
+}
+.btn-sm {
+  padding: 0.3rem 0.65rem;
+  font-size: 0.8rem;
+}
 
 /* ── Form controls ── */
-.form-group { margin-bottom: 1rem; }
-.form-label { display: block; font-size: .875rem; font-weight: 500; color: var(--gray-700); margin-bottom: .35rem; }
-.form-hint { margin-top: .4rem; font-size: .8rem; color: var(--gray-600); line-height: 1.5; }
+.form-group {
+  margin-bottom: 1rem;
+}
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--gray-700);
+  margin-bottom: 0.35rem;
+}
+.form-hint {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--gray-600);
+  line-height: 1.5;
+}
 .form-control {
   width: 100%;
-  padding: .5rem .75rem;
+  padding: 0.5rem 0.75rem;
   border: 1px solid var(--gray-200);
   border-radius: 7px;
-  font-size: .875rem;
+  font-size: 0.875rem;
   background: #fff;
   color: var(--gray-900);
-  transition: border-color .15s;
+  transition: border-color 0.15s;
 }
-.form-control:focus { outline: none; border-color: var(--blue); box-shadow: 0 0 0 3px rgba(59,130,246,.15); }
-.form-control-sm { padding: .3rem .6rem; font-size: .8rem; }
+.form-control:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+.form-control-sm {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.8rem;
+}
 
 /* ── Table ── */
-.table-wrap { overflow-x: auto; }
-table { width: 100%; border-collapse: collapse; font-size: .875rem; }
-th { text-align: left; padding: .6rem .75rem; font-weight: 600; color: var(--gray-600); background: var(--gray-50); border-bottom: 1px solid var(--gray-200); }
-td { padding: .65rem .75rem; border-bottom: 1px solid var(--gray-100); color: var(--gray-700); }
-tr:last-child td { border-bottom: none; }
-tr:hover td { background: var(--gray-50); }
+.table-wrap {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+th {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  font-weight: 600;
+  color: var(--gray-600);
+  background: var(--gray-50);
+  border-bottom: 1px solid var(--gray-200);
+}
+td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--gray-100);
+  color: var(--gray-700);
+}
+tr:last-child td {
+  border-bottom: none;
+}
+tr:hover td {
+  background: var(--gray-50);
+}
 
 /* ── Tag list ── */
-.tag-list { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .5rem; }
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
 .tag {
   display: inline-flex;
   align-items: center;
-  gap: .3rem;
+  gap: 0.3rem;
   background: var(--gray-100);
   border-radius: 6px;
-  padding: .2rem .5rem;
-  font-size: .75rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
   color: var(--gray-700);
 }
 .tag-remove {
@@ -493,51 +667,92 @@ tr:hover td { background: var(--gray-50); }
   cursor: pointer;
   color: var(--gray-400);
   padding: 0;
-  font-size: .9rem;
+  font-size: 0.9rem;
   line-height: 1;
 }
-.tag-remove:hover { color: var(--red); }
+.tag-remove:hover {
+  color: var(--red);
+}
 
 /* ── Day picker ── */
-.day-picker { display: flex; gap: .3rem; }
+.day-picker {
+  display: flex;
+  gap: 0.3rem;
+}
 .day-btn {
-  width: 34px; height: 34px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   border: 1px solid var(--gray-200);
   background: #fff;
-  font-size: .78rem;
+  font-size: 0.78rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all .15s;
+  transition: all 0.15s;
   color: var(--gray-600);
 }
-.day-btn.selected { background: var(--blue); color: #fff; border-color: var(--blue); }
+.day-btn.selected {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
 
 /* ── Progress bar ── */
-.progress-bar { height: 6px; background: var(--gray-100); border-radius: 9999px; overflow: hidden; margin: .5rem 0; }
-.progress-fill { height: 100%; border-radius: 9999px; transition: width .4s; }
-.progress-fill.cooling { background: var(--blue); }
-.progress-fill.heating { background: var(--orange); }
+.progress-bar {
+  height: 6px;
+  background: var(--gray-100);
+  border-radius: 9999px;
+  overflow: hidden;
+  margin: 0.5rem 0;
+}
+.progress-fill {
+  height: 100%;
+  border-radius: 9999px;
+  transition: width 0.4s;
+}
+.progress-fill.cooling {
+  background: var(--blue);
+}
+.progress-fill.heating {
+  background: var(--orange);
+}
 
 /* ── Vent indicator ── */
 .vent-dot {
-  width: 10px; height: 10px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   display: inline-block;
 }
-.vent-dot.open  { background: var(--green); }
-.vent-dot.closed { background: var(--gray-400); }
-.vent-dot.unknown { background: var(--orange); }
+.vent-dot.open {
+  background: var(--green);
+}
+.vent-dot.closed {
+  background: var(--gray-400);
+}
+.vent-dot.unknown {
+  background: var(--orange);
+}
 
 /* ── Temp display ── */
-.temp-large { font-size: 2rem; font-weight: 700; color: var(--gray-900); }
-.temp-unit  { font-size: 1rem; color: var(--gray-400); }
+.temp-large {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+.temp-unit {
+  font-size: 1rem;
+  color: var(--gray-400);
+}
 
 /* ── Modal ── */
 .modal-backdrop {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,.4);
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 200;
 }
 .modal {
@@ -549,42 +764,103 @@ tr:hover td { background: var(--gray-50); }
   overflow-y: auto;
   box-shadow: var(--shadow-md);
 }
-.modal-title { font-size: 1.1rem; font-weight: 700; margin-bottom: 1rem; }
-.modal-footer { display: flex; gap: .5rem; justify-content: flex-end; margin-top: 1.25rem; }
+.modal-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+.modal-footer {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+}
 
 /* ── Misc ── */
-.empty-state { text-align: center; padding: 3rem 1rem; color: var(--gray-400); }
-.empty-state p { font-size: .95rem; }
-.divider { border: none; border-top: 1px solid var(--gray-100); margin: 1rem 0; }
-.flex { display: flex; }
-.flex-between { display: flex; align-items: center; justify-content: space-between; }
-.gap-sm { gap: .5rem; }
-.gap-md { gap: 1rem; }
-.mt-1 { margin-top: .5rem; }
-.mt-2 { margin-top: 1rem; }
-.text-sm { font-size: .875rem; }
-.text-muted { color: var(--gray-400); }
-.text-green { color: #15803d; }
-.text-blue { color: #1d4ed8; }
-.text-red { color: var(--red); }
-.font-mono { font-family: ui-monospace, monospace; font-size: .8rem; }
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--gray-400);
+}
+.empty-state p {
+  font-size: 0.95rem;
+}
+.divider {
+  border: none;
+  border-top: 1px solid var(--gray-100);
+  margin: 1rem 0;
+}
+.flex {
+  display: flex;
+}
+.flex-between {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.gap-sm {
+  gap: 0.5rem;
+}
+.gap-md {
+  gap: 1rem;
+}
+.mt-1 {
+  margin-top: 0.5rem;
+}
+.mt-2 {
+  margin-top: 1rem;
+}
+.text-sm {
+  font-size: 0.875rem;
+}
+.text-muted {
+  color: var(--gray-400);
+}
+.text-green {
+  color: #15803d;
+}
+.text-blue {
+  color: #1d4ed8;
+}
+.text-red {
+  color: var(--red);
+}
+.font-mono {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+}
 
 /* ── Loading spinner ── */
 .spinner {
   border: 2px solid var(--gray-200);
   border-top-color: var(--blue);
   border-radius: 50%;
-  width: 20px; height: 20px;
-  animation: spin .7s linear infinite;
+  width: 20px;
+  height: 20px;
+  animation: spin 0.7s linear infinite;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
-.loading { display: flex; align-items: center; gap: .75rem; padding: 2rem; color: var(--gray-600); }
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  color: var(--gray-600);
+}
 
 /* ── Inline entity picker ── */
-.entity-picker { position: relative; }
+.entity-picker {
+  position: relative;
+}
 .entity-dropdown {
   position: absolute;
-  top: 100%; left: 0; right: 0;
+  top: 100%;
+  left: 0;
+  right: 0;
   background: #fff;
   border: 1px solid var(--gray-200);
   border-radius: 7px;
@@ -594,58 +870,91 @@ tr:hover td { background: var(--gray-50); }
   box-shadow: var(--shadow-md);
 }
 .entity-option {
-  padding: .5rem .75rem;
+  padding: 0.5rem 0.75rem;
   cursor: pointer;
-  font-size: .85rem;
+  font-size: 0.85rem;
 }
-.entity-option:hover { background: var(--blue-light); }
-.entity-option .entity-id { font-family: ui-monospace, monospace; font-size: .78rem; color: var(--gray-600); }
+.entity-option:hover {
+  background: var(--blue-light);
+}
+.entity-option .entity-id {
+  font-family: ui-monospace, monospace;
+  font-size: 0.78rem;
+  color: var(--gray-600);
+}
 
 /* ── Tab bar ── */
-.tab-bar { display: flex; gap: .25rem; }
+.tab-bar {
+  display: flex;
+  gap: 0.25rem;
+}
 .tab-btn {
-  padding: .35rem .85rem;
+  padding: 0.35rem 0.85rem;
   border: 1px solid var(--gray-200);
   border-radius: 6px;
   background: white;
   color: var(--gray-600);
-  font-size: .875rem;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
-.tab-btn:hover { background: var(--gray-100); }
-.tab-btn.active { background: var(--blue-light); color: var(--blue); border-color: var(--blue); }
+.tab-btn:hover {
+  background: var(--gray-100);
+}
+.tab-btn.active {
+  background: var(--blue-light);
+  color: var(--blue);
+  border-color: var(--blue);
+}
 
 /* ── Event feed ── */
 .event-feed {
   max-height: calc(100vh - 220px);
   overflow-y: auto;
-  padding: .5rem;
+  padding: 0.5rem;
   font-family: ui-monospace, monospace;
-  font-size: .8rem;
+  font-size: 0.8rem;
 }
 .event-entry {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: .4rem;
-  padding: .3rem .5rem;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
   border-radius: 4px;
 }
-.event-entry:hover { background: var(--gray-50); }
-.event-ts { color: var(--gray-400); min-width: 5.5rem; }
-.event-level { font-weight: 700; min-width: 4rem; }
-.event-category { color: var(--gray-600); }
-.event-msg { color: var(--gray-900); flex: 1; }
-.event-expand { color: var(--gray-400); font-size: .7rem; }
+.event-entry:hover {
+  background: var(--gray-50);
+}
+.event-ts {
+  color: var(--gray-400);
+  min-width: 5.5rem;
+}
+.event-level {
+  font-weight: 700;
+  min-width: 4rem;
+}
+.event-category {
+  color: var(--gray-600);
+}
+.event-msg {
+  color: var(--gray-900);
+  flex: 1;
+}
+.event-expand {
+  color: var(--gray-400);
+  font-size: 0.7rem;
+}
 .event-details {
   width: 100%;
-  margin: .25rem 0 0 6rem;
-  padding: .5rem;
+  margin: 0.25rem 0 0 6rem;
+  padding: 0.5rem;
   background: var(--gray-100);
   border-radius: 4px;
-  font-size: .75rem;
+  font-size: 0.75rem;
   overflow-x: auto;
   white-space: pre;
 }

--- a/smart_vent/frontend/tsconfig.json
+++ b/smart_vent/frontend/tsconfig.json
@@ -12,8 +12,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Closes #13.

- Added ESLint v9 (flat config) and Prettier as dev dependencies, along with `typescript-eslint`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`, and `eslint-config-prettier`
- Created `eslint.config.js` and `.prettierrc` with the configuration specified in the issue
- Added `lint`, `lint:fix`, `format`, and `format:check` npm scripts
- Fixed all existing lint violations (`DAY_LABELS` unused in Dashboard, `autoScroll` unused in DevMode, `tick` unused value in Rooms)
- Ran Prettier over all source files to enforce consistent formatting
- Enabled `noUnusedLocals` and `noUnusedParameters` in `tsconfig.json`
- Added `frontend-lint` CI job to `.github/workflows/lint.yml` that runs `npm run lint` and `npm run format:check` on every push/PR to main

## Test plan

- [ ] `npm run lint` exits 0 (warnings only, no errors)
- [ ] `npm run format:check` exits 0 (all files formatted)
- [ ] CI `frontend-lint` job passes on this PR

https://claude.ai/code/session_01EH8bDeaRiXjjAn44YS7QXu