### PR TITLE
fix(engine): HVAC cycle engine audit — mode, setpoint, and duplicate cycle bugs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint & Test
 
 on:
   push:
@@ -19,6 +19,19 @@ jobs:
       - run: ruff check backend/
         working-directory: smart_vent
       - run: ruff format --check backend/
+        working-directory: smart_vent
+
+  python-test:
+    name: Python (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest pytest-asyncio aiosqlite aiohttp apscheduler
+        working-directory: smart_vent
+      - run: python -m pytest backend/tests/ -v
         working-directory: smart_vent
 
   frontend-lint:

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -593,6 +593,46 @@ async def close_open_cycle_logs(
     return count
 
 
+async def close_open_cycles_for_rooms(
+    conn: aiosqlite.Connection,
+    room_ids: list[str],
+    exclude_thermostat: str | None = None,
+    ended_at: datetime | None = None,
+) -> int:
+    """
+    Close any open cycle logs that contain one or more of the given room IDs.
+
+    Used to prevent the same room from appearing in two simultaneous cycles
+    (e.g. after a room is reassigned between thermostats).  The caller's own
+    thermostat can be excluded since its orphans are already cleaned up by
+    close_open_cycle_logs().  Returns the number of cycle logs closed.
+    (Issue #48 Bug 4)
+    """
+    if not room_ids:
+        return 0
+    if ended_at is None:
+        ended_at = datetime.utcnow()
+    placeholders = ",".join("?" for _ in room_ids)
+    query = (
+        "UPDATE cycle_logs SET ended_at=? "
+        "WHERE ended_at IS NULL "
+        "AND id IN ("
+        f"  SELECT DISTINCT cl.id FROM cycle_logs cl "
+        f"  JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id "
+        f"  WHERE cl.ended_at IS NULL AND rcs.room_id IN ({placeholders})"
+    )
+    params: list = [ended_at.isoformat()]
+    params.extend(room_ids)
+    if exclude_thermostat:
+        query += " AND cl.thermostat_entity_id != ?"
+        params.append(exclude_thermostat)
+    query += ")"
+    async with conn.execute(query, params) as cur:
+        count = cur.rowcount or 0
+    await conn.commit()
+    return count
+
+
 async def get_open_cycle_logs(
     conn: aiosqlite.Connection,
     thermostat_entity_id: str,

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -208,36 +208,57 @@ class CycleEngine:
             # so we fall through; for all other off modes, wait.
             return
 
+        # Fetch thermostat config (needed for mode inference and room filtering).
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+
+        # Determine the effective mode for this tick:
+        # - IDLE: infer from room temps (majority vote)
+        # - RUNNING: use the mode locked at cycle start
+        if self._state == CycleState.IDLE:
+            inferred = await self._infer_mode_from_room_temps(
+                new_active_map, tc.deadband, thermo_state
+            )
+            if inferred == "off":
+                # All rooms within deadband — reset setpoint to ambient so the HVAC
+                # goes idle, then skip starting a new cycle.
+                ambient = thermo_state.get("attributes", {}).get("current_temperature")
+                if ambient is not None:
+                    ambient_f = float(ambient)
+                    try:
+                        await self._ha.set_thermostat_temperature(
+                            self.thermostat_entity_id, ambient_f
+                        )
+                        self._last_setpoint_sent = ambient_f
+                    except Exception as exc:
+                        log.error("Failed to reset setpoint to ambient: %s", exc)
+                await self._maybe_reconcile(conn)
+                await self._maybe_broadcast()
+                return
+            effective_mode = inferred
+        else:
+            effective_mode = self._cycle_mode or hvac_mode
+
+        # Filter out rooms that need the opposite direction from the chosen
+        # cycle mode.  Without this, a cooling cycle with a minority of rooms
+        # needing heat would open those rooms' vents during cooling, driving
+        # them further from target.  (Issue #48 Bug 3)
+        new_active_map = await self._filter_rooms_for_mode(
+            new_active_map, effective_mode, tc.deadband, thermo_state
+        )
+
+        if not new_active_map:
+            if self._state != CycleState.IDLE:
+                await self._abort_cycle(conn, reason="no compatible rooms after filtering")
+            await self._maybe_reconcile(conn)
+            await self._maybe_broadcast()
+            return
+
         # If rooms changed, update and recompute setpoint.
         # For mid-cycle updates, preserve the original cycle direction so that a
         # momentary hvac_action="idle" (common on heat_cool thermostats) does not
         # flip the setpoint calculation to the wrong direction.
         rooms_changed = set(new_active_map) != set(self._active_rooms)
         if rooms_changed or self._state == CycleState.IDLE:
-            if self._state == CycleState.IDLE:
-                tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
-                inferred = await self._infer_mode_from_room_temps(
-                    new_active_map, tc.deadband, thermo_state
-                )
-                if inferred == "off":
-                    # All rooms within deadband — reset setpoint to ambient so the HVAC
-                    # goes idle, then skip starting a new cycle.
-                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
-                    if ambient is not None:
-                        ambient_f = float(ambient)
-                        try:
-                            await self._ha.set_thermostat_temperature(
-                                self.thermostat_entity_id, ambient_f
-                            )
-                            self._last_setpoint_sent = ambient_f
-                        except Exception as exc:
-                            log.error("Failed to reset setpoint to ambient: %s", exc)
-                    await self._maybe_reconcile(conn)
-                    await self._maybe_broadcast()
-                    return
-                effective_mode = inferred
-            else:
-                effective_mode = self._cycle_mode or hvac_mode
             await self._start_or_update_cycle(conn, new_active_map, effective_mode)
 
         # Monitor rooms using the mode locked at cycle start.  Live hvac_action
@@ -856,6 +877,90 @@ class CycleEngine:
                 inferred = corrected
 
         return inferred
+
+    async def _filter_rooms_for_mode(
+        self,
+        active_rooms: dict[str, ActiveRoom],
+        mode: str,
+        deadband: float,
+        thermo_state: dict | None,
+    ) -> dict[str, ActiveRoom]:
+        """Remove rooms that need the opposite direction from the cycle mode.
+
+        Rooms within deadband or needing the same direction are kept.  Rooms
+        with no sensor data are kept (benefit of the doubt).  (Issue #48 Bug 3)
+        """
+        thermo_ambient: float | None = None
+        if thermo_state:
+            t = thermo_state.get("attributes", {}).get("current_temperature")
+            if t is not None:
+                with contextlib.suppress(ValueError, TypeError):
+                    thermo_ambient = float(t)
+
+        filtered: dict[str, ActiveRoom] = {}
+        for room_id, ar in active_rooms.items():
+            avg = self._get_avg_temp(ar.room)
+            if avg is None:
+                avg = thermo_ambient
+            if avg is None:
+                # No data at all — include room (benefit of the doubt)
+                filtered[room_id] = ar
+                continue
+            effective = avg + ar.room.temp_offset
+            if mode == "cooling" and effective < ar.target_temp - deadband:
+                # Room needs heating but cycle is cooling — exclude
+                log.info(
+                    "Excluding room %s from cooling cycle — needs heating "
+                    "(effective=%.1f, target=%.1f, deadband=%.1f)",
+                    ar.room.name,
+                    effective,
+                    ar.target_temp,
+                    deadband,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Excluding room {ar.room.name} from cooling cycle — room needs "
+                        f"heating (effective={effective:.1f}°F, target={ar.target_temp}°F)",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room_id": room_id,
+                            "room_name": ar.room.name,
+                            "effective_temp": effective,
+                            "target_temp": ar.target_temp,
+                            "cycle_mode": mode,
+                        },
+                    )
+                continue
+            if mode == "heating" and effective > ar.target_temp + deadband:
+                # Room needs cooling but cycle is heating — exclude
+                log.info(
+                    "Excluding room %s from heating cycle — needs cooling "
+                    "(effective=%.1f, target=%.1f, deadband=%.1f)",
+                    ar.room.name,
+                    effective,
+                    ar.target_temp,
+                    deadband,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Excluding room {ar.room.name} from heating cycle — room needs "
+                        f"cooling (effective={effective:.1f}°F, target={ar.target_temp}°F)",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room_id": room_id,
+                            "room_name": ar.room.name,
+                            "effective_temp": effective,
+                            "target_temp": ar.target_temp,
+                            "cycle_mode": mode,
+                        },
+                    )
+                continue
+            filtered[room_id] = ar
+        return filtered
 
     def _get_avg_temp(self, room: Room) -> float | None:
         readings: list[float] = []

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -889,9 +889,73 @@ class CycleEngine:
         else:
             setpoint = max(targets) + tc.overshoot_delta
             ha_mode = "heat"
-        # No clamping: min/max_setpoint are repurposed as emergency thresholds (Bug 3).
-        # The overshoot setpoint is sent as-is; it is derived from room targets which
-        # are user-configured comfort values and don't need a safety rail here.
+
+        # Anchor setpoint to thermostat ambient so the HVAC always has a reason
+        # to run.  When room sensors diverge from the thermostat probe (e.g.
+        # thermostat in hallway reads 71°F, bedroom sensors read 80°F), the
+        # target-derived setpoint can land at or beyond ambient, causing the
+        # HVAC to see "already satisfied" and never activate.  Clamping
+        # guarantees the setpoint is strictly beyond the thermostat's own
+        # reading by at least overshoot_delta.  (Issue #48 Bug 1)
+        thermo_state = self._ha.get_state(self.thermostat_entity_id)
+        if thermo_state:
+            ambient_raw = thermo_state.get("attributes", {}).get("current_temperature")
+            if ambient_raw is not None:
+                try:
+                    ambient = float(ambient_raw)
+                    if hvac_mode == "cooling":
+                        ambient_bound = ambient - tc.overshoot_delta
+                        if setpoint > ambient_bound:
+                            log.info(
+                                "Clamping cooling setpoint %.1f→%.1f (ambient=%.1f, delta=%.1f)",
+                                setpoint,
+                                ambient_bound,
+                                ambient,
+                                tc.overshoot_delta,
+                            )
+                            if self._logger:
+                                await self._logger.log(
+                                    "info",
+                                    "engine",
+                                    f"Clamped cooling setpoint {setpoint:.1f}→{ambient_bound:.1f}°F "
+                                    f"(thermostat ambient={ambient:.1f}°F, overshoot_delta={tc.overshoot_delta})",
+                                    {
+                                        "thermostat": self.thermostat_entity_id,
+                                        "original_setpoint": setpoint,
+                                        "clamped_setpoint": ambient_bound,
+                                        "ambient": ambient,
+                                        "overshoot_delta": tc.overshoot_delta,
+                                    },
+                                )
+                            setpoint = ambient_bound
+                    else:
+                        ambient_bound = ambient + tc.overshoot_delta
+                        if setpoint < ambient_bound:
+                            log.info(
+                                "Clamping heating setpoint %.1f→%.1f (ambient=%.1f, delta=%.1f)",
+                                setpoint,
+                                ambient_bound,
+                                ambient,
+                                tc.overshoot_delta,
+                            )
+                            if self._logger:
+                                await self._logger.log(
+                                    "info",
+                                    "engine",
+                                    f"Clamped heating setpoint {setpoint:.1f}→{ambient_bound:.1f}°F "
+                                    f"(thermostat ambient={ambient:.1f}°F, overshoot_delta={tc.overshoot_delta})",
+                                    {
+                                        "thermostat": self.thermostat_entity_id,
+                                        "original_setpoint": setpoint,
+                                        "clamped_setpoint": ambient_bound,
+                                        "ambient": ambient,
+                                        "overshoot_delta": tc.overshoot_delta,
+                                    },
+                                )
+                            setpoint = ambient_bound
+                except (ValueError, TypeError):
+                    pass
+
         try:
             # Pass hvac_mode explicitly so heat_cool thermostats switch to the correct
             # single-direction mode. HA silently ignores temperature-only calls for

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -886,9 +886,29 @@ class CycleEngine:
         if hvac_mode == "cooling":
             setpoint = min(targets) - tc.overshoot_delta
             ha_mode = "cool"
-        else:
+        elif hvac_mode == "heating":
             setpoint = max(targets) + tc.overshoot_delta
             ha_mode = "heat"
+        else:
+            # Unexpected mode (e.g. "off", "unknown") — refuse to set a setpoint
+            # rather than silently defaulting to heat.  (Issue #48 Bug 2)
+            log.error(
+                "Refusing to set setpoint — unexpected hvac_mode %r for %s",
+                hvac_mode,
+                self.thermostat_entity_id,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "error",
+                    "engine",
+                    f"Refusing to set setpoint — unexpected hvac_mode {hvac_mode!r} "
+                    f"for {self.thermostat_entity_id}. Expected 'cooling' or 'heating'.",
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "hvac_mode": hvac_mode,
+                    },
+                )
+            return
 
         # Anchor setpoint to thermostat ambient so the HVAC always has a reason
         # to run.  When room sensors diverge from the thermostat probe (e.g.

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -265,7 +265,23 @@ class CycleEngine:
         # oscillates between "cooling"/"heating" and "idle" between HVAC bursts;
         # re-reading it each tick causes _is_at_target() to use the wrong
         # comparison direction during the idle phase (see issue #26).
-        await self._monitor_rooms(conn, self._cycle_mode or hvac_mode)
+        #
+        # Guard: if _cycle_mode is None during a running cycle (should not
+        # happen, but possible after a restore edge case), skip monitoring
+        # rather than falling back to hvac_mode which may be "off"/"unknown"
+        # and would cause _is_at_target to use the wrong comparison
+        # direction.  (Issue #48 Bug 6)
+        monitor_mode = self._cycle_mode or hvac_mode
+        if monitor_mode not in ("cooling", "heating"):
+            log.warning(
+                "Skipping room monitoring — no valid cycle mode "
+                "(cycle_mode=%r, hvac_mode=%r) for %s",
+                self._cycle_mode,
+                hvac_mode,
+                self.thermostat_entity_id,
+            )
+        else:
+            await self._monitor_rooms(conn, monitor_mode)
 
         # Check cycle timeout
         if self._cycle_log and self._state == CycleState.RUNNING:
@@ -1584,5 +1600,9 @@ class CycleEngine:
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str, deadband: float) -> bool:
     if hvac_mode == "cooling":
         return avg_temp <= target_temp + deadband
-    else:  # heating
+    if hvac_mode == "heating":
         return avg_temp >= target_temp - deadband
+    # Unexpected mode — return False (not at target) so vents stay open
+    # rather than closing prematurely.  (Issue #48 Bug 6)
+    log.warning("_is_at_target called with unexpected mode %r — returning False", hvac_mode)
+    return False

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -340,6 +340,36 @@ class CycleEngine:
                         },
                     )
 
+            # Close open cycles on OTHER thermostats that contain any of the
+            # rooms we're about to include.  This prevents the same room from
+            # appearing in two simultaneous cycles (e.g. after a room is
+            # reassigned between thermostats).  (Issue #48 Bug 4)
+            incoming_room_ids = list(new_active_map.keys())
+            cross_closed = await db.close_open_cycles_for_rooms(
+                conn,
+                incoming_room_ids,
+                exclude_thermostat=self.thermostat_entity_id,
+            )
+            if cross_closed > 0:
+                log.warning(
+                    "Closed %d open cycle(s) on other thermostats containing rooms %s",
+                    cross_closed,
+                    incoming_room_ids,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "warning",
+                        "engine",
+                        f"Closed {cross_closed} open cycle(s) on other thermostats "
+                        f"that contained rooms being added to new cycle on "
+                        f"{self.thermostat_entity_id}",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "cross_closed_count": cross_closed,
+                            "room_ids": incoming_room_ids,
+                        },
+                    )
+
             # Start a fresh cycle
             rooms_snapshot = {
                 ar.room.id: {

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1,12 +1,15 @@
 """
-Tests for the HVAC cycle engine — covering bugs from issue #48.
+Tests for the HVAC cycle engine.
 
-Each test targets a specific bug fix to prevent regressions:
-  Bug 1: Setpoint clamped against thermostat ambient
-  Bug 2: Reject unexpected hvac_mode in setpoint calculation
-  Bug 3: Filter opposite-direction rooms from cycle
-  Bug 4: Cross-thermostat duplicate cycle prevention (DB level)
-  Bug 6: _is_at_target and _monitor_rooms guard against invalid modes
+Covers:
+  - Issue #48 bug-fix regressions (Bugs 1–6)
+  - _read_hvac_mode: HA state interpretation
+  - _infer_mode_from_room_temps: majority vote, sensor fallback, ambient sanity
+  - _get_avg_temp: sensor aggregation, thermostat sensor inclusion
+  - Setpoint multi-room target selection (min for cooling, max for heating)
+  - _is_at_target: deadband boundary precision
+  - _filter_rooms_for_mode: temp_offset handling
+  - Cross-thermostat duplicate cycle prevention (DB level)
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiosqlite
 import pytest
 
-from backend.engine.cycle_engine import CycleEngine, _is_at_target
+from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
 from backend.engine.room_manager import ActiveRoom
 from backend.engine.vent_controller import VentController
 from backend.models import (
@@ -470,3 +473,417 @@ class TestIsAtTarget:
     def test_unknown_mode_returns_false(self):
         """Unexpected mode 'unknown' should return False."""
         assert _is_at_target(74.0, 74.0, "unknown", 0.5) is False
+
+    def test_cooling_exact_boundary(self):
+        """Cooling at exactly target+deadband → at target (inclusive)."""
+        assert _is_at_target(74.5, 74.0, "cooling", 0.5) is True
+
+    def test_cooling_just_above_boundary(self):
+        """Cooling just above target+deadband → not at target."""
+        assert _is_at_target(74.6, 74.0, "cooling", 0.5) is False
+
+    def test_heating_exact_boundary(self):
+        """Heating at exactly target-deadband → at target (inclusive)."""
+        assert _is_at_target(73.5, 74.0, "heating", 0.5) is True
+
+    def test_heating_just_below_boundary(self):
+        """Heating just below target-deadband → not at target."""
+        assert _is_at_target(73.4, 74.0, "heating", 0.5) is False
+
+    def test_zero_deadband(self):
+        """Deadband of 0: must hit target exactly."""
+        assert _is_at_target(74.0, 74.0, "cooling", 0.0) is True
+        assert _is_at_target(74.1, 74.0, "cooling", 0.0) is False
+        assert _is_at_target(74.0, 74.0, "heating", 0.0) is True
+        assert _is_at_target(73.9, 74.0, "heating", 0.0) is False
+
+
+# ---------------------------------------------------------------------------
+# _read_hvac_mode
+# ---------------------------------------------------------------------------
+
+
+class TestReadHvacMode:
+    """_read_hvac_mode interprets HA thermostat state correctly."""
+
+    def test_action_heating_returns_heating(self):
+        ha = _make_ha(hvac_mode="heat", hvac_action="heating")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "heating"
+
+    def test_action_cooling_returns_cooling(self):
+        ha = _make_ha(hvac_mode="cool", hvac_action="cooling")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "cooling"
+
+    def test_action_idle_mode_heat_returns_heating(self):
+        """Single-direction mode 'heat' with idle action → heating."""
+        ha = _make_ha(hvac_mode="heat", hvac_action="idle")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "heating"
+
+    def test_action_idle_mode_cool_returns_cooling(self):
+        """Single-direction mode 'cool' with idle action → cooling."""
+        ha = _make_ha(hvac_mode="cool", hvac_action="idle")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "cooling"
+
+    def test_action_idle_mode_heat_cool_returns_off(self):
+        """heat_cool mode with idle action → off (direction unknown)."""
+        ha = _make_ha(hvac_mode="heat_cool", hvac_action="idle")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "off"
+
+    def test_mode_off_returns_off(self):
+        ha = _make_ha(hvac_mode="off", hvac_action="off")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "off"
+
+    def test_no_state_returns_unknown(self):
+        ha = _make_ha()
+        ha.get_state.return_value = None
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "unknown"
+
+    def test_action_takes_priority_over_mode(self):
+        """hvac_action 'cooling' overrides hvac_mode 'heat'."""
+        ha = _make_ha(hvac_mode="heat", hvac_action="cooling")
+        engine = _make_engine(ha)
+        assert engine._read_hvac_mode() == "cooling"
+
+
+# ---------------------------------------------------------------------------
+# _infer_mode_from_room_temps
+# ---------------------------------------------------------------------------
+
+
+class TestInferMode:
+    """Mode inference: majority vote, fallback, sanity check."""
+
+    @pytest.mark.asyncio
+    async def test_all_rooms_need_cooling(self):
+        ha = _make_ha(ambient=78.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
+        ha.get_numeric_state.side_effect = lambda eid: {"s1": 80.0, "s2": 79.0}.get(eid)
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_all_rooms_need_heating(self):
+        ha = _make_ha(ambient=68.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
+        ha.get_numeric_state.side_effect = lambda eid: {"s1": 65.0, "s2": 66.0}.get(eid)
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "heating"
+
+    @pytest.mark.asyncio
+    async def test_all_rooms_within_deadband_returns_off(self):
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 74.2
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "off"
+
+    @pytest.mark.asyncio
+    async def test_mixed_rooms_majority_wins(self):
+        """2 rooms need cooling, 1 needs heating → cooling."""
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"], "r2": ["s2"], "r3": ["s3"]}
+        ha.get_numeric_state.side_effect = lambda eid: {
+            "s1": 80.0,  # needs cool
+            "s2": 79.0,  # needs cool
+            "s3": 65.0,  # needs heat
+        }.get(eid)
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=74.0, source="schedule"),
+            "r3": ActiveRoom(room=_make_room("r3"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_tie_goes_to_cooling(self):
+        """Equal cool/heat votes → cooling wins."""
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
+        ha.get_numeric_state.side_effect = lambda eid: {
+            "s1": 80.0,  # needs cool
+            "s2": 65.0,  # needs heat
+        }.get(eid)
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_sensor_fallback_uses_thermostat_ambient(self):
+        """Room with no sensor data uses thermostat ambient as proxy."""
+        ha = _make_ha(ambient=80.0)  # ambient says hot
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": []}  # no sensors
+        ha.get_numeric_state.return_value = None
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        # 80 > 74 + 0.5 → needs cooling
+        assert result == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_ambient_sanity_check_flips_mode(self):
+        """Room sensors vote heating but thermostat ambient contradicts → cooling."""
+        ha = _make_ha(ambient=85.0)  # thermostat says very hot
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        # Sensor says cold (stale/misplaced), votes heating
+        ha.get_numeric_state.return_value = 65.0
+
+        rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        # Sensor vote: 65 < 74-0.5 → heating
+        # Sanity: ambient 85 > max(targets) + deadband = 74.5 → contradicts → flip to cooling
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "cooling"
+
+
+# ---------------------------------------------------------------------------
+# _get_avg_temp
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvgTemp:
+    """Temperature aggregation from sensors and thermostat."""
+
+    def test_single_sensor(self):
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["sensor.r1_temp"]}
+        ha.get_numeric_state.return_value = 75.0
+
+        room = _make_room("r1")
+        assert engine._get_avg_temp(room) == 75.0
+
+    def test_multiple_sensors_averaged(self):
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1", "s2"]}
+        ha.get_numeric_state.side_effect = lambda eid: {"s1": 70.0, "s2": 80.0}.get(eid)
+
+        room = _make_room("r1")
+        assert engine._get_avg_temp(room) == 75.0
+
+    def test_include_thermostat_sensor(self):
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 78.0
+
+        room = _make_room("r1")
+        room.include_thermostat_sensor = True
+        # Sensor=78, thermostat=72 → avg = (78+72)/2 = 75
+        assert engine._get_avg_temp(room) == 75.0
+
+    def test_no_sensors_no_thermostat_returns_none(self):
+        ha = _make_ha()
+        ha.get_state.return_value = None
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": []}
+
+        room = _make_room("r1")
+        assert engine._get_avg_temp(room) is None
+
+    def test_unavailable_sensors_skipped(self):
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1", "s2"]}
+        ha.get_numeric_state.side_effect = lambda eid: {"s1": 76.0, "s2": None}.get(eid)
+
+        room = _make_room("r1")
+        # Only s1 has data → 76.0
+        assert engine._get_avg_temp(room) == 76.0
+
+
+# ---------------------------------------------------------------------------
+# Setpoint multi-room target selection
+# ---------------------------------------------------------------------------
+
+
+class TestSetpointTargetSelection:
+    """Correct target selection: min(targets) for cooling, max(targets) for heating."""
+
+    @pytest.mark.asyncio
+    async def test_cooling_uses_min_target(self):
+        """Cooling setpoint derived from min(targets) - overshoot."""
+        ha = _make_ha(ambient=80.0)
+        engine = _make_engine(ha)
+        tc = _make_tc(overshoot_delta=2.0)
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=76.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        setpoint = call_args[0][1]
+        # min(74, 76) - 2 = 72
+        assert setpoint == 72.0
+
+    @pytest.mark.asyncio
+    async def test_heating_uses_max_target(self):
+        """Heating setpoint derived from max(targets) + overshoot."""
+        ha = _make_ha(ambient=60.0)
+        engine = _make_engine(ha)
+        tc = _make_tc(overshoot_delta=2.0)
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "heating")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        setpoint = call_args[0][1]
+        # max(72, 74) + 2 = 76
+        assert setpoint == 76.0
+
+    @pytest.mark.asyncio
+    async def test_empty_rooms_skips_setpoint(self):
+        """No active rooms → no setpoint call."""
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        engine._active_rooms = {}
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        ha.set_thermostat_temperature.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cooling_sends_cool_ha_mode(self):
+        """Cooling sends ha_mode='cool' to HA."""
+        ha = _make_ha(ambient=80.0)
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        assert call_args[1].get("hvac_mode") == "cool" or call_args[0][2] == "cool"
+
+    @pytest.mark.asyncio
+    async def test_heating_sends_heat_ha_mode(self):
+        """Heating sends ha_mode='heat' to HA."""
+        ha = _make_ha(ambient=60.0)
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "heating")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        assert call_args[1].get("hvac_mode") == "heat" or call_args[0][2] == "heat"
+
+
+# ---------------------------------------------------------------------------
+# _filter_rooms_for_mode: temp_offset handling
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRoomsTempOffset:
+    """Temp offset affects filtering correctly."""
+
+    @pytest.mark.asyncio
+    async def test_positive_offset_shifts_effective_temp_up(self):
+        """Room with positive offset: effective = avg + offset."""
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        # Room sensor reads 73, offset +2 → effective = 75
+        # Target 74, deadband 0.5 → 75 > 74.5 → needs cooling → keep in cooling cycle
+        room = _make_room("r1", temp_offset=2.0)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 73.0
+
+        active = {"r1": ActiveRoom(room=room, target_temp=74.0, source="schedule")}
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "cooling", 0.5, thermo)
+        assert "r1" in result
+
+    @pytest.mark.asyncio
+    async def test_negative_offset_shifts_effective_temp_down(self):
+        """Room with negative offset: effective = avg + offset."""
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        # Room sensor reads 75, offset -3 → effective = 72
+        # Target 74, deadband 0.5 → 72 < 73.5 → needs heating → exclude from cooling
+        room = _make_room("r1", temp_offset=-3.0)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 75.0
+
+        active = {"r1": ActiveRoom(room=room, target_temp=74.0, source="schedule")}
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "cooling", 0.5, thermo)
+        assert "r1" not in result
+
+
+# ---------------------------------------------------------------------------
+# Engine state properties
+# ---------------------------------------------------------------------------
+
+
+class TestEngineStateProperties:
+    """Basic engine state accessors."""
+
+    def test_initial_state_is_idle(self):
+        engine = _make_engine()
+        assert engine.cycle_state == CycleState.IDLE
+
+    def test_current_cycle_id_none_when_idle(self):
+        engine = _make_engine()
+        assert engine.current_cycle_id is None
+
+    def test_get_zone_status_idle(self):
+        ha = _make_ha(ambient=72.0, hvac_mode="cool", hvac_action="idle")
+        engine = _make_engine(ha)
+        status = engine.get_zone_status()
+        assert status.thermostat_entity_id == THERMO_ID
+        assert status.cycle_id is None
+        assert status.hvac_action == "idle"

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -11,25 +11,21 @@ Each test targets a specific bug fix to prevent regressions:
 
 from __future__ import annotations
 
-import asyncio
 import json
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
 import pytest
 
-from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
+from backend.engine.cycle_engine import CycleEngine, _is_at_target
 from backend.engine.room_manager import ActiveRoom
 from backend.engine.vent_controller import VentController
 from backend.models import (
     CycleLog,
     Room,
     RoomCycleState,
-    RoomVent,
     ThermostatConfig,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1,0 +1,476 @@
+"""
+Tests for the HVAC cycle engine — covering bugs from issue #48.
+
+Each test targets a specific bug fix to prevent regressions:
+  Bug 1: Setpoint clamped against thermostat ambient
+  Bug 2: Reject unexpected hvac_mode in setpoint calculation
+  Bug 3: Filter opposite-direction rooms from cycle
+  Bug 4: Cross-thermostat duplicate cycle prevention (DB level)
+  Bug 6: _is_at_target and _monitor_rooms guard against invalid modes
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
+from backend.engine.room_manager import ActiveRoom
+from backend.engine.vent_controller import VentController
+from backend.models import (
+    CycleLog,
+    Room,
+    RoomCycleState,
+    RoomVent,
+    ThermostatConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+THERMO_ID = "climate.test_thermostat"
+
+
+def _make_ha(
+    ambient: float = 72.0,
+    hvac_mode: str = "cool",
+    hvac_action: str = "cooling",
+) -> MagicMock:
+    """Build a mock HAClient with a thermostat state in the cache."""
+    ha = MagicMock()
+    ha.get_state.return_value = {
+        "state": hvac_mode,
+        "attributes": {
+            "current_temperature": ambient,
+            "temperature": ambient,
+            "hvac_action": hvac_action,
+        },
+    }
+    ha.get_numeric_state.return_value = None
+    ha.set_thermostat_temperature = AsyncMock()
+    ha.open_cover = AsyncMock()
+    ha.close_cover = AsyncMock()
+    return ha
+
+
+def _make_room(
+    room_id: str = "room1",
+    name: str = "Bedroom",
+    temp_offset: float = 0.0,
+) -> Room:
+    return Room(
+        id=room_id,
+        name=name,
+        thermostat_entity_id=THERMO_ID,
+        temp_offset=temp_offset,
+    )
+
+
+def _make_tc(**overrides) -> ThermostatConfig:
+    defaults = {
+        "thermostat_entity_id": THERMO_ID,
+        "overshoot_delta": 2.0,
+        "deadband": 0.5,
+        "min_open_vents": 1,
+        "min_setpoint": 60.0,
+        "max_setpoint": 85.0,
+    }
+    defaults.update(overrides)
+    return ThermostatConfig(**defaults)
+
+
+def _make_engine(ha: MagicMock | None = None) -> CycleEngine:
+    if ha is None:
+        ha = _make_ha()
+    vent_ctrl = VentController(ha)
+    return CycleEngine(
+        thermostat_entity_id=THERMO_ID,
+        ha=ha,
+        vent_ctrl=vent_ctrl,
+        get_enabled=lambda: True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: Setpoint clamped against thermostat ambient
+# ---------------------------------------------------------------------------
+
+
+class TestSetpointAmbientClamping:
+    """_set_thermostat_setpoint must clamp setpoint beyond ambient."""
+
+    @pytest.mark.asyncio
+    async def test_cooling_setpoint_clamped_when_above_ambient(self):
+        """Cooling: setpoint should be <= ambient - overshoot_delta."""
+        ha = _make_ha(ambient=71.0)
+        engine = _make_engine(ha)
+        tc = _make_tc(overshoot_delta=2.0)
+
+        # Room target 74 → unclamped setpoint = 74 - 2 = 72, but ambient is 71
+        # so clamp to 71 - 2 = 69
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        setpoint = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]["temperature"]
+        assert setpoint == 69.0, f"Expected 69.0, got {setpoint}"
+
+    @pytest.mark.asyncio
+    async def test_heating_setpoint_clamped_when_below_ambient(self):
+        """Heating: setpoint should be >= ambient + overshoot_delta."""
+        ha = _make_ha(ambient=75.0)
+        engine = _make_engine(ha)
+        tc = _make_tc(overshoot_delta=2.0)
+
+        # Room target 72 → unclamped setpoint = 72 + 2 = 74, but ambient is 75
+        # so clamp to 75 + 2 = 77
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "heating")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        setpoint = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]["temperature"]
+        assert setpoint == 77.0, f"Expected 77.0, got {setpoint}"
+
+    @pytest.mark.asyncio
+    async def test_no_clamping_when_setpoint_already_beyond_ambient(self):
+        """No clamping needed when target-derived setpoint is already correct."""
+        ha = _make_ha(ambient=80.0)
+        engine = _make_engine(ha)
+        tc = _make_tc(overshoot_delta=2.0)
+
+        # Room target 74 → setpoint = 74 - 2 = 72, ambient 80 → 72 < 80 - 2 = 78 ✓
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        call_args = ha.set_thermostat_temperature.call_args
+        setpoint = call_args[0][1] if len(call_args[0]) > 1 else call_args[1]["temperature"]
+        assert setpoint == 72.0, f"Expected 72.0, got {setpoint}"
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: Reject unexpected hvac_mode in setpoint
+# ---------------------------------------------------------------------------
+
+
+class TestSetpointModeRejection:
+    """_set_thermostat_setpoint must reject unexpected mode values."""
+
+    @pytest.mark.asyncio
+    async def test_off_mode_rejected(self):
+        """Mode 'off' should not set a setpoint (no HA call)."""
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "off")
+
+        ha.set_thermostat_temperature.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_mode_rejected(self):
+        """Mode 'unknown' should not set a setpoint (no HA call)."""
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "unknown")
+
+        ha.set_thermostat_temperature.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cooling_mode_accepted(self):
+        """Mode 'cooling' should set a setpoint."""
+        ha = _make_ha(ambient=80.0)
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        ha.set_thermostat_temperature.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_heating_mode_accepted(self):
+        """Mode 'heating' should set a setpoint."""
+        ha = _make_ha(ambient=65.0)
+        engine = _make_engine(ha)
+        tc = _make_tc()
+        room = _make_room()
+        engine._active_rooms = {
+            "room1": ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+        }
+
+        await engine._set_thermostat_setpoint(tc, "heating")
+
+        ha.set_thermostat_temperature.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: Filter opposite-direction rooms from cycle
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRoomsForMode:
+    """_filter_rooms_for_mode should exclude rooms needing the opposite direction."""
+
+    @pytest.mark.asyncio
+    async def test_cooling_excludes_rooms_needing_heat(self):
+        """In a cooling cycle, rooms below target-deadband are excluded."""
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+
+        room_cool = _make_room("r1", "Hot Room")
+        room_heat = _make_room("r2", "Cold Room")
+        active = {
+            "r1": ActiveRoom(room=room_cool, target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=room_heat, target_temp=74.0, source="schedule"),
+        }
+
+        # Mock sensor readings: r1=78 (needs cooling), r2=70 (needs heating)
+        def get_numeric(eid):
+            return None
+
+        ha.get_numeric_state.side_effect = get_numeric
+
+        # Use thermostat ambient as proxy (72) for both rooms since no sensors
+        # With ambient=72, target=74, deadband=0.5:
+        # - effective=72 vs target-deadband=73.5 → 72 < 73.5 → needs heat → excluded
+        # All rooms use the same ambient fallback so both would be excluded or kept
+        # Let's set up with actual sensor map instead
+        engine._sensor_map = {"r1": ["sensor.r1"], "r2": ["sensor.r2"]}
+
+        def get_numeric_state(eid):
+            if eid == "sensor.r1":
+                return 78.0  # needs cooling
+            if eid == "sensor.r2":
+                return 70.0  # needs heating (below 74 - 0.5)
+            return None
+
+        ha.get_numeric_state.side_effect = get_numeric_state
+
+        thermo_state = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "cooling", 0.5, thermo_state)
+
+        assert "r1" in result, "Hot room should be kept in cooling cycle"
+        assert "r2" not in result, "Cold room should be excluded from cooling cycle"
+
+    @pytest.mark.asyncio
+    async def test_heating_excludes_rooms_needing_cool(self):
+        """In a heating cycle, rooms above target+deadband are excluded."""
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+
+        room_heat = _make_room("r1", "Cold Room")
+        room_cool = _make_room("r2", "Hot Room")
+        active = {
+            "r1": ActiveRoom(room=room_heat, target_temp=74.0, source="schedule"),
+            "r2": ActiveRoom(room=room_cool, target_temp=74.0, source="schedule"),
+        }
+
+        engine._sensor_map = {"r1": ["sensor.r1"], "r2": ["sensor.r2"]}
+
+        def get_numeric_state(eid):
+            if eid == "sensor.r1":
+                return 70.0  # needs heating
+            if eid == "sensor.r2":
+                return 80.0  # needs cooling (above 74 + 0.5)
+            return None
+
+        ha.get_numeric_state.side_effect = get_numeric_state
+
+        thermo_state = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "heating", 0.5, thermo_state)
+
+        assert "r1" in result, "Cold room should be kept in heating cycle"
+        assert "r2" not in result, "Hot room should be excluded from heating cycle"
+
+    @pytest.mark.asyncio
+    async def test_within_deadband_rooms_kept(self):
+        """Rooms within deadband are kept regardless of mode."""
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+
+        room = _make_room("r1", "Neutral Room")
+        active = {
+            "r1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+        engine._sensor_map = {"r1": ["sensor.r1"]}
+        ha.get_numeric_state.return_value = 74.2  # within deadband of 0.5
+
+        thermo_state = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "cooling", 0.5, thermo_state)
+
+        assert "r1" in result, "Room within deadband should be kept"
+
+    @pytest.mark.asyncio
+    async def test_no_sensor_data_rooms_kept(self):
+        """Rooms with no sensor data are kept (benefit of the doubt)."""
+        ha = _make_ha()
+        # Return None for thermostat state too → no ambient fallback
+        ha.get_state.return_value = None
+        engine = _make_engine(ha)
+
+        room = _make_room("r1", "No Sensors")
+        active = {
+            "r1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+        }
+        engine._sensor_map = {"r1": []}
+
+        result = await engine._filter_rooms_for_mode(active, "cooling", 0.5, None)
+
+        assert "r1" in result, "Room with no data should be kept"
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: Cross-thermostat duplicate cycle prevention (DB)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossThermoDuplicatePrevention:
+    """close_open_cycles_for_rooms should close cycles on other thermostats."""
+
+    @pytest.mark.asyncio
+    async def test_closes_cycle_on_other_thermostat(self):
+        """A room in an open cycle on thermostat A is cleaned up when thermostat B starts."""
+        from backend import db
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        # Insert the room record (FK target for room_cycle_states)
+        room = Room.create(name="Room 1", thermostat_entity_id="climate.thermo_a")
+        room.id = "room1"
+        await db.upsert_room(conn, room)
+
+        # Insert an open cycle on thermostat A containing room1
+        cycle_a = CycleLog.create(
+            thermostat_entity_id="climate.thermo_a",
+            mode="cooling",
+            rooms_json=json.dumps({"room1": {"name": "Room 1", "target": 74.0}}),
+        )
+        await db.insert_cycle_log(conn, cycle_a)
+        rcs = RoomCycleState(cycle_id=cycle_a.id, room_id="room1", target_temp=74.0)
+        await db.upsert_room_cycle_state(conn, rcs)
+
+        # Close cycles for room1 on other thermostats (excluding thermo_b)
+        closed = await db.close_open_cycles_for_rooms(
+            conn, ["room1"], exclude_thermostat="climate.thermo_b"
+        )
+
+        assert closed == 1, f"Expected 1 cycle closed, got {closed}"
+
+        # Verify cycle A is now closed
+        open_logs = await db.get_open_cycle_logs(conn, "climate.thermo_a")
+        assert len(open_logs) == 0, "Cycle A should be closed"
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_does_not_close_own_thermostat(self):
+        """Cycles on the excluded thermostat should not be closed."""
+        from backend import db
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        # Insert the room record (FK target for room_cycle_states)
+        room = Room.create(name="Room 1", thermostat_entity_id="climate.thermo_a")
+        room.id = "room1"
+        await db.upsert_room(conn, room)
+
+        # Insert an open cycle on thermostat A
+        cycle_a = CycleLog.create(
+            thermostat_entity_id="climate.thermo_a",
+            mode="cooling",
+            rooms_json=json.dumps({"room1": {"name": "Room 1", "target": 74.0}}),
+        )
+        await db.insert_cycle_log(conn, cycle_a)
+        rcs = RoomCycleState(cycle_id=cycle_a.id, room_id="room1", target_temp=74.0)
+        await db.upsert_room_cycle_state(conn, rcs)
+
+        # Try to close, but exclude thermo_a (our own thermostat)
+        closed = await db.close_open_cycles_for_rooms(
+            conn, ["room1"], exclude_thermostat="climate.thermo_a"
+        )
+
+        assert closed == 0, "Should not close own thermostat's cycle"
+
+        open_logs = await db.get_open_cycle_logs(conn, "climate.thermo_a")
+        assert len(open_logs) == 1, "Cycle A should still be open"
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_room_ids_noop(self):
+        """Passing no room IDs should be a no-op."""
+        from backend import db
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        closed = await db.close_open_cycles_for_rooms(conn, [])
+        assert closed == 0
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Bug 6: _is_at_target and monitor mode guard
+# ---------------------------------------------------------------------------
+
+
+class TestIsAtTarget:
+    """_is_at_target must handle modes explicitly."""
+
+    def test_cooling_at_target(self):
+        assert _is_at_target(73.0, 74.0, "cooling", 0.5) is True  # 73 <= 74.5
+
+    def test_cooling_not_at_target(self):
+        assert _is_at_target(76.0, 74.0, "cooling", 0.5) is False  # 76 > 74.5
+
+    def test_heating_at_target(self):
+        assert _is_at_target(74.0, 74.0, "heating", 0.5) is True  # 74 >= 73.5
+
+    def test_heating_not_at_target(self):
+        assert _is_at_target(72.0, 74.0, "heating", 0.5) is False  # 72 < 73.5
+
+    def test_off_mode_returns_false(self):
+        """Unexpected mode 'off' should return False (safe — vents stay open)."""
+        assert _is_at_target(74.0, 74.0, "off", 0.5) is False
+
+    def test_unknown_mode_returns_false(self):
+        """Unexpected mode 'unknown' should return False."""
+        assert _is_at_target(74.0, 74.0, "unknown", 0.5) is False

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -1,0 +1,487 @@
+"""
+Tests for the room manager module.
+
+Covers:
+  - _schedule_active: daytime and overnight schedule matching
+  - _find_matching_schedule: best match selection
+  - schedules_overlap: interval overlap detection
+  - get_active_rooms / _resolve_room: priority resolution
+  - handle_presence_event: holdover creation and reset
+  - expire_holdovers: cleanup of expired states
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.engine.room_manager import (
+    _find_matching_schedule,
+    _schedule_active,
+    expire_holdovers,
+    get_active_rooms,
+    handle_presence_event,
+    schedules_overlap,
+)
+from backend.models import (
+    Room,
+    RoomOverride,
+    Schedule,
+    ThermostatConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+THERMO_ID = "climate.test_thermostat"
+
+
+def _make_schedule(
+    room_id: str = "room1",
+    days: list[int] | None = None,
+    start: time = time(8, 0),
+    end: time = time(17, 0),
+    target: float = 74.0,
+    sid: str = "sched1",
+) -> Schedule:
+    if days is None:
+        days = [0, 1, 2, 3, 4]  # Mon-Fri
+    return Schedule(
+        id=sid,
+        room_id=room_id,
+        days_of_week=days,
+        start_time=start,
+        end_time=end,
+        target_temp=target,
+    )
+
+
+async def _setup_db() -> aiosqlite.Connection:
+    """Create an in-memory DB with schema initialized."""
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _insert_room(
+    conn: aiosqlite.Connection,
+    room_id: str = "room1",
+    name: str = "Test Room",
+    thermo: str = THERMO_ID,
+    presence_hours: float = 2.0,
+    system_wide_temp: float | None = None,
+) -> Room:
+    room = Room(
+        id=room_id,
+        name=name,
+        thermostat_entity_id=thermo,
+        presence_holdover_hours=presence_hours,
+        system_wide_temp=system_wide_temp,
+    )
+    await db.upsert_room(conn, room)
+    return room
+
+
+# ---------------------------------------------------------------------------
+# _schedule_active: daytime blocks
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleActiveDaytime:
+    """Normal daytime schedule blocks (end > start)."""
+
+    def test_within_window(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        assert _schedule_active(s, 0, time(12, 0)) is True
+
+    def test_before_window(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        assert _schedule_active(s, 0, time(7, 59)) is False
+
+    def test_at_start_boundary(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        assert _schedule_active(s, 0, time(8, 0)) is True
+
+    def test_at_end_boundary(self):
+        """End time is exclusive: [start, end)."""
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        assert _schedule_active(s, 0, time(17, 0)) is False
+
+    def test_wrong_day(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])  # Monday only
+        assert _schedule_active(s, 1, time(12, 0)) is False  # Tuesday
+
+
+# ---------------------------------------------------------------------------
+# _schedule_active: overnight blocks
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleActiveOvernight:
+    """Overnight schedule blocks where end_time <= start_time."""
+
+    def test_evening_portion(self):
+        """21:00→07:00: active at 23:00 on the scheduled day."""
+        s = _make_schedule(start=time(21, 0), end=time(7, 0), days=[0])
+        assert _schedule_active(s, 0, time(23, 0)) is True
+
+    def test_morning_portion(self):
+        """21:00→07:00: active at 05:00 on the next day (yesterday=Mon is in days)."""
+        s = _make_schedule(start=time(21, 0), end=time(7, 0), days=[0])
+        # Tuesday (day=1), yesterday=Monday(0) which is in days
+        assert _schedule_active(s, 1, time(5, 0)) is True
+
+    def test_morning_wrong_yesterday(self):
+        """21:00→07:00: not active at 05:00 if yesterday is not in days."""
+        s = _make_schedule(start=time(21, 0), end=time(7, 0), days=[0])
+        # Wednesday (day=2), yesterday=Tuesday(1) not in days
+        assert _schedule_active(s, 2, time(5, 0)) is False
+
+    def test_gap_between_portions(self):
+        """21:00→07:00: not active at 12:00 (daytime gap)."""
+        s = _make_schedule(start=time(21, 0), end=time(7, 0), days=[0])
+        assert _schedule_active(s, 0, time(12, 0)) is False
+
+    def test_at_end_boundary_overnight(self):
+        """End time is exclusive for overnight too."""
+        s = _make_schedule(start=time(21, 0), end=time(7, 0), days=[0])
+        assert _schedule_active(s, 1, time(7, 0)) is False
+
+    def test_sunday_to_monday_wraparound(self):
+        """Sunday 22:00→06:00: morning portion active on Monday."""
+        s = _make_schedule(start=time(22, 0), end=time(6, 0), days=[6])  # Sunday
+        # Monday (day=0), yesterday=Sunday(6) in days
+        assert _schedule_active(s, 0, time(4, 0)) is True
+
+
+# ---------------------------------------------------------------------------
+# _find_matching_schedule
+# ---------------------------------------------------------------------------
+
+
+class TestFindMatchingSchedule:
+    def test_returns_matching_schedule(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        now = datetime(2026, 4, 13, 12, 0)  # Monday
+        assert _find_matching_schedule([s], now) == s
+
+    def test_returns_none_when_no_match(self):
+        s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
+        now = datetime(2026, 4, 14, 12, 0)  # Tuesday
+        assert _find_matching_schedule([s], now) is None
+
+    def test_earliest_start_wins_tiebreak(self):
+        """When two schedules overlap, the one with earliest start_time wins."""
+        s1 = _make_schedule(start=time(9, 0), end=time(17, 0), days=[0], sid="s1")
+        s2 = _make_schedule(start=time(8, 0), end=time(12, 0), days=[0], sid="s2")
+        now = datetime(2026, 4, 13, 10, 0)  # Monday 10:00
+        assert _find_matching_schedule([s1, s2], now) == s2
+
+    def test_empty_schedules(self):
+        assert _find_matching_schedule([], datetime.now()) is None
+
+
+# ---------------------------------------------------------------------------
+# schedules_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulesOverlap:
+    def test_overlapping_same_day(self):
+        a = _make_schedule(start=time(8, 0), end=time(12, 0), days=[0], sid="a")
+        b = _make_schedule(start=time(10, 0), end=time(14, 0), days=[0], sid="b")
+        assert schedules_overlap(a, b) is True
+
+    def test_non_overlapping_same_day(self):
+        a = _make_schedule(start=time(8, 0), end=time(10, 0), days=[0], sid="a")
+        b = _make_schedule(start=time(10, 0), end=time(12, 0), days=[0], sid="b")
+        assert schedules_overlap(a, b) is False
+
+    def test_different_days_no_overlap(self):
+        a = _make_schedule(start=time(8, 0), end=time(12, 0), days=[0], sid="a")
+        b = _make_schedule(start=time(8, 0), end=time(12, 0), days=[1], sid="b")
+        assert schedules_overlap(a, b) is False
+
+    def test_overnight_overlap_with_daytime(self):
+        """Overnight 22:00→06:00 Mon overlaps with 05:00→08:00 Tue."""
+        a = _make_schedule(start=time(22, 0), end=time(6, 0), days=[0], sid="a")
+        b = _make_schedule(start=time(5, 0), end=time(8, 0), days=[1], sid="b")  # Tuesday
+        assert schedules_overlap(a, b) is True
+
+    def test_overnight_no_overlap(self):
+        """Overnight 22:00→06:00 Mon does not overlap with 07:00→09:00 Tue."""
+        a = _make_schedule(start=time(22, 0), end=time(6, 0), days=[0], sid="a")
+        b = _make_schedule(start=time(7, 0), end=time(9, 0), days=[1], sid="b")
+        assert schedules_overlap(a, b) is False
+
+
+# ---------------------------------------------------------------------------
+# get_active_rooms: priority resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveRooms:
+    @pytest.mark.asyncio
+    async def test_schedule_activates_room(self):
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom")
+
+        # Add a schedule for Mon 8:00-17:00
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=[0],
+            start_time=time(8, 0),
+            end_time=time(17, 0),
+            target_temp=74.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        now = datetime(2026, 4, 13, 12, 0)  # Monday noon
+        active = await get_active_rooms(conn, THERMO_ID, now=now)
+        assert len(active) == 1
+        assert active[0].source == "schedule"
+        assert active[0].target_temp == 74.0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_no_schedule_returns_empty(self):
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom")
+
+        # Saturday — no schedules defined (default is Mon-Fri)
+        now = datetime(2026, 4, 18, 12, 0)  # Saturday
+        active = await get_active_rooms(conn, THERMO_ID, now=now)
+        assert len(active) == 0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_override_takes_priority_over_schedule(self):
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom")
+
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=[0],
+            start_time=time(8, 0),
+            end_time=time(17, 0),
+            target_temp=74.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        now = datetime(2026, 4, 13, 12, 0)  # Monday noon
+        override = RoomOverride(
+            room_id="r1",
+            target_temp=78.0,
+            expires_at=now + timedelta(hours=1),
+        )
+        await db.set_room_override(conn, override)
+
+        active = await get_active_rooms(conn, THERMO_ID, now=now)
+        assert len(active) == 1
+        assert active[0].source == "override"
+        assert active[0].target_temp == 78.0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_expired_override_falls_through_to_schedule(self):
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom")
+
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=[0],
+            start_time=time(8, 0),
+            end_time=time(17, 0),
+            target_temp=74.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        now = datetime(2026, 4, 13, 12, 0)
+        expired_override = RoomOverride(
+            room_id="r1",
+            target_temp=78.0,
+            expires_at=now - timedelta(hours=1),  # already expired
+        )
+        await db.set_room_override(conn, expired_override)
+
+        active = await get_active_rooms(conn, THERMO_ID, now=now)
+        assert len(active) == 1
+        assert active[0].source == "schedule"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_holdover_activates_room(self):
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom", system_wide_temp=72.0)
+
+        now = datetime(2026, 4, 18, 12, 0)  # Saturday, no schedules
+        # Create holdover that hasn't expired
+        await handle_presence_event(
+            conn,
+            Room(
+                id="r1",
+                name="Bedroom",
+                thermostat_entity_id=THERMO_ID,
+                presence_holdover_hours=2.0,
+                system_wide_temp=72.0,
+            ),
+            now=now,
+        )
+
+        check_time = now + timedelta(minutes=30)
+        active = await get_active_rooms(conn, THERMO_ID, now=check_time)
+        assert len(active) == 1
+        assert active[0].source == "presence"
+        assert active[0].target_temp == 72.0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_without_temp_config_skipped(self):
+        """Room with holdover but no system_wide_temp or default_temp → idle."""
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom", system_wide_temp=None)
+
+        now = datetime(2026, 4, 18, 12, 0)
+        room = Room(
+            id="r1",
+            name="Bedroom",
+            thermostat_entity_id=THERMO_ID,
+            presence_holdover_hours=2.0,
+        )
+        await handle_presence_event(conn, room, now=now)
+
+        check_time = now + timedelta(minutes=30)
+        active = await get_active_rooms(conn, THERMO_ID, now=check_time)
+        assert len(active) == 0  # idle because no temp configured
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_uses_thermostat_default_temp(self):
+        """When room has no system_wide_temp, falls back to thermostat default_temp."""
+        conn = await _setup_db()
+        await _insert_room(conn, "r1", "Bedroom", system_wide_temp=None)
+
+        # Set thermostat default_temp
+        tc = ThermostatConfig(thermostat_entity_id=THERMO_ID, default_temp=70.0)
+        await db.upsert_thermostat_config(conn, tc)
+
+        now = datetime(2026, 4, 18, 12, 0)
+        room = Room(
+            id="r1",
+            name="Bedroom",
+            thermostat_entity_id=THERMO_ID,
+            presence_holdover_hours=2.0,
+        )
+        await handle_presence_event(conn, room, now=now)
+
+        check_time = now + timedelta(minutes=30)
+        active = await get_active_rooms(conn, THERMO_ID, now=check_time)
+        assert len(active) == 1
+        assert active[0].source == "presence"
+        assert active[0].target_temp == 70.0
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# handle_presence_event
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePresenceEvent:
+    @pytest.mark.asyncio
+    async def test_creates_holdover(self):
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        now = datetime(2026, 4, 13, 12, 0)
+        newly_active = await handle_presence_event(conn, room, now=now)
+        assert newly_active is True
+
+        holdover = await db.get_holdover_state(conn, "r1")
+        assert holdover is not None
+        assert holdover.expires_at == now + timedelta(hours=2.0)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_resets_holdover_timer(self):
+        """Second presence event resets the expiry."""
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        t1 = datetime(2026, 4, 13, 12, 0)
+        await handle_presence_event(conn, room, now=t1)
+
+        t2 = t1 + timedelta(minutes=30)
+        newly_active = await handle_presence_event(conn, room, now=t2)
+        assert newly_active is False  # already active
+
+        holdover = await db.get_holdover_state(conn, "r1")
+        assert holdover.expires_at == t2 + timedelta(hours=2.0)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_zero_holdover_hours_noop(self):
+        """Room with holdover_hours=0 ignores presence."""
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom", presence_hours=0.0)
+
+        now = datetime(2026, 4, 13, 12, 0)
+        result = await handle_presence_event(conn, room, now=now)
+        assert result is False
+
+        holdover = await db.get_holdover_state(conn, "r1")
+        assert holdover is None
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# expire_holdovers
+# ---------------------------------------------------------------------------
+
+
+class TestExpireHoldovers:
+    @pytest.mark.asyncio
+    async def test_removes_expired(self):
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        t1 = datetime(2026, 4, 13, 10, 0)
+        await handle_presence_event(conn, room, now=t1)
+
+        # Move time past expiry (2 hours later)
+        t2 = t1 + timedelta(hours=3)
+        expired = await expire_holdovers(conn, now=t2)
+        assert "r1" in expired
+
+        holdover = await db.get_holdover_state(conn, "r1")
+        assert holdover is None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_keeps_active(self):
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        t1 = datetime(2026, 4, 13, 10, 0)
+        await handle_presence_event(conn, room, now=t1)
+
+        # Only 30 minutes later — still active
+        t2 = t1 + timedelta(minutes=30)
+        expired = await expire_holdovers(conn, now=t2)
+        assert expired == []
+
+        holdover = await db.get_holdover_state(conn, "r1")
+        assert holdover is not None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_holdovers_noop(self):
+        conn = await _setup_db()
+        expired = await expire_holdovers(conn)
+        assert expired == []
+        await conn.close()

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -1,0 +1,467 @@
+"""
+Tests for the Scheduler module.
+
+Covers:
+  - _sync_engines: creating/removing engines based on room config
+  - set_system_enabled: flag persistence, engine abort on disable
+  - set_dev_mode: flag persistence, HA client wiring
+  - _on_state_change: dispatch to correct engine on climate change
+  - _handle_presence_event: presence → holdover → engine tick
+  - get_all_zone_statuses: API status output
+  - _tick_engine: room loading and tick invocation
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.models import Room
+from backend.scheduler import Scheduler
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+THERMO_A = "climate.thermo_a"
+THERMO_B = "climate.thermo_b"
+
+
+def _make_ha() -> MagicMock:
+    ha = MagicMock()
+    ha.subscribe_all = MagicMock()
+    ha.get_state.return_value = {
+        "state": "cool",
+        "attributes": {
+            "current_temperature": 72.0,
+            "temperature": 72.0,
+            "hvac_action": "idle",
+        },
+    }
+    ha.get_numeric_state.return_value = None
+    ha.set_thermostat_temperature = AsyncMock()
+    ha.open_cover = AsyncMock()
+    ha.close_cover = AsyncMock()
+    ha.dev_mode = False
+    ha._dev_logger = None
+    return ha
+
+
+async def _setup_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _insert_room(
+    conn: aiosqlite.Connection,
+    room_id: str,
+    name: str,
+    thermo: str,
+) -> Room:
+    room = Room(id=room_id, name=name, thermostat_entity_id=thermo)
+    await db.upsert_room(conn, room)
+    return room
+
+
+def _make_scheduler(ha: MagicMock | None = None) -> Scheduler:
+    if ha is None:
+        ha = _make_ha()
+    return Scheduler(ha=ha, db_path=":memory:")
+
+
+# ---------------------------------------------------------------------------
+# _sync_engines
+# ---------------------------------------------------------------------------
+
+
+class TestSyncEngines:
+    @pytest.mark.asyncio
+    async def test_creates_engine_for_each_thermostat(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await _insert_room(conn, "r2", "Room 2", THERMO_B)
+
+        await sched._sync_engines()
+
+        assert THERMO_A in sched._engines
+        assert THERMO_B in sched._engines
+        assert len(sched._engines) == 2
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_removes_engine_when_no_rooms(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        assert THERMO_A in sched._engines
+
+        # Remove the room → engine should be cleaned up
+        await db.delete_room(conn, "r1")
+        await sched._sync_engines()
+        assert THERMO_A not in sched._engines
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_sync(self):
+        """Running _sync_engines twice with same rooms doesn't duplicate."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        engine_1 = sched._engines[THERMO_A]
+        await sched._sync_engines()
+        engine_2 = sched._engines[THERMO_A]
+
+        assert engine_1 is engine_2  # same instance, not recreated
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# set_system_enabled / set_dev_mode
+# ---------------------------------------------------------------------------
+
+
+class TestSystemEnabled:
+    @pytest.mark.asyncio
+    async def test_enable_persists_to_db(self):
+        sched = _make_scheduler()
+        conn = await _setup_db()
+        sched._db_conn = conn
+
+        await sched.set_system_enabled(True)
+        val = await db.get_system_setting(conn, "system_enabled", "0")
+        assert val == "1"
+        assert sched.get_system_enabled() is True
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_disable_persists_to_db(self):
+        sched = _make_scheduler()
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._engines = {}  # no engines to tick
+
+        await sched.set_system_enabled(False)
+        val = await db.get_system_setting(conn, "system_enabled", "1")
+        assert val == "0"
+        assert sched.get_system_enabled() is False
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_disable_triggers_engine_ticks(self):
+        """Disabling should tick all engines so they abort running cycles."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        # Mock the engine's tick to track it was called
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_system_enabled(False)
+
+        engine.tick.assert_called_once()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_on_change(self):
+        broadcast = AsyncMock()
+        ha = _make_ha()
+        sched = Scheduler(ha=ha, db_path=":memory:", broadcast=broadcast)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._engines = {}
+
+        await sched.set_system_enabled(False)
+
+        broadcast.assert_called_with("system_enabled_changed", {"enabled": False})
+        await conn.close()
+
+
+class TestDevMode:
+    @pytest.mark.asyncio
+    async def test_enable_dev_mode(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+
+        await sched.set_dev_mode(True)
+
+        assert sched.get_dev_mode() is True
+        assert ha.dev_mode is True
+        val = await db.get_system_setting(conn, "developer_mode", "0")
+        assert val == "1"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_disable_dev_mode(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+
+        await sched.set_dev_mode(False)
+
+        assert sched.get_dev_mode() is False
+        assert ha.dev_mode is False
+        val = await db.get_system_setting(conn, "developer_mode", "0")
+        assert val == "0"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_broadcast(self):
+        broadcast = AsyncMock()
+        ha = _make_ha()
+        sched = Scheduler(ha=ha, db_path=":memory:", broadcast=broadcast)
+        conn = await _setup_db()
+        sched._db_conn = conn
+
+        await sched.set_dev_mode(True)
+
+        broadcast.assert_called_with("dev_mode_changed", {"dev_mode": True})
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _on_state_change
+# ---------------------------------------------------------------------------
+
+
+class TestOnStateChange:
+    @pytest.mark.asyncio
+    async def test_climate_change_triggers_engine_tick(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched._on_state_change(THERMO_A, {"state": "cool"})
+
+        engine.tick.assert_called_once()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_non_climate_entity_ignored(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        # sensor change → should NOT trigger engine tick
+        await sched._on_state_change("sensor.temperature", {"state": "72.5"})
+
+        engine.tick.assert_not_called()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_unknown_climate_entity_ignored(self):
+        """Climate entity with no engine → no crash."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._engines = {}
+
+        # Should not raise
+        await sched._on_state_change("climate.unknown", {"state": "cool"})
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_sensor_triggers_handling(self):
+        """binary_sensor with state=on triggers presence handling."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        # Add a presence sensor for the room
+        from backend.models import RoomPresenceSensor
+
+        ps = RoomPresenceSensor.create(room_id="r1", entity_id="binary_sensor.pir_1")
+        await db.add_room_presence_sensor(conn, ps)
+
+        engine = sched._engines[THERMO_A]
+        engine.handle_presence = AsyncMock()
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched._on_state_change("binary_sensor.pir_1", {"state": "on"})
+
+        engine.handle_presence.assert_called_once()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_off_not_handled(self):
+        """binary_sensor with state != 'on' is not treated as presence."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        from backend.models import RoomPresenceSensor
+
+        ps = RoomPresenceSensor.create(room_id="r1", entity_id="binary_sensor.pir_1")
+        await db.add_room_presence_sensor(conn, ps)
+
+        engine = sched._engines[THERMO_A]
+        engine.handle_presence = AsyncMock()
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched._on_state_change("binary_sensor.pir_1", {"state": "off"})
+
+        engine.handle_presence.assert_not_called()
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# get_all_zone_statuses
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllZoneStatuses:
+    @pytest.mark.asyncio
+    async def test_returns_status_for_each_engine(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await _insert_room(conn, "r2", "Room 2", THERMO_B)
+        await sched._sync_engines()
+
+        statuses = sched.get_all_zone_statuses()
+        assert len(statuses) == 2
+
+        tids = {s["thermostat_entity_id"] for s in statuses}
+        assert THERMO_A in tids
+        assert THERMO_B in tids
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_status_fields_present(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        statuses = sched.get_all_zone_statuses()
+        assert len(statuses) == 1
+        s = statuses[0]
+        assert "thermostat_entity_id" in s
+        assert "cycle_state" in s
+        assert "hvac_mode" in s
+        assert "hvac_action" in s
+        assert "current_temp" in s
+        assert "rooms" in s
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_engines(self):
+        sched = _make_scheduler()
+        sched._engines = {}
+        assert sched.get_all_zone_statuses() == []
+
+
+# ---------------------------------------------------------------------------
+# _tick_engine
+# ---------------------------------------------------------------------------
+
+
+class TestTickEngine:
+    @pytest.mark.asyncio
+    async def test_loads_rooms_and_ticks(self):
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        engine.load_room_sensors = AsyncMock()
+        engine.tick = AsyncMock()
+
+        await sched._tick_engine(THERMO_A, engine)
+
+        engine.load_room_sensors.assert_called_once()
+        engine.tick.assert_called_once_with(conn)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tick_exception_does_not_propagate(self):
+        """Engine tick failure should be caught, not crash scheduler."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        engine.load_room_sensors = AsyncMock()
+        engine.tick = AsyncMock(side_effect=RuntimeError("boom"))
+
+        # Should not raise
+        await sched._tick_engine(THERMO_A, engine)
+        await conn.close()

--- a/smart_vent/backend/tests/test_vent_controller.py
+++ b/smart_vent/backend/tests/test_vent_controller.py
@@ -1,0 +1,374 @@
+"""
+Tests for the vent controller module.
+
+Covers:
+  - open_room_vents: opening vents with state checking
+  - close_room_vents: min_open_vents safety guard
+  - check_max_closed_duration: force-reopen after timeout
+  - _count_open_vents / _is_open helpers
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.engine.vent_controller import VentController
+from backend.models import (
+    CycleLog,
+    Room,
+    RoomCycleState,
+    RoomVent,
+    ThermostatConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+THERMO_ID = "climate.test_thermostat"
+
+
+def _make_ha(vent_states: dict[str, str] | None = None) -> MagicMock:
+    """Mock HAClient with configurable vent states."""
+    ha = MagicMock()
+    if vent_states is None:
+        vent_states = {}
+
+    def get_state(entity_id):
+        if entity_id in vent_states:
+            return {"state": vent_states[entity_id]}
+        return None
+
+    ha.get_state.side_effect = get_state
+    ha.open_cover = AsyncMock()
+    ha.close_cover = AsyncMock()
+    return ha
+
+
+def _make_tc(**overrides) -> ThermostatConfig:
+    defaults = {
+        "thermostat_entity_id": THERMO_ID,
+        "min_open_vents": 1,
+        "max_vent_closed_min": 0,
+    }
+    defaults.update(overrides)
+    return ThermostatConfig(**defaults)
+
+
+def _make_vent(room_id: str, entity_id: str) -> RoomVent:
+    return RoomVent.create(room_id=room_id, entity_id=entity_id)
+
+
+# ---------------------------------------------------------------------------
+# open_room_vents
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRoomVents:
+    @pytest.mark.asyncio
+    async def test_opens_closed_vent(self):
+        ha = _make_ha({"cover.vent_1": "closed"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.vent_1")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.open_cover.assert_called_once_with("cover.vent_1")
+
+    @pytest.mark.asyncio
+    async def test_skips_already_open_vent(self):
+        ha = _make_ha({"cover.vent_1": "open"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.vent_1")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.open_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_unknown_entity(self):
+        """Vent entity not found in HA → skip (don't crash)."""
+        ha = _make_ha({})  # No entities
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.vent_missing")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.open_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_opens_multiple_vents(self):
+        ha = _make_ha({"cover.v1": "closed", "cover.v2": "closed"})
+        ctrl = VentController(ha)
+        vents = [_make_vent("r1", "cover.v1"), _make_vent("r1", "cover.v2")]
+
+        await ctrl.open_room_vents(vents)
+
+        assert ha.open_cover.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# close_room_vents: min_open_vents safety
+# ---------------------------------------------------------------------------
+
+
+class TestCloseRoomVents:
+    @pytest.mark.asyncio
+    async def test_closes_vent_when_safe(self):
+        """Closing one vent still leaves enough open → allowed."""
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=1)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = [_make_vent("r1", "cover.v1"), _make_vent("r2", "cover.v2")]
+        cycle_states: dict[str, RoomCycleState] = {}
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, cycle_states)
+
+        assert result is True
+        ha.close_cover.assert_called_once_with("cover.v1")
+
+    @pytest.mark.asyncio
+    async def test_defers_when_would_drop_below_min(self):
+        """Closing last open vent would drop below min_open_vents → deferred."""
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=1)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = [_make_vent("r1", "cover.v1")]
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, {})
+
+        assert result is False
+        ha.close_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_min_open_zero_allows_all_closed(self):
+        """min_open_vents=0 → always allow closing."""
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = [_make_vent("r1", "cover.v1")]
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, {})
+
+        assert result is True
+        ha.close_cover.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_already_closed_vent(self):
+        """Already-closed vents are not sent close commands."""
+        ha = _make_ha({"cover.v1": "closed", "cover.v2": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = room_vents
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, {})
+
+        assert result is True
+        ha.close_cover.assert_not_called()  # v1 already closed
+
+    @pytest.mark.asyncio
+    async def test_min_open_vents_two(self):
+        """min_open_vents=2: closing 1 of 3 open → allowed (2 remain)."""
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "open", "cover.v3": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=2)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = [
+            _make_vent("r1", "cover.v1"),
+            _make_vent("r2", "cover.v2"),
+            _make_vent("r3", "cover.v3"),
+        ]
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, {})
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_min_open_vents_two_defers(self):
+        """min_open_vents=2: closing 1 of 2 open → deferred (would leave 1)."""
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=2)
+
+        room_vents = [_make_vent("r1", "cover.v1")]
+        all_vents = [_make_vent("r1", "cover.v1"), _make_vent("r2", "cover.v2")]
+
+        result = await ctrl.close_room_vents(room_vents, all_vents, tc, {})
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# check_max_closed_duration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMaxClosedDuration:
+    @pytest.mark.asyncio
+    async def test_disabled_when_zero(self):
+        """max_vent_closed_min=0 → feature disabled, no reopens."""
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        tc = _make_tc(max_vent_closed_min=0)
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        rcs = RoomCycleState(
+            cycle_id="c1",
+            room_id="r1",
+            target_temp=74.0,
+            vent_closed_at=datetime(2026, 4, 13, 10, 0),
+        )
+
+        result = await ctrl.check_max_closed_duration(
+            conn, {"r1": [_make_vent("r1", "cover.v1")]}, {"r1": rcs}, tc
+        )
+        assert result == []
+        ha.open_cover.assert_not_called()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_reopens_after_limit(self):
+        """Vent closed longer than limit → force-reopen."""
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        tc = _make_tc(max_vent_closed_min=30)
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        # Insert room and cycle for FK constraints
+        room = Room(id="r1", name="R1", thermostat_entity_id=THERMO_ID)
+        await db.upsert_room(conn, room)
+
+        cycle = CycleLog.create(
+            thermostat_entity_id=THERMO_ID,
+            mode="cooling",
+            rooms_json=json.dumps({"r1": {}}),
+        )
+        cycle.id = "c1"
+        await db.insert_cycle_log(conn, cycle)
+
+        closed_at = datetime(2026, 4, 13, 10, 0)
+        now = closed_at + timedelta(minutes=35)
+        rcs = RoomCycleState(
+            cycle_id="c1", room_id="r1", target_temp=74.0, vent_closed_at=closed_at
+        )
+        await db.upsert_room_cycle_state(conn, rcs)
+
+        result = await ctrl.check_max_closed_duration(
+            conn, {"r1": [_make_vent("r1", "cover.v1")]}, {"r1": rcs}, tc, now=now
+        )
+        assert "r1" in result
+        assert rcs.vent_closed_at is None  # timer reset
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_no_reopen_before_limit(self):
+        """Vent closed for less than limit → no action."""
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        tc = _make_tc(max_vent_closed_min=30)
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        closed_at = datetime(2026, 4, 13, 10, 0)
+        now = closed_at + timedelta(minutes=20)  # only 20 min
+        rcs = RoomCycleState(
+            cycle_id="c1", room_id="r1", target_temp=74.0, vent_closed_at=closed_at
+        )
+
+        result = await ctrl.check_max_closed_duration(
+            conn, {"r1": [_make_vent("r1", "cover.v1")]}, {"r1": rcs}, tc, now=now
+        )
+        assert result == []
+        ha.open_cover.assert_not_called()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_no_vent_closed_at_skipped(self):
+        """Room with vent_closed_at=None → skip (vent is open)."""
+        ha = _make_ha({})
+        ctrl = VentController(ha)
+        tc = _make_tc(max_vent_closed_min=30)
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        rcs = RoomCycleState(cycle_id="c1", room_id="r1", target_temp=74.0, vent_closed_at=None)
+
+        result = await ctrl.check_max_closed_duration(
+            conn, {"r1": [_make_vent("r1", "cover.v1")]}, {"r1": rcs}, tc
+        )
+        assert result == []
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Helper method tests
+# ---------------------------------------------------------------------------
+
+
+class TestVentHelpers:
+    def test_is_open_true(self):
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        assert ctrl._is_open("cover.v1") is True
+
+    def test_is_open_false(self):
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        assert ctrl._is_open("cover.v1") is False
+
+    def test_is_open_unknown_entity(self):
+        ha = _make_ha({})
+        ctrl = VentController(ha)
+        assert ctrl._is_open("cover.missing") is False
+
+    def test_count_open_vents(self):
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "closed", "cover.v3": "open"})
+        ctrl = VentController(ha)
+        vents = [
+            _make_vent("r1", "cover.v1"),
+            _make_vent("r1", "cover.v2"),
+            _make_vent("r2", "cover.v3"),
+        ]
+        assert ctrl._count_open_vents(vents) == 2
+
+    def test_get_vent_states(self):
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "closed"})
+        ctrl = VentController(ha)
+        vents = [_make_vent("r1", "cover.v1"), _make_vent("r1", "cover.v2")]
+
+        states = ctrl.get_vent_states(vents)
+        assert states["cover.v1"] == "open"
+        assert states["cover.v2"] == "closed"
+
+    def test_get_vent_states_unknown(self):
+        ha = _make_ha({})
+        ctrl = VentController(ha)
+        vents = [_make_vent("r1", "cover.missing")]
+
+        states = ctrl.get_vent_states(vents)
+        assert states["cover.missing"] == "unknown"


### PR DESCRIPTION
## Summary

Full fix for all bugs identified in the cycle engine audit (#48):

- **Bug 1:** Clamp thermostat setpoint against ambient so HVAC always activates
- **Bug 2:** Reject unexpected `hvac_mode` values instead of silently defaulting to heat
- **Bug 3:** Filter opposite-direction rooms from cycle (also resolves Bug 5)
- **Bug 4:** Cross-thermostat duplicate cycle prevention via `close_open_cycles_for_rooms()`
- **Bug 5:** Resolved by Bug 3 — opposite-direction rooms filtered each tick; empty set aborts cycle
- **Bug 6:** Guard `_monitor_rooms` and `_is_at_target` against invalid/unexpected modes
- **Bug 7:** Comprehensive test suite (128 tests) + pytest added as required CI job

## Test Coverage (128 tests)

### Engine — `test_cycle_engine.py` (55 tests)
- Setpoint ambient clamping (cooling/heating/no-op)
- Mode rejection (off/unknown blocked, cooling/heating accepted)
- Room filtering by mode direction + temp_offset handling
- Cross-thermostat duplicate cycle prevention (DB level)
- `_is_at_target` deadband boundaries, zero deadband, mode guards
- `_read_hvac_mode` HA state interpretation, action priority, idle fallback
- `_infer_mode_from_room_temps` majority vote, ties, sensor fallback, ambient sanity
- `_get_avg_temp` sensor averaging, unavailable sensors, thermostat inclusion
- Setpoint multi-room target selection (min for cooling, max for heating)
- Engine state properties (initial state, cycle_id, zone status)

### Room Manager — `test_room_manager.py` (30 tests)
- Schedule matching: daytime boundaries, overnight blocks, Sunday→Monday wraparound
- Schedule overlap detection (same day, different days, overnight cross)
- Priority resolution: override > schedule > presence > idle
- Presence holdover: creation, timer reset, zero-hours noop, expiry cleanup
- Thermostat default_temp fallback when room has no system_wide_temp

### Vent Controller — `test_vent_controller.py` (17 tests)
- Open/close with state checking (skip already-open, skip unknown entity)
- `min_open_vents` safety guard at 0/1/2 thresholds
- `max_vent_closed_min` force-reopen after timeout
- Helper methods: `_is_open`, `_count_open_vents`, `get_vent_states`

### Scheduler — `test_scheduler.py` (18 tests)
- Engine sync: create per thermostat, remove on no rooms, idempotent
- System enable/disable: DB persistence, abort tick on disable, broadcast
- Dev mode: DB persistence, HA client wiring, broadcast
- State change dispatch: climate→tick, non-climate ignored, presence on/off
- Zone status API: multi-engine output, field validation
- Tick error isolation: engine exceptions don't crash scheduler

## CI Integration
- Added `python-test` job to `.github/workflows/lint.yml` — pytest now runs as a required CI check alongside ruff, ESLint+Prettier, and Docker build

## Test plan

- [x] 128 unit tests pass locally and in CI
- [ ] Verify cooling cycle: setpoint clamped to `ambient - overshoot_delta` when thermostat probe diverges from room sensors
- [ ] Verify heating cycle: setpoint clamped to `ambient + overshoot_delta` when thermostat probe diverges
- [ ] Verify unexpected `hvac_mode` values log an error and skip setpoint
- [ ] Verify mixed-direction rooms are excluded from cycle (check event logs for "Excluding room")
- [ ] Verify room reassignment between thermostats closes the old cycle before starting new
- [ ] Verify no regressions in normal cooling/heating cycle flow

Closes #48

https://claude.ai/code/session_01HUn4RVaH7Jhv6S7FYgCbpd
