### PR TITLE
fix: close cycle DB record before fallible vent/setpoint ops (#51)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -632,9 +632,7 @@ class CycleEngine:
             try:
                 await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
             except Exception as exc:
-                log.error(
-                    "Failed to close cycle log %s in DB: %s", self._cycle_log.id, exc
-                )
+                log.error("Failed to close cycle log %s in DB: %s", self._cycle_log.id, exc)
 
         # Set thermostat setpoint to its own current ambient → HVAC shuts off.
         # Leave the thermostat in the cycle's mode (heat/cool) — setting setpoint=ambient

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -626,6 +626,16 @@ class CycleEngine:
         log.info("All rooms at target for %s — terminating cycle", self.thermostat_entity_id)
         self._state = CycleState.TERMINATING
 
+        # Close the DB record FIRST so the cycle log is never left orphaned
+        # with ended_at=NULL if subsequent vent/setpoint operations fail.
+        if self._cycle_log:
+            try:
+                await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
+            except Exception as exc:
+                log.error(
+                    "Failed to close cycle log %s in DB: %s", self._cycle_log.id, exc
+                )
+
         # Set thermostat setpoint to its own current ambient → HVAC shuts off.
         # Leave the thermostat in the cycle's mode (heat/cool) — setting setpoint=ambient
         # means the HVAC satisfies itself immediately and goes idle.
@@ -657,9 +667,6 @@ class CycleEngine:
                 except Exception as exc:
                     log.error("Failed to set termination setpoint: %s", exc)
 
-        if self._cycle_log:
-            await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
-
         # Capture all zone vents before clearing state so we can re-open them.
         # Vents are closed as rooms hit target during the cycle; on termination
         # they should all return to open (idle state = vents open).
@@ -678,13 +685,20 @@ class CycleEngine:
                 "Cycle complete — re-opening all zone vents for %s",
                 self.thermostat_entity_id,
             )
-            await self._vent.open_room_vents(all_zone_vents)
-            if self._logger:
-                await self._logger.log(
-                    "info",
-                    "engine",
-                    f"Cycle complete for {self.thermostat_entity_id} — all zone vents re-opened",
-                    {"thermostat": self.thermostat_entity_id},
+            try:
+                await self._vent.open_room_vents(all_zone_vents)
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Cycle complete for {self.thermostat_entity_id} — all zone vents re-opened",
+                        {"thermostat": self.thermostat_entity_id},
+                    )
+            except Exception as exc:
+                log.error(
+                    "Terminate: vent re-open failed for %s: %s",
+                    self.thermostat_entity_id,
+                    exc,
                 )
 
     async def _abort_cycle(
@@ -706,24 +720,33 @@ class CycleEngine:
                 },
             )
 
-        all_vents = [v for vl in self._room_vents.values() for v in vl]
-        if safe_close:
-            # Thermostat unavailable — close everything for safety
-            await self._vent.close_all_zone_vents(all_vents)
-        elif all_vents:
-            # Abnormal termination (no active rooms, timeout, mode change) —
-            # return all vents to open/idle state, mirroring _terminate_cycle.
-            # Previously vents were left in whatever physical state they happened
-            # to be in, which could leave rooms closed with no engine tracking
-            # until the next IDLE reconciliation pass.
-            await self._vent.open_room_vents(all_vents)
-            if self._logger:
-                await self._logger.log(
-                    "info",
-                    "engine",
-                    f"Cycle aborted for {self.thermostat_entity_id} ({reason}) — all zone vents re-opened",
-                    {"thermostat": self.thermostat_entity_id, "reason": reason},
+        # Close the DB record FIRST so the cycle log is never left orphaned
+        # with ended_at=NULL if subsequent vent/setpoint operations fail.
+        if self._cycle_log:
+            try:
+                await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
+            except Exception as exc:
+                log.error(
+                    "Abort: failed to close cycle log %s in DB: %s",
+                    self._cycle_log.id,
+                    exc,
                 )
+
+        all_vents = [v for vl in self._room_vents.values() for v in vl]
+        try:
+            if safe_close:
+                await self._vent.close_all_zone_vents(all_vents)
+            elif all_vents:
+                await self._vent.open_room_vents(all_vents)
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Cycle aborted for {self.thermostat_entity_id} ({reason}) — all zone vents re-opened",
+                        {"thermostat": self.thermostat_entity_id, "reason": reason},
+                    )
+        except Exception as exc:
+            log.error("Abort: vent operation failed for %s: %s", self.thermostat_entity_id, exc)
 
         # Reset the thermostat setpoint to current ambient so the HVAC goes idle.
         # _terminate_cycle() does this on normal termination; mirroring it here
@@ -757,8 +780,6 @@ class CycleEngine:
                     except Exception as exc:
                         log.error("Abort: failed to reset setpoint to ambient: %s", exc)
 
-        if self._cycle_log:
-            await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
         self._state = CycleState.IDLE
         self._cycle_mode = None
         self._cycle_ha_mode = None

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -154,6 +154,21 @@ class Scheduler:
             # Each engine's _do_tick will see the disabled flag and call _abort_cycle.
             tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]
             await asyncio.gather(*tasks, return_exceptions=True)
+            # Safety net: close any cycle log rows that are still open despite
+            # the abort ticks above.  This catches edge cases where the DB close
+            # inside _abort_cycle failed (e.g. connection error) so the UI never
+            # shows stale "Active" cycles after a system disable.
+            for tid in self._engines:
+                try:
+                    closed = await db.close_open_cycle_logs(self._db_conn, tid)
+                    if closed:
+                        log.warning(
+                            "Safety-net: closed %d orphaned cycle log(s) for %s after system disable",
+                            closed,
+                            tid,
+                        )
+                except Exception as exc:
+                    log.error("Safety-net cycle cleanup failed for %s: %s", tid, exc)
         if self._broadcast:
             await self._broadcast("system_enabled_changed", {"enabled": enabled})
 

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -887,3 +887,179 @@ class TestEngineStateProperties:
         assert status.thermostat_entity_id == THERMO_ID
         assert status.cycle_id is None
         assert status.hvac_action == "idle"
+
+
+# ---------------------------------------------------------------------------
+# _abort_cycle: DB close ordering (issue #51)
+# ---------------------------------------------------------------------------
+
+
+async def _setup_engine_with_running_cycle(ha=None):
+    """Create an engine with a RUNNING cycle backed by a real in-memory DB."""
+    from backend import db
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+
+    if ha is None:
+        ha = _make_ha(ambient=72.0)
+    engine = _make_engine(ha)
+
+    # Insert room for FK constraints
+    room = Room.create(name="Test Room", thermostat_entity_id=THERMO_ID)
+    room.id = "r1"
+    await db.upsert_room(conn, room)
+
+    # Insert a cycle log and put engine in RUNNING state
+    cycle = CycleLog.create(
+        thermostat_entity_id=THERMO_ID,
+        mode="cooling",
+        rooms_json=json.dumps({"r1": {"name": "Test Room", "target": 74.0}}),
+    )
+    await db.insert_cycle_log(conn, cycle)
+
+    engine._state = CycleState.RUNNING
+    engine._cycle_log = cycle
+    engine._cycle_mode = "cooling"
+    engine._cycle_ha_mode = "cool"
+    engine._active_rooms = {
+        "r1": ActiveRoom(room=room, target_temp=74.0, source="schedule"),
+    }
+
+    return engine, conn, cycle
+
+
+class TestAbortCycleDbClose:
+    """_abort_cycle must close the DB record even when vent/setpoint ops fail."""
+
+    @pytest.mark.asyncio
+    async def test_abort_closes_db_record(self):
+        """Basic abort should set ended_at in the DB."""
+        from backend import db
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+
+        await engine._abort_cycle(conn, reason="test")
+
+        # Verify DB record is closed
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "Cycle should be closed in DB after abort"
+
+        # Verify engine state is reset
+        assert engine.cycle_state == CycleState.IDLE
+        assert engine._cycle_log is None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_closes_db_even_when_vent_open_fails(self):
+        """DB record must be closed even if vent operations raise."""
+        from backend import db
+
+        ha = _make_ha(ambient=72.0)
+        ha.open_cover = AsyncMock(side_effect=RuntimeError("HA unavailable"))
+        engine, conn, cycle = await _setup_engine_with_running_cycle(ha)
+
+        # Give the engine some vents so it tries to open them
+        from backend.models import RoomVent
+
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_1")]}
+
+        await engine._abort_cycle(conn, reason="test")
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "DB record must be closed despite vent failure"
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_closes_db_even_when_setpoint_reset_fails(self):
+        """DB record must be closed even if setpoint reset raises."""
+        from backend import db
+
+        ha = _make_ha(ambient=72.0)
+        ha.set_thermostat_temperature = AsyncMock(side_effect=RuntimeError("HA unavailable"))
+        engine, conn, cycle = await _setup_engine_with_running_cycle(ha)
+
+        await engine._abort_cycle(conn, reason="test")
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "DB record must be closed despite setpoint failure"
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_no_cycle_log_is_noop(self):
+        """Aborting with no cycle_log should not crash."""
+        engine = _make_engine()
+        engine._state = CycleState.RUNNING
+        engine._cycle_log = None
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        from backend import db
+
+        await db.init_db(conn)
+
+        await engine._abort_cycle(conn, reason="test")
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _terminate_cycle: DB close ordering (issue #51)
+# ---------------------------------------------------------------------------
+
+
+class TestTerminateCycleDbClose:
+    """_terminate_cycle must close the DB record even when vent/setpoint ops fail."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_closes_db_record(self):
+        """Normal termination should set ended_at in the DB."""
+        from backend import db
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+
+        await engine._terminate_cycle(conn)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "Cycle should be closed in DB after termination"
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_terminate_closes_db_even_when_setpoint_fails(self):
+        """DB record must be closed even if setpoint reset raises."""
+        from backend import db
+
+        ha = _make_ha(ambient=72.0)
+        ha.set_thermostat_temperature = AsyncMock(side_effect=RuntimeError("HA unavailable"))
+        engine, conn, cycle = await _setup_engine_with_running_cycle(ha)
+
+        await engine._terminate_cycle(conn)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "DB record must be closed despite setpoint failure"
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_terminate_closes_db_even_when_vent_open_fails(self):
+        """DB record must be closed even if vent re-open after termination raises."""
+        from backend import db
+
+        ha = _make_ha(ambient=72.0)
+        ha.open_cover = AsyncMock(side_effect=RuntimeError("HA unavailable"))
+        engine, conn, cycle = await _setup_engine_with_running_cycle(ha)
+
+        from backend.models import RoomVent
+
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_1")]}
+
+        await engine._terminate_cycle(conn)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 0, "DB record must be closed despite vent failure"
+        assert engine.cycle_state == CycleState.IDLE
+        await conn.close()

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -202,6 +202,81 @@ class TestSystemEnabled:
         broadcast.assert_called_with("system_enabled_changed", {"enabled": False})
         await conn.close()
 
+    @pytest.mark.asyncio
+    async def test_disable_closes_orphaned_cycle_logs(self):
+        """Safety net: set_system_enabled(False) closes any DB cycle logs
+        that are still open after engine ticks complete."""
+        import json
+
+        from backend.models import CycleLog
+
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        # Insert an open cycle log directly in the DB (simulating a failed abort)
+        cycle = CycleLog.create(
+            thermostat_entity_id=THERMO_A,
+            mode="cooling",
+            rooms_json=json.dumps({"r1": {"name": "Room 1", "target": 74.0}}),
+        )
+        await db.insert_cycle_log(conn, cycle)
+
+        # Mock engine tick to be a no-op (simulates abort that fails to close DB)
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_system_enabled(False)
+
+        # The safety net should have closed the orphaned cycle log
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_A)
+        assert len(open_logs) == 0, "Orphaned cycle log should be closed by safety net"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_disable_safety_net_handles_multiple_thermostats(self):
+        """Safety net runs for every thermostat, not just the first."""
+        import json
+
+        from backend.models import CycleLog
+
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await _insert_room(conn, "r2", "Room 2", THERMO_B)
+        await sched._sync_engines()
+
+        # Insert orphaned cycle logs for both thermostats
+        for tid in [THERMO_A, THERMO_B]:
+            cycle = CycleLog.create(
+                thermostat_entity_id=tid,
+                mode="cooling",
+                rooms_json=json.dumps({}),
+            )
+            await db.insert_cycle_log(conn, cycle)
+
+        for eng in sched._engines.values():
+            eng.tick = AsyncMock()
+            eng.load_room_sensors = AsyncMock()
+
+        await sched.set_system_enabled(False)
+
+        open_a = await db.get_open_cycle_logs(conn, THERMO_A)
+        open_b = await db.get_open_cycle_logs(conn, THERMO_B)
+        assert len(open_a) == 0, "Thermostat A orphan should be closed"
+        assert len(open_b) == 0, "Thermostat B orphan should be closed"
+        await conn.close()
+
 
 class TestDevMode:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #51 — Cycle history log shows "running" after system disable because the DB record's `ended_at` column is never set.

**Root cause:** `_abort_cycle()` and `_terminate_cycle()` called `db.close_cycle_log()` *after* fallible vent/setpoint HA operations. If those operations threw an exception, the DB row kept `ended_at=NULL`, but in-memory `self._cycle_log` was set to `None` during state cleanup — losing the reference permanently. The event logger showed "aborted" because it wrote before the DB close attempt.

## Changes

### Three-layer fix:

1. **DB close first** (`cycle_engine.py`): In both `_abort_cycle()` and `_terminate_cycle()`, moved `db.close_cycle_log()` to execute *before* any vent or setpoint operations, wrapped in its own try/except.

2. **Vent ops wrapped** (`cycle_engine.py`): Wrapped vent open/close operations in try/except in both methods so they can't prevent state cleanup from completing.

3. **Scheduler safety-net** (`scheduler.py`): After `set_system_enabled(False)` runs abort ticks for all engines, added a sweep that calls `db.close_open_cycle_logs()` for every thermostat — catching any rows that slipped through despite the above fixes.

### Files changed:
- `smart_vent/backend/engine/cycle_engine.py` — Core fix: reorder DB close before fallible ops, wrap vent ops
- `smart_vent/backend/scheduler.py` — Safety-net sweep after system disable
- `smart_vent/backend/tests/test_cycle_engine.py` — 7 new tests for abort/terminate DB close ordering
- `smart_vent/backend/tests/test_scheduler.py` — 2 new tests for safety-net sweep

## Test plan

- [x] 137 tests pass (128 existing + 9 new)
- [x] `TestAbortCycleDbClose` (4 tests): basic abort, DB closed despite vent failure, DB closed despite setpoint failure, no-cycle-log noop
- [x] `TestTerminateCycleDbClose` (3 tests): basic terminate, DB closed despite setpoint failure, DB closed despite vent failure
- [x] `TestSchedulerDisable` (2 tests): orphaned cycle logs closed after disable, multiple thermostats handled
- [x] ruff check + ruff format pass
- [ ] Manual: disable system while cycle is running → cycle history shows ended (not "running")

https://claude.ai/code/session_01HUn4RVaH7Jhv6S7FYgCbpd