### PR TITLE
fix: per-vent control_method + surface vent errors to UI (#57)

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -21,6 +21,7 @@ from aiohttp import web
 from .. import db
 from ..engine import room_manager
 from ..models import (
+    VALID_CONTROL_METHODS,
     Room,
     RoomOverride,
     RoomPresenceSensor,
@@ -217,17 +218,50 @@ async def add_vent(request: web.Request) -> web.Response:
     body = await request.json()
     if not body.get("entity_id"):
         return error("entity_id required")
+    method = body.get("control_method", "open_close")
+    if method not in VALID_CONTROL_METHODS:
+        return error(f"invalid control_method: {method}")
     conn = await get_conn(request)
-    v = RoomVent.create(room_id=request.match_info["room_id"], entity_id=body["entity_id"])
+    v = RoomVent.create(
+        room_id=request.match_info["room_id"],
+        entity_id=body["entity_id"],
+        control_method=method,
+    )
     await db.add_room_vent(conn, v)
     await emit(
         request,
         "info",
         "api",
         f"Vent added to room {request.match_info['room_id']}: {body['entity_id']}",
-        {"room_id": request.match_info["room_id"], "entity_id": body["entity_id"]},
+        {
+            "room_id": request.match_info["room_id"],
+            "entity_id": body["entity_id"],
+            "control_method": method,
+        },
     )
     return json_response(v.__dict__, status=201)
+
+
+@routes.patch("/api/rooms/{room_id}/vents/{entity_id:.*}")
+async def update_vent(request: web.Request) -> web.Response:
+    body = await request.json()
+    method = body.get("control_method")
+    if method is None:
+        return error("control_method required")
+    if method not in VALID_CONTROL_METHODS:
+        return error(f"invalid control_method: {method}")
+    conn = await get_conn(request)
+    room_id = request.match_info["room_id"]
+    entity_id = request.match_info["entity_id"]
+    await db.update_room_vent_control_method(conn, room_id, entity_id, method)
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Vent {entity_id} control method updated to {method}",
+        {"room_id": room_id, "entity_id": entity_id, "control_method": method},
+    )
+    return json_response({"updated": True, "control_method": method})
 
 
 @routes.delete("/api/rooms/{room_id}/vents/{entity_id:.*}")
@@ -235,6 +269,71 @@ async def remove_vent(request: web.Request) -> web.Response:
     conn = await get_conn(request)
     await db.remove_room_vent(conn, request.match_info["room_id"], request.match_info["entity_id"])
     return json_response({"deleted": True})
+
+
+@routes.post("/api/vents/test")
+async def test_vent(request: web.Request) -> web.Response:
+    """Invoke the chosen open/close action against an entity immediately.
+
+    Accepts draft form state (entity_id + control_method + direction) so the
+    user can iterate on the method choice before saving. Surfaces the raw HA
+    error message on failure so misconfigured integrations are diagnosable
+    inside the app.
+    """
+    body = await request.json()
+    entity_id = body.get("entity_id")
+    method = body.get("control_method")
+    direction = body.get("direction")
+    if not entity_id:
+        return error("entity_id required")
+    if method not in VALID_CONTROL_METHODS:
+        return error(f"invalid control_method: {method}")
+    if direction not in ("open", "close"):
+        return error("direction must be 'open' or 'close'")
+
+    ha = request.app["ha"]
+    try:
+        if direction == "open":
+            if method == "set_position":
+                await ha.set_cover_position(entity_id, 100)
+            elif method == "set_tilt_position":
+                await ha.set_cover_tilt_position(entity_id, 100)
+            elif method == "toggle":
+                await ha.toggle_cover(entity_id)
+            else:
+                await ha.open_cover(entity_id)
+        else:
+            if method == "set_position":
+                await ha.set_cover_position(entity_id, 0)
+            elif method == "set_tilt_position":
+                await ha.set_cover_tilt_position(entity_id, 0)
+            elif method == "toggle":
+                await ha.toggle_cover(entity_id)
+            else:
+                await ha.close_cover(entity_id)
+    except Exception as exc:
+        await emit(
+            request,
+            "warning",
+            "api",
+            f"Vent test {direction} failed for {entity_id} ({method}): {exc}",
+            {
+                "entity_id": entity_id,
+                "control_method": method,
+                "direction": direction,
+                "error": str(exc),
+            },
+        )
+        return error(str(exc), status=400)
+
+    await emit(
+        request,
+        "info",
+        "api",
+        f"Vent test {direction} succeeded for {entity_id} ({method})",
+        {"entity_id": entity_id, "control_method": method, "direction": direction},
+    )
+    return json_response({"ok": True})
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS room_vents (
     id TEXT PRIMARY KEY,
     room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
     entity_id TEXT NOT NULL,
+    control_method TEXT NOT NULL DEFAULT 'open_close',
     UNIQUE(room_id, entity_id)
 );
 
@@ -158,6 +159,7 @@ _MIGRATIONS = [
     "ALTER TABLE thermostat_configs ADD COLUMN name TEXT NOT NULL DEFAULT ''",
     "ALTER TABLE thermostat_configs ADD COLUMN default_temp REAL",
     "ALTER TABLE thermostat_configs ADD COLUMN reconciliation_interval_min INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE room_vents ADD COLUMN control_method TEXT NOT NULL DEFAULT 'open_close'",
 ]
 
 
@@ -281,13 +283,34 @@ async def remove_room_sensor(conn: aiosqlite.Connection, room_id: str, entity_id
 async def get_room_vents(conn: aiosqlite.Connection, room_id: str) -> list[RoomVent]:
     async with conn.execute("SELECT * FROM room_vents WHERE room_id=?", (room_id,)) as cur:
         rows = await cur.fetchall()
-    return [RoomVent(id=r["id"], room_id=r["room_id"], entity_id=r["entity_id"]) for r in rows]
+    return [
+        RoomVent(
+            id=r["id"],
+            room_id=r["room_id"],
+            entity_id=r["entity_id"],
+            control_method=r["control_method"],
+        )
+        for r in rows
+    ]
 
 
 async def add_room_vent(conn: aiosqlite.Connection, v: RoomVent) -> None:
     await conn.execute(
-        "INSERT OR IGNORE INTO room_vents(id,room_id,entity_id) VALUES (?,?,?)",
-        (v.id, v.room_id, v.entity_id),
+        "INSERT OR IGNORE INTO room_vents(id,room_id,entity_id,control_method) VALUES (?,?,?,?)",
+        (v.id, v.room_id, v.entity_id, v.control_method),
+    )
+    await conn.commit()
+
+
+async def update_room_vent_control_method(
+    conn: aiosqlite.Connection,
+    room_id: str,
+    entity_id: str,
+    control_method: str,
+) -> None:
+    await conn.execute(
+        "UPDATE room_vents SET control_method=? WHERE room_id=? AND entity_id=?",
+        (control_method, room_id, entity_id),
     )
     await conn.commit()
 

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -27,6 +27,61 @@ class VentController:
         self._logger = event_logger
 
     # ------------------------------------------------------------------
+    # Dispatch: per-vent control method → HA service call
+    # ------------------------------------------------------------------
+
+    async def _invoke_open(self, vent: RoomVent) -> None:
+        """Issue the configured 'open' action for one vent. Raises if HA fails."""
+        method = vent.control_method
+        if method == "set_position":
+            await self._ha.set_cover_position(vent.entity_id, 100)
+        elif method == "set_tilt_position":
+            await self._ha.set_cover_tilt_position(vent.entity_id, 100)
+        elif method == "toggle":
+            await self._ha.toggle_cover(vent.entity_id)
+        else:  # "open_close" (default)
+            await self._ha.open_cover(vent.entity_id)
+
+    async def _invoke_close(self, vent: RoomVent) -> None:
+        """Issue the configured 'close' action for one vent. Raises if HA fails."""
+        method = vent.control_method
+        if method == "set_position":
+            await self._ha.set_cover_position(vent.entity_id, 0)
+        elif method == "set_tilt_position":
+            await self._ha.set_cover_tilt_position(vent.entity_id, 0)
+        elif method == "toggle":
+            await self._ha.toggle_cover(vent.entity_id)
+        else:  # "open_close"
+            await self._ha.close_cover(vent.entity_id)
+
+    async def _log_vent_error(self, vent: RoomVent, direction: str, exc: Exception) -> None:
+        """Surface a vent service-call failure to the UI Live Feed.
+
+        Vent failures never abort a cycle — they're logged here and the engine
+        moves on to the next vent. Misconfigured control_method on a single
+        vent must not stall the zone.
+        """
+        log.error(
+            "Vent %s %s failed (method=%s): %s",
+            vent.entity_id,
+            direction,
+            vent.control_method,
+            exc,
+        )
+        if self._logger:
+            await self._logger.log(
+                "error",
+                "engine",
+                f"Failed to {direction} vent {vent.entity_id} using {vent.control_method}: {exc}",
+                {
+                    "entity_id": vent.entity_id,
+                    "control_method": vent.control_method,
+                    "direction": direction,
+                    "error": str(exc),
+                },
+            )
+
+    # ------------------------------------------------------------------
     # Open / close with safety guards
     # ------------------------------------------------------------------
 
@@ -36,15 +91,20 @@ class VentController:
             if state is None:
                 log.error("Vent entity %s not found in HA", vent.entity_id)
                 continue
-            if state.get("state") != "open":
-                await self._ha.open_cover(vent.entity_id)
-                if self._logger:
-                    await self._logger.log(
-                        "info",
-                        "engine",
-                        f"Opened vent {vent.entity_id}",
-                        {"entity_id": vent.entity_id},
-                    )
+            if state.get("state") == "open":
+                continue
+            try:
+                await self._invoke_open(vent)
+            except Exception as exc:
+                await self._log_vent_error(vent, "open", exc)
+                continue
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Opened vent {vent.entity_id}",
+                    {"entity_id": vent.entity_id, "control_method": vent.control_method},
+                )
 
     async def close_room_vents(
         self,
@@ -87,15 +147,20 @@ class VentController:
                 return False
 
         for vent in vents:
-            if self._is_open(vent.entity_id):
-                await self._ha.close_cover(vent.entity_id)
-                if self._logger:
-                    await self._logger.log(
-                        "info",
-                        "engine",
-                        f"Closed vent {vent.entity_id} (room at target)",
-                        {"entity_id": vent.entity_id},
-                    )
+            if not self._is_open(vent.entity_id):
+                continue
+            try:
+                await self._invoke_close(vent)
+            except Exception as exc:
+                await self._log_vent_error(vent, "close", exc)
+                continue
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Closed vent {vent.entity_id} (room at target)",
+                    {"entity_id": vent.entity_id, "control_method": vent.control_method},
+                )
 
         return True
 
@@ -158,16 +223,16 @@ class VentController:
         """Emergency: close every vent in a zone (thermostat unavailable etc.)."""
         for vent in all_zone_vents:
             try:
-                await self._ha.close_cover(vent.entity_id)
+                await self._invoke_close(vent)
                 if self._logger:
                     await self._logger.log(
                         "warning",
                         "engine",
                         f"Emergency closed vent {vent.entity_id}",
-                        {"entity_id": vent.entity_id},
+                        {"entity_id": vent.entity_id, "control_method": vent.control_method},
                     )
             except Exception as exc:
-                log.error("Failed to close vent %s: %s", vent.entity_id, exc)
+                await self._log_vent_error(vent, "close", exc)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -217,6 +217,64 @@ class HAClient:
         log.info("Closing vent %s", entity_id)
         await self.call_service("cover", "close_cover", {"entity_id": entity_id})
 
+    async def set_cover_position(self, entity_id: str, position: int) -> None:
+        """cover.set_cover_position (0..100). Dev mode is a no-op logged to dev_logger."""
+        if self.dev_mode:
+            log.info("[DEV] Would set %s position → %d", entity_id, position)
+            if self._dev_logger:
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
+                    f"Would set vent {entity_id} position → {position}",
+                    {"entity_id": entity_id, "action": "set_position", "position": position},
+                )
+            return
+        log.info("Setting vent %s position → %d", entity_id, position)
+        await self.call_service(
+            "cover", "set_cover_position", {"entity_id": entity_id, "position": position}
+        )
+
+    async def set_cover_tilt_position(self, entity_id: str, tilt_position: int) -> None:
+        """cover.set_cover_tilt_position (0..100). Used by integrations (e.g. some
+        Flair vents) that expose tilt rather than open/close or position."""
+        if self.dev_mode:
+            log.info("[DEV] Would set %s tilt → %d", entity_id, tilt_position)
+            if self._dev_logger:
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
+                    f"Would set vent {entity_id} tilt → {tilt_position}",
+                    {
+                        "entity_id": entity_id,
+                        "action": "set_tilt_position",
+                        "tilt_position": tilt_position,
+                    },
+                )
+            return
+        log.info("Setting vent %s tilt → %d", entity_id, tilt_position)
+        await self.call_service(
+            "cover",
+            "set_cover_tilt_position",
+            {"entity_id": entity_id, "tilt_position": tilt_position},
+        )
+
+    async def toggle_cover(self, entity_id: str) -> None:
+        """cover.toggle — invert current state. Caller must ensure the current
+        state does not already match the desired state (vent_controller does
+        this via its state-match skip)."""
+        if self.dev_mode:
+            log.info("[DEV] Would toggle %s", entity_id)
+            if self._dev_logger:
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
+                    f"Would toggle vent {entity_id}",
+                    {"entity_id": entity_id, "action": "toggle"},
+                )
+            return
+        log.info("Toggling vent %s", entity_id)
+        await self.call_service("cover", "toggle", {"entity_id": entity_id})
+
     async def get_entities_by_domain(self, domain: str) -> list[dict]:
         """Return all cached states for a given domain."""
         await self._connected.wait()

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -8,6 +8,15 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, time
+from typing import Literal
+
+ControlMethod = Literal["open_close", "set_position", "set_tilt_position", "toggle"]
+VALID_CONTROL_METHODS: tuple[ControlMethod, ...] = (
+    "open_close",
+    "set_position",
+    "set_tilt_position",
+    "toggle",
+)
 
 
 def new_id() -> str:
@@ -51,10 +60,21 @@ class RoomVent:
     id: str
     room_id: str
     entity_id: str  # cover.*
+    control_method: ControlMethod = "open_close"
 
     @classmethod
-    def create(cls, room_id: str, entity_id: str) -> RoomVent:
-        return cls(id=new_id(), room_id=room_id, entity_id=entity_id)
+    def create(
+        cls,
+        room_id: str,
+        entity_id: str,
+        control_method: ControlMethod = "open_close",
+    ) -> RoomVent:
+        return cls(
+            id=new_id(),
+            room_id=room_id,
+            entity_id=entity_id,
+            control_method=control_method,
+        )
 
 
 @dataclass

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -286,6 +286,20 @@ class Scheduler:
             await engine.tick(self._db_conn)
         except Exception as exc:
             log.exception("Tick error for %s: %s", tid, exc)
+            # Mirror to event logger so the UI Live Feed surfaces tick crashes
+            # (vent service errors, HA unavailability, anything else). Without
+            # this, errors only land in container logs and the user has no way
+            # to notice from inside the app.
+            if self._event_logger:
+                try:
+                    await self._event_logger.log(
+                        "error",
+                        "engine",
+                        f"Tick error for {tid}: {exc}",
+                        {"thermostat": tid, "error": str(exc)},
+                    )
+                except Exception:
+                    log.exception("Failed to write tick error to event logger for %s", tid)
 
     # ------------------------------------------------------------------
     # HA state change dispatch

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -687,3 +687,34 @@ class TestTickEngine:
         # Should not raise
         await sched._tick_engine(THERMO_A, engine)
         await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tick_exception_written_to_event_logger(self):
+        """Issue #57: tick failures must surface to the UI Live Feed, not just
+        container logs. Scheduler mirrors the exception to event_logger so the
+        user can see vent/HA errors from inside the app."""
+        from backend.event_logger import EventLogger
+
+        ha = _make_ha()
+        event_logger = EventLogger()
+        sched = Scheduler(ha=ha, db_path=":memory:", event_logger=event_logger)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        event_logger.set_conn(conn)
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+
+        engine = sched._engines[THERMO_A]
+        engine.load_room_sensors = AsyncMock()
+        engine.tick = AsyncMock(side_effect=RuntimeError("set_cover_position failed"))
+
+        await sched._tick_engine(THERMO_A, engine)
+
+        events = await db.get_event_logs(conn, category="engine", limit=10)
+        tick_errors = [e for e in events if e["level"] == "error" and "Tick error" in e["message"]]
+        assert len(tick_errors) == 1
+        assert THERMO_A in tick_errors[0]["message"]
+        assert "set_cover_position failed" in tick_errors[0]["message"]
+        await conn.close()

--- a/smart_vent/backend/tests/test_vent_controller.py
+++ b/smart_vent/backend/tests/test_vent_controller.py
@@ -48,7 +48,22 @@ def _make_ha(vent_states: dict[str, str] | None = None) -> MagicMock:
     ha.get_state.side_effect = get_state
     ha.open_cover = AsyncMock()
     ha.close_cover = AsyncMock()
+    ha.set_cover_position = AsyncMock()
+    ha.set_cover_tilt_position = AsyncMock()
+    ha.toggle_cover = AsyncMock()
     return ha
+
+
+class _RecordingLogger:
+    """Stand-in for EventLogger — captures calls for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, str, dict | None]] = []
+
+    async def log(
+        self, level: str, category: str, message: str, details: dict | None = None
+    ) -> None:
+        self.events.append((level, category, message, details))
 
 
 def _make_tc(**overrides) -> ThermostatConfig:
@@ -61,8 +76,8 @@ def _make_tc(**overrides) -> ThermostatConfig:
     return ThermostatConfig(**defaults)
 
 
-def _make_vent(room_id: str, entity_id: str) -> RoomVent:
-    return RoomVent.create(room_id=room_id, entity_id=entity_id)
+def _make_vent(room_id: str, entity_id: str, control_method: str = "open_close") -> RoomVent:
+    return RoomVent.create(room_id=room_id, entity_id=entity_id, control_method=control_method)
 
 
 # ---------------------------------------------------------------------------
@@ -372,3 +387,183 @@ class TestVentHelpers:
 
         states = ctrl.get_vent_states(vents)
         assert states["cover.missing"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Per-vent control_method dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestControlMethodDispatch:
+    @pytest.mark.asyncio
+    async def test_open_uses_open_cover_by_default(self):
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.v1", control_method="open_close")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.open_cover.assert_called_once_with("cover.v1")
+        ha.set_cover_position.assert_not_called()
+        ha.set_cover_tilt_position.assert_not_called()
+        ha.toggle_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_uses_set_position(self):
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.v1", control_method="set_position")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.set_cover_position.assert_called_once_with("cover.v1", 100)
+        ha.open_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_uses_set_tilt_position(self):
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.v1", control_method="set_tilt_position")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.set_cover_tilt_position.assert_called_once_with("cover.v1", 100)
+        ha.open_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_open_uses_toggle(self):
+        ha = _make_ha({"cover.v1": "closed"})
+        ctrl = VentController(ha)
+        vent = _make_vent("r1", "cover.v1", control_method="toggle")
+
+        await ctrl.open_room_vents([vent])
+
+        ha.toggle_cover.assert_called_once_with("cover.v1")
+        ha.open_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_close_uses_close_cover_by_default(self):
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+        vent = _make_vent("r1", "cover.v1", control_method="open_close")
+
+        await ctrl.close_room_vents([vent], [vent], tc, {})
+
+        ha.close_cover.assert_called_once_with("cover.v1")
+
+    @pytest.mark.asyncio
+    async def test_close_uses_set_position_zero(self):
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+        vent = _make_vent("r1", "cover.v1", control_method="set_position")
+
+        await ctrl.close_room_vents([vent], [vent], tc, {})
+
+        ha.set_cover_position.assert_called_once_with("cover.v1", 0)
+        ha.close_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_close_uses_set_tilt_position_zero(self):
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+        vent = _make_vent("r1", "cover.v1", control_method="set_tilt_position")
+
+        await ctrl.close_room_vents([vent], [vent], tc, {})
+
+        ha.set_cover_tilt_position.assert_called_once_with("cover.v1", 0)
+        ha.close_cover.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_close_uses_toggle(self):
+        ha = _make_ha({"cover.v1": "open"})
+        ctrl = VentController(ha)
+        tc = _make_tc(min_open_vents=0)
+        vent = _make_vent("r1", "cover.v1", control_method="toggle")
+
+        await ctrl.close_room_vents([vent], [vent], tc, {})
+
+        ha.toggle_cover.assert_called_once_with("cover.v1")
+        ha.close_cover.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Service-call failure handling — never abort the cycle, always log
+# ---------------------------------------------------------------------------
+
+
+class TestVentFailureLogging:
+    @pytest.mark.asyncio
+    async def test_open_failure_logs_and_continues(self):
+        """If one vent raises during open, the remaining vents still open."""
+        ha = _make_ha({"cover.v1": "closed", "cover.v2": "closed"})
+        ha.open_cover.side_effect = [RuntimeError("HA boom"), None]
+        event_logger = _RecordingLogger()
+        ctrl = VentController(ha, event_logger=event_logger)
+
+        vents = [_make_vent("r1", "cover.v1"), _make_vent("r1", "cover.v2")]
+        # Must not raise — failures are swallowed per vent
+        await ctrl.open_room_vents(vents)
+
+        assert ha.open_cover.call_count == 2
+        # One error event for v1, one info event for v2 (successful open)
+        errors = [e for e in event_logger.events if e[0] == "error"]
+        assert len(errors) == 1
+        assert "cover.v1" in errors[0][2]
+        assert "open" in errors[0][2].lower()
+
+    @pytest.mark.asyncio
+    async def test_close_failure_logs_and_continues(self):
+        """If one vent raises during close, the remaining vents still close."""
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "open"})
+        ha.close_cover.side_effect = [RuntimeError("nope"), None]
+        event_logger = _RecordingLogger()
+        ctrl = VentController(ha, event_logger=event_logger)
+        tc = _make_tc(min_open_vents=0)
+
+        vents = [_make_vent("r1", "cover.v1"), _make_vent("r1", "cover.v2")]
+        result = await ctrl.close_room_vents(vents, vents, tc, {})
+
+        # Cycle does not abort — close_room_vents returns True (close attempted)
+        assert result is True
+        assert ha.close_cover.call_count == 2
+        errors = [e for e in event_logger.events if e[0] == "error"]
+        assert len(errors) == 1
+        assert "cover.v1" in errors[0][2]
+
+    @pytest.mark.asyncio
+    async def test_set_tilt_failure_logs_method_in_details(self):
+        """Failure details include control_method so users can see which was tried."""
+        ha = _make_ha({"cover.v1": "closed"})
+        ha.set_cover_tilt_position.side_effect = RuntimeError("unsupported service")
+        event_logger = _RecordingLogger()
+        ctrl = VentController(ha, event_logger=event_logger)
+
+        vent = _make_vent("r1", "cover.v1", control_method="set_tilt_position")
+        await ctrl.open_room_vents([vent])
+
+        errors = [e for e in event_logger.events if e[0] == "error"]
+        assert len(errors) == 1
+        _, category, message, details = errors[0]
+        assert category == "engine"
+        assert "set_tilt_position" in message
+        assert details is not None
+        assert details["control_method"] == "set_tilt_position"
+        assert details["direction"] == "open"
+
+    @pytest.mark.asyncio
+    async def test_close_all_zone_vents_continues_on_failure(self):
+        """Emergency close: one failure must not prevent the rest from closing."""
+        ha = _make_ha({"cover.v1": "open", "cover.v2": "open"})
+        ha.close_cover.side_effect = [RuntimeError("boom"), None]
+        event_logger = _RecordingLogger()
+        ctrl = VentController(ha, event_logger=event_logger)
+
+        vents = [_make_vent("r1", "cover.v1"), _make_vent("r1", "cover.v2")]
+        await ctrl.close_all_zone_vents(vents)
+
+        assert ha.close_cover.call_count == 2
+        errors = [e for e in event_logger.events if e[0] == "error"]
+        assert len(errors) == 1

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -187,7 +187,11 @@ export const updateVentControlMethod = (
   );
 export const removeVent = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/vents/${entity_id}`, { method: "DELETE" });
-export const testVent = (entity_id: string, control_method: ControlMethod, direction: "open" | "close") =>
+export const testVent = (
+  entity_id: string,
+  control_method: ControlMethod,
+  direction: "open" | "close"
+) =>
   api<{ ok: true }>("/api/vents/test", {
     method: "POST",
     body: JSON.stringify({ entity_id, control_method, direction }),

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -22,10 +22,20 @@ export interface RoomSensor {
   room_id: string;
   entity_id: string;
 }
+export type ControlMethod = "open_close" | "set_position" | "set_tilt_position" | "toggle";
+
+export const CONTROL_METHOD_LABELS: Record<ControlMethod, string> = {
+  open_close: "Open / close (cover.open_cover · cover.close_cover)",
+  set_position: "Set position 0/100 (cover.set_cover_position)",
+  set_tilt_position: "Set tilt 0/100 (cover.set_cover_tilt_position)",
+  toggle: "Toggle (cover.toggle)",
+};
+
 export interface RoomVent {
   id: string;
   room_id: string;
   entity_id: string;
+  control_method: ControlMethod;
 }
 export interface RoomPresenceSensor {
   id: string;
@@ -157,13 +167,31 @@ export const removeSensor = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/sensors/${entity_id}`, { method: "DELETE" });
 
 // Vents
-export const addVent = (room_id: string, entity_id: string) =>
+export const addVent = (
+  room_id: string,
+  entity_id: string,
+  control_method: ControlMethod = "open_close"
+) =>
   api<RoomVent>(`/api/rooms/${room_id}/vents`, {
     method: "POST",
-    body: JSON.stringify({ entity_id }),
+    body: JSON.stringify({ entity_id, control_method }),
   });
+export const updateVentControlMethod = (
+  room_id: string,
+  entity_id: string,
+  control_method: ControlMethod
+) =>
+  api<{ updated: boolean; control_method: ControlMethod }>(
+    `/api/rooms/${room_id}/vents/${entity_id}`,
+    { method: "PATCH", body: JSON.stringify({ control_method }) }
+  );
 export const removeVent = (room_id: string, entity_id: string) =>
   api<unknown>(`/api/rooms/${room_id}/vents/${entity_id}`, { method: "DELETE" });
+export const testVent = (entity_id: string, control_method: ControlMethod, direction: "open" | "close") =>
+  api<{ ok: true }>("/api/vents/test", {
+    method: "POST",
+    body: JSON.stringify({ entity_id, control_method, direction }),
+  });
 
 // Presence sensors
 export const addPresence = (room_id: string, entity_id: string) =>

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -305,8 +305,8 @@ function VentTable({
       </div>
       <p className="text-sm text-muted" style={{ marginBottom: ".75rem" }}>
         Vents in this room, controlled as cover entities. When the room hits target, the system
-        closes these vents. Each vent can use a different control method depending on which
-        services its HA integration exposes.
+        closes these vents. Each vent can use a different control method depending on which services
+        its HA integration exposes.
       </p>
 
       <EntityPicker

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -9,12 +9,17 @@ import {
   removeSensor,
   addVent,
   removeVent,
+  updateVentControlMethod,
+  testVent,
   addPresence,
   removePresence,
   getThermostats,
   getEntityStates,
   getRoomActiveStatuses,
+  CONTROL_METHOD_LABELS,
+  type ControlMethod,
   type Room,
+  type RoomVent,
   type ThermostatConfig,
   type EntityState,
   type RoomActiveStatus,
@@ -280,6 +285,169 @@ function EntitySection({
 }
 
 // ---------------------------------------------------------------------------
+// Flair Vents table — per-vent control method + test actions
+// ---------------------------------------------------------------------------
+function VentTable({
+  roomId,
+  vents,
+  onChanged,
+}: {
+  roomId: string;
+  vents: RoomVent[];
+  onChanged: () => Promise<void>;
+}) {
+  return (
+    <div style={{ marginBottom: "1.5rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: ".5rem", marginBottom: ".3rem" }}>
+        <span style={{ fontSize: "1.2rem" }}>💨</span>
+        <span style={{ fontWeight: 700, fontSize: "1rem" }}>Flair Vents</span>
+        {vents.length > 0 && <span className="badge badge-blue">{vents.length}</span>}
+      </div>
+      <p className="text-sm text-muted" style={{ marginBottom: ".75rem" }}>
+        Vents in this room, controlled as cover entities. When the room hits target, the system
+        closes these vents. Each vent can use a different control method depending on which
+        services its HA integration exposes.
+      </p>
+
+      <EntityPicker
+        domain="cover"
+        placeholder="Search Flair vents (cover.*)…"
+        onSelect={async (id) => {
+          await addVent(roomId, id);
+          await onChanged();
+        }}
+      />
+
+      {vents.length === 0 ? (
+        <p className="text-sm text-muted" style={{ marginTop: ".5rem", fontStyle: "italic" }}>
+          No vents added yet — search above to add one. Rooms without vents are sensor-only and
+          still participate in schedules and presence control.
+        </p>
+      ) : (
+        <div style={{ marginTop: ".75rem", overflowX: "auto" }}>
+          <table className="vent-table" style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border, #ddd)" }}>
+                <th style={{ padding: ".4rem .5rem" }}>Entity</th>
+                <th style={{ padding: ".4rem .5rem" }}>Control method</th>
+                <th style={{ padding: ".4rem .5rem" }}>Test</th>
+                <th style={{ padding: ".4rem .5rem" }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {vents.map((v) => (
+                <VentRow key={v.id} vent={v} onChanged={onChanged} />
+              ))}
+            </tbody>
+          </table>
+          <p className="text-sm text-muted" style={{ marginTop: ".5rem", fontStyle: "italic" }}>
+            Not sure which method your vent uses? Try it in Home Assistant → Developer Tools →
+            Actions against the entity to see which service works.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VentRow({ vent, onChanged }: { vent: RoomVent; onChanged: () => Promise<void> }) {
+  const [method, setMethod] = useState<ControlMethod>(vent.control_method);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState<"open" | "close" | null>(null);
+  const [status, setStatus] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  const onChangeMethod = async (next: ControlMethod) => {
+    setMethod(next);
+    setSaving(true);
+    setStatus(null);
+    try {
+      await updateVentControlMethod(vent.room_id, vent.entity_id, next);
+      await onChanged();
+    } catch (err) {
+      setStatus({ ok: false, msg: `Save failed: ${(err as Error).message}` });
+      setMethod(vent.control_method);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runTest = async (direction: "open" | "close") => {
+    setTesting(direction);
+    setStatus(null);
+    try {
+      await testVent(vent.entity_id, method, direction);
+      setStatus({ ok: true, msg: `${direction === "open" ? "Open" : "Close"} command accepted` });
+    } catch (err) {
+      setStatus({ ok: false, msg: (err as Error).message });
+    } finally {
+      setTesting(null);
+    }
+  };
+
+  return (
+    <tr style={{ borderBottom: "1px solid var(--border, #eee)", verticalAlign: "top" }}>
+      <td style={{ padding: ".5rem" }}>
+        <span className="font-mono text-sm">{vent.entity_id}</span>
+      </td>
+      <td style={{ padding: ".5rem" }}>
+        <select
+          value={method}
+          onChange={(e) => onChangeMethod(e.target.value as ControlMethod)}
+          disabled={saving}
+          style={{ minWidth: "20rem" }}
+        >
+          {(Object.keys(CONTROL_METHOD_LABELS) as ControlMethod[]).map((m) => (
+            <option key={m} value={m}>
+              {CONTROL_METHOD_LABELS[m]}
+            </option>
+          ))}
+        </select>
+        {status && (
+          <div
+            className="text-sm"
+            style={{
+              marginTop: ".25rem",
+              color: status.ok ? "var(--success, #1a7f37)" : "var(--danger, #b3261e)",
+            }}
+          >
+            {status.ok ? "✓" : "✗"} {status.msg}
+          </div>
+        )}
+      </td>
+      <td style={{ padding: ".5rem", whiteSpace: "nowrap" }}>
+        <button
+          className="btn btn-sm"
+          onClick={() => runTest("open")}
+          disabled={testing !== null || saving}
+          style={{ marginRight: ".25rem" }}
+        >
+          {testing === "open" ? "…" : "Test open"}
+        </button>
+        <button
+          className="btn btn-sm"
+          onClick={() => runTest("close")}
+          disabled={testing !== null || saving}
+        >
+          {testing === "close" ? "…" : "Test close"}
+        </button>
+      </td>
+      <td style={{ padding: ".5rem" }}>
+        <button
+          className="tag-remove"
+          title="Remove"
+          onClick={async () => {
+            await removeVent(vent.room_id, vent.entity_id);
+            await onChanged();
+          }}
+        >
+          ×
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Room configure view (sensors, vents, presence)
 // ---------------------------------------------------------------------------
 function RoomConfigure({
@@ -433,17 +601,7 @@ function RoomConfigure({
 
         <hr className="divider" />
 
-        <EntitySection
-          title="Flair Vents"
-          description="Vents in this room controlled as cover entities. When the room hits its target temperature the system closes these vents."
-          icon="💨"
-          items={vents}
-          domain="cover"
-          pickerPlaceholder="Search Flair vents (cover.*)…"
-          emptyHint="No vents added yet — search above to add one. Rooms without vents are sensor-only and still participate in schedules and presence control."
-          onAdd={wrap("Adding vent…", (id: string) => addVent(room.id, id))}
-          onRemove={wrap("Removing vent…", (id: string) => removeVent(room.id, id))}
-        />
+        <VentTable roomId={room.id} vents={room.vents ?? []} onChanged={refresh} />
 
         <hr className="divider" />
 


### PR DESCRIPTION
## Summary

Resolves #57. Flair and other HA cover integrations don't all accept `cover.open_cover`/`close_cover`; some need `set_cover_tilt_position`, `set_cover_position`, or `toggle`. Previously every vent was forced through the same service calls, so unsupported integrations failed on every cycle and the error only appeared in container logs — the user had no way to diagnose from inside the app.

- Each vent now stores a `control_method` (`open_close` | `set_position` | `set_tilt_position` | `toggle`). Existing rows default to `open_close` via a DB migration.
- `VentController` dispatches the chosen service per-vent and wraps every call in `try/except` so one misconfigured vent can't abort the cycle — failures are logged to the event logger and the engine continues.
- Scheduler `_tick_engine` mirrors tick exceptions to the event logger so vent/HA errors surface in the UI Live Feed, not just the container logs.
- New `HAClient` wrappers: `set_cover_position`, `set_cover_tilt_position`, `toggle_cover` (each dev-mode aware).
- Flair Vents section is now a table with a method dropdown, **Test open** / **Test close** buttons, and a remove button. `POST /api/vents/test` runs the chosen action immediately against a draft entity+method so users can verify the right service before saving.

## Test plan

- [x] `python -m pytest` — 155 tests pass (added 9 new: per-method dispatch for each of the four methods, failure-path logging without cycle abort, emergency-close failure handling, tick-error mirrored to event logger)
- [x] `ruff check backend/` + `ruff format --check backend/` clean
- [x] `tsc --noEmit` + `vite build` clean
- [ ] Manual: pick `set_tilt_position` on a Flair vent, click **Test close** — verify the vent moves and the Live Feed shows either success or the HA error (instead of only container logs)
- [ ] Manual: pick `set_position` (unsupported by Flair) on the same vent — verify the failure appears in the Live Feed and does **not** abort the rest of the cycle

https://claude.ai/code/session_01RSVZbjiJZAdUJfeoQExmvG