### PR TITLE
fix: terminate and re-evaluate cycles on every system/dev toggle

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -104,6 +104,19 @@ class CycleEngine:
         async with self._lock:
             await self._on_presence(conn, room)
 
+    async def force_abort(self, conn: aiosqlite.Connection, reason: str) -> None:
+        """Abort the current cycle regardless of the enabled flag.
+
+        Called by the scheduler on system/dev mode toggles to guarantee a clean
+        slate — the normal abort path inside `_do_tick` only fires when
+        `_get_enabled()` is False, so a transition like system-on or
+        dev-off-with-system-still-on wouldn't otherwise terminate an in-flight
+        cycle.
+        """
+        async with self._lock:
+            if self._state != CycleState.IDLE:
+                await self._abort_cycle(conn, reason=reason)
+
     def get_zone_status(self) -> ZoneStatus:
         """Return a snapshot of the current zone status (no DB call needed)."""
         thermo_state = self._ha.get_state(self.thermostat_entity_id)

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -149,26 +149,7 @@ class Scheduler:
         self._system_enabled = enabled
         await db.set_system_setting(self._db_conn, "system_enabled", "1" if enabled else "0")
         log.info("System %s", "enabled" if enabled else "disabled")
-        if not enabled:
-            # Abort any running cycles immediately — don't wait for the next 60s tick.
-            # Each engine's _do_tick will see the disabled flag and call _abort_cycle.
-            tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]
-            await asyncio.gather(*tasks, return_exceptions=True)
-            # Safety net: close any cycle log rows that are still open despite
-            # the abort ticks above.  This catches edge cases where the DB close
-            # inside _abort_cycle failed (e.g. connection error) so the UI never
-            # shows stale "Active" cycles after a system disable.
-            for tid in self._engines:
-                try:
-                    closed = await db.close_open_cycle_logs(self._db_conn, tid)
-                    if closed:
-                        log.warning(
-                            "Safety-net: closed %d orphaned cycle log(s) for %s after system disable",
-                            closed,
-                            tid,
-                        )
-                except Exception as exc:
-                    log.error("Safety-net cycle cleanup failed for %s: %s", tid, exc)
+        await self._reset_and_reevaluate(reason=f"system {'enabled' if enabled else 'disabled'}")
         if self._broadcast:
             await self._broadcast("system_enabled_changed", {"enabled": enabled})
 
@@ -186,8 +167,52 @@ class Scheduler:
                 "system",
                 f"Developer mode {'enabled' if enabled else 'disabled'}",
             )
+        await self._reset_and_reevaluate(
+            reason=f"developer mode {'enabled' if enabled else 'disabled'}"
+        )
         if self._broadcast:
             await self._broadcast("dev_mode_changed", {"dev_mode": enabled})
+
+    async def _reset_and_reevaluate(self, reason: str) -> None:
+        """Terminate every open cycle, then tick every engine so they re-evaluate
+        what should be running under the new system/dev mode state.
+
+        Invoked on every system/dev toggle (on or off). Guarantees that cycles
+        from a previous mode never linger as ACTIVE after a transition and that
+        engine state tracks the flag change without waiting for the next
+        scheduled 60s tick.
+        """
+        if not self._engines:
+            return
+        # 1. Force-abort any in-flight cycle in each engine — regardless of the
+        # current enabled flag. The normal tick-driven abort only fires when
+        # _get_enabled() is False, so transitions like system-on or
+        # dev-off-while-system-on wouldn't otherwise clean up.
+        for tid, eng in self._engines.items():
+            try:
+                await eng.force_abort(self._db_conn, reason=reason)
+            except Exception as exc:
+                log.error("force_abort failed for %s (%s): %s", tid, reason, exc)
+        # 2. Safety net: close any cycle_log rows that are still open despite
+        # the force_abort above. Catches edge cases where DB close inside
+        # _abort_cycle failed, so the UI never shows stale "Active" cycles.
+        for tid in self._engines:
+            try:
+                closed = await db.close_open_cycle_logs(self._db_conn, tid)
+                if closed:
+                    log.warning(
+                        "Safety-net: closed %d orphaned cycle log(s) for %s after %s",
+                        closed,
+                        tid,
+                        reason,
+                    )
+            except Exception as exc:
+                log.error("Safety-net cycle cleanup failed for %s: %s", tid, exc)
+        # 3. Re-evaluate: tick every engine so they start a fresh cycle if
+        # still needed under the new flag state. Engines that are now disabled
+        # will see that and skip; engines newly enabled will pick up work.
+        tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     # ------------------------------------------------------------------
     # Engine management

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -324,6 +324,153 @@ class TestDevMode:
 
 
 # ---------------------------------------------------------------------------
+# Reset + re-evaluate on every system/dev toggle
+# ---------------------------------------------------------------------------
+
+
+async def _insert_open_cycle(conn: aiosqlite.Connection, thermostat: str) -> str:
+    """Insert an open (ended_at IS NULL) cycle log for a thermostat. Returns id."""
+    import json
+
+    from backend.models import CycleLog
+
+    cycle = CycleLog.create(
+        thermostat_entity_id=thermostat,
+        mode="cooling",
+        rooms_json=json.dumps({}),
+    )
+    await db.insert_cycle_log(conn, cycle)
+    return cycle.id
+
+
+class TestResetAndReevaluate:
+    """Every system/dev toggle must (1) terminate open cycles and (2) tick
+    every engine so it re-evaluates under the new flag state."""
+
+    @pytest.mark.asyncio
+    async def test_system_enable_closes_open_cycle(self):
+        """System OFF → ON must not leave a stale ACTIVE cycle behind."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        await _insert_open_cycle(conn, THERMO_A)
+
+        # Engine's _state is IDLE (no restore), so force_abort is a no-op; the
+        # safety net is what catches this orphan. Mock tick to isolate.
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_system_enabled(True)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_A)
+        assert len(open_logs) == 0, "System enable must close orphaned cycles"
+        engine.tick.assert_called_once()  # re-evaluation tick
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_enable_closes_open_cycle(self):
+        """Entering dev mode wipes any pre-existing open cycle so real and
+        simulated cycles never coexist."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        await _insert_open_cycle(conn, THERMO_A)
+
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_dev_mode(True)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_A)
+        assert len(open_logs) == 0, "Dev ON must close orphaned cycles"
+        engine.tick.assert_called_once()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_disable_closes_open_cycle(self):
+        """Leaving dev mode must terminate any dev-mode-created cycle even if
+        the system remains enabled (regression: this was the reported bug)."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        sched._dev_mode = True  # start in dev mode
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        await _insert_open_cycle(conn, THERMO_A)
+
+        engine = sched._engines[THERMO_A]
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_dev_mode(False)
+
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_A)
+        assert len(open_logs) == 0, "Dev OFF must close dev-mode cycles"
+        engine.tick.assert_called_once()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_force_abort_called_on_running_engine(self):
+        """When an engine has an in-flight cycle in memory, the toggle must
+        invoke force_abort so engine state resets — not just DB cleanup."""
+        from backend.engine.cycle_engine import CycleState
+
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        # Simulate an in-flight cycle in memory.
+        engine._state = CycleState.RUNNING
+        engine.force_abort = AsyncMock()
+        engine.tick = AsyncMock()
+        engine.load_room_sensors = AsyncMock()
+
+        await sched.set_dev_mode(True)
+
+        engine.force_abort.assert_called_once()
+        call_kwargs = engine.force_abort.call_args.kwargs
+        assert "reason" in call_kwargs
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_toggle_with_no_engines_is_noop(self):
+        """Toggles must not crash when no engines are registered yet."""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._engines = {}
+
+        # None of these should raise.
+        await sched.set_system_enabled(True)
+        await sched.set_system_enabled(False)
+        await sched.set_dev_mode(True)
+        await sched.set_dev_mode(False)
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
 # _on_state_change
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #54. Dev-mode cycles were lingering as `ACTIVE` in Cycle History after flipping dev off or system on because only `set_system_enabled(False)` cleaned up open cycles — the other three transitions (`system(True)`, `dev(True)`, `dev(False)`) were flag-flips with no engine or DB reset.

The engine's tick-based abort path only fires when `_get_enabled()` is False, so a transition like system-on or dev-off-while-system-still-on never aborted the in-flight cycle. This refactors the cleanup pattern into a single `_reset_and_reevaluate` helper called from both setters (both directions).

## Changes

- **`engine/cycle_engine.py`**: new public `force_abort(conn, reason)` that wraps `_abort_cycle` under the engine lock, invoked regardless of the enabled flag.
- **`scheduler.py`**: new `_reset_and_reevaluate(reason)` that (1) force-aborts every engine's in-flight cycle, (2) runs the existing `close_open_cycle_logs` safety net, (3) ticks every engine so fresh cycles start under the new flag state without waiting for the next 60s tick. Called from both `set_system_enabled` and `set_dev_mode` in both directions.
- **`tests/test_scheduler.py`**: 5 new tests covering system-on cleanup, dev-on cleanup, dev-off cleanup (the reported bug), force_abort invocation on a running engine, and no-engine no-op safety.

| Transition | Before | After |
|---|---|---|
| System OFF | Terminate only | Terminate + re-evaluate |
| System ON  | Flag flip only | Terminate + re-evaluate |
| Dev OFF    | Flag flip only | Terminate + re-evaluate |
| Dev ON     | Flag flip only | Terminate + re-evaluate |

## Test plan

- [x] `pytest` — all 142 tests pass (27 scheduler, 5 new).
- [x] `ruff check backend/` — clean.
- [x] `ruff format --check backend/` — clean.
- [ ] Manual: reproduction from #54 (dev ON → start cycle → dev OFF → system ON) should now show no `ACTIVE` cycle.

Closes #54

https://claude.ai/code/session_01RSVZbjiJZAdUJfeoQExmvG