### PR TITLE
feat: cycle history diagnostics — trigger/temp/vent/setpoint capture …

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -697,6 +697,36 @@ async def ha_entities(request: web.Request) -> web.Response:
     return json_response(result)
 
 
+def _cycle_log_to_dict(log_entry) -> dict:
+    try:
+        rooms = json.loads(log_entry.rooms_json) if log_entry.rooms_json else {}
+    except (ValueError, TypeError):
+        rooms = {}
+    try:
+        vents_at_start = json.loads(log_entry.vents_at_start) if log_entry.vents_at_start else None
+    except (ValueError, TypeError):
+        vents_at_start = None
+    try:
+        vents_at_end = json.loads(log_entry.vents_at_end) if log_entry.vents_at_end else None
+    except (ValueError, TypeError):
+        vents_at_end = None
+    return {
+        "id": log_entry.id,
+        "thermostat_entity_id": log_entry.thermostat_entity_id,
+        "started_at": log_entry.started_at.isoformat(),
+        "ended_at": log_entry.ended_at.isoformat() if log_entry.ended_at else None,
+        "mode": log_entry.mode,
+        "rooms": rooms,
+        "ended_reason": log_entry.ended_reason,
+        "thermostat_temp_at_start": log_entry.thermostat_temp_at_start,
+        "thermostat_temp_at_end": log_entry.thermostat_temp_at_end,
+        "setpoint_at_start": log_entry.setpoint_at_start,
+        "setpoint_at_end": log_entry.setpoint_at_end,
+        "vents_at_start": vents_at_start,
+        "vents_at_end": vents_at_end,
+    }
+
+
 @routes.get("/api/logs")
 async def get_logs(request: web.Request) -> web.Response:
     conn = await get_conn(request)
@@ -705,17 +735,100 @@ async def get_logs(request: web.Request) -> web.Response:
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
     logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
+    return json_response([_cycle_log_to_dict(log_entry) for log_entry in logs])
+
+
+@routes.get("/api/logs/{cycle_id}/detail")
+async def get_log_detail(request: web.Request) -> web.Response:
+    """Return enriched per-cycle diagnostics: rooms, vent events, setpoint history."""
+    conn = await get_conn(request)
+    cycle_id = request.match_info["cycle_id"]
+    cycle = await db.get_cycle_log(conn, cycle_id)
+    if cycle is None:
+        return json_response({"error": "not_found"}, status=404)
+
+    rooms_meta: dict = {}
+    try:
+        rooms_meta = json.loads(cycle.rooms_json) if cycle.rooms_json else {}
+    except (ValueError, TypeError):
+        rooms_meta = {}
+
+    room_states = await db.get_room_cycle_states(conn, cycle_id)
+    rooms_payload = []
+    for rcs in room_states:
+        meta = rooms_meta.get(rcs.room_id, {}) or {}
+        try:
+            trigger = json.loads(rcs.trigger_detail) if rcs.trigger_detail else None
+        except (ValueError, TypeError):
+            trigger = None
+        rooms_payload.append(
+            {
+                "room_id": rcs.room_id,
+                "name": meta.get("name"),
+                "source": meta.get("source"),
+                "target_temp": rcs.target_temp,
+                "reached_at": rcs.reached_at.isoformat() if rcs.reached_at else None,
+                "vent_closed_at": rcs.vent_closed_at.isoformat() if rcs.vent_closed_at else None,
+                "temp_at_start": rcs.temp_at_start,
+                "temp_at_end": rcs.temp_at_end,
+                "trigger_detail": trigger,
+                "joined_at": rcs.joined_at.isoformat() if rcs.joined_at else None,
+            }
+        )
+
+    vent_events = await db.get_cycle_vent_events(conn, cycle_id)
+    vent_events_payload = [
+        {
+            "id": ev.id,
+            "timestamp": ev.timestamp.isoformat(),
+            "entity_id": ev.entity_id,
+            "room_id": ev.room_id,
+            "action": ev.action,
+            "reason": ev.reason,
+        }
+        for ev in vent_events
+    ]
+
+    setpoint_history = await db.get_cycle_setpoint_history(conn, cycle_id)
+    setpoint_history_payload = [
+        {
+            "id": sp.id,
+            "timestamp": sp.timestamp.isoformat(),
+            "setpoint": sp.setpoint,
+            "reason": sp.reason,
+        }
+        for sp in setpoint_history
+    ]
+
+    return json_response(
+        {
+            "cycle": _cycle_log_to_dict(cycle),
+            "rooms": rooms_payload,
+            "vent_events": vent_events_payload,
+            "setpoint_history": setpoint_history_payload,
+        }
+    )
+
+
+@routes.get("/api/logs/{cycle_id}/temp-samples")
+async def get_log_temp_samples(request: web.Request) -> web.Response:
+    """Return periodic temperature samples for a cycle, optionally filtered by room."""
+    conn = await get_conn(request)
+    cycle_id = request.match_info["cycle_id"]
+    room_id = request.rel_url.query.get("room_id") or None
+    samples = await db.get_cycle_temp_samples(conn, cycle_id, room_id=room_id)
     return json_response(
         [
             {
-                "id": log_entry.id,
-                "thermostat_entity_id": log_entry.thermostat_entity_id,
-                "started_at": log_entry.started_at.isoformat(),
-                "ended_at": log_entry.ended_at.isoformat() if log_entry.ended_at else None,
-                "mode": log_entry.mode,
-                "rooms": json.loads(log_entry.rooms_json),
+                "id": s.id,
+                "cycle_id": s.cycle_id,
+                "room_id": s.room_id,
+                "timestamp": s.timestamp.isoformat(),
+                "room_temp": s.room_temp,
+                "thermostat_temp": s.thermostat_temp,
+                "setpoint": s.setpoint,
             }
-            for log_entry in logs
+            for s in samples
         ]
     )
 

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -14,6 +14,9 @@ import aiosqlite
 
 from .models import (
     CycleLog,
+    CycleSetpointHistory,
+    CycleTempSample,
+    CycleVentEvent,
     PresenceHoldoverState,
     Room,
     RoomCycleState,
@@ -108,7 +111,14 @@ CREATE TABLE IF NOT EXISTS cycle_logs (
     started_at TEXT NOT NULL,
     ended_at TEXT,
     mode TEXT NOT NULL,
-    rooms_json TEXT NOT NULL DEFAULT '{}'
+    rooms_json TEXT NOT NULL DEFAULT '{}',
+    ended_reason TEXT,
+    thermostat_temp_at_start REAL,
+    thermostat_temp_at_end REAL,
+    setpoint_at_start REAL,
+    setpoint_at_end REAL,
+    vents_at_start TEXT,
+    vents_at_end TEXT
 );
 
 CREATE TABLE IF NOT EXISTS room_cycle_states (
@@ -117,7 +127,39 @@ CREATE TABLE IF NOT EXISTS room_cycle_states (
     target_temp REAL NOT NULL,
     reached_at TEXT,
     vent_closed_at TEXT,
+    temp_at_start REAL,
+    temp_at_end REAL,
+    trigger_detail TEXT,
+    joined_at TEXT,
     PRIMARY KEY (cycle_id, room_id)
+);
+
+CREATE TABLE IF NOT EXISTS cycle_temp_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_id TEXT NOT NULL REFERENCES cycle_logs(id) ON DELETE CASCADE,
+    room_id TEXT,
+    timestamp TEXT NOT NULL,
+    room_temp REAL,
+    thermostat_temp REAL,
+    setpoint REAL
+);
+
+CREATE TABLE IF NOT EXISTS cycle_setpoint_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_id TEXT NOT NULL REFERENCES cycle_logs(id) ON DELETE CASCADE,
+    timestamp TEXT NOT NULL,
+    setpoint REAL NOT NULL,
+    reason TEXT
+);
+
+CREATE TABLE IF NOT EXISTS cycle_vent_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_id TEXT NOT NULL REFERENCES cycle_logs(id) ON DELETE CASCADE,
+    timestamp TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    room_id TEXT,
+    action TEXT NOT NULL,
+    reason TEXT
 );
 
 CREATE TABLE IF NOT EXISTS system_settings (
@@ -139,6 +181,9 @@ CREATE INDEX IF NOT EXISTS idx_cycle_logs_thermostat ON cycle_logs(thermostat_en
 CREATE INDEX IF NOT EXISTS idx_cycle_logs_ended ON cycle_logs(ended_at);
 CREATE INDEX IF NOT EXISTS idx_event_log_category ON event_log(category);
 CREATE INDEX IF NOT EXISTS idx_event_log_ts ON event_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_cycle_temp_samples_cycle ON cycle_temp_samples(cycle_id, room_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_cycle_setpoint_history_cycle ON cycle_setpoint_history(cycle_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_cycle_vent_events_cycle ON cycle_vent_events(cycle_id, timestamp);
 """
 
 
@@ -160,6 +205,18 @@ _MIGRATIONS = [
     "ALTER TABLE thermostat_configs ADD COLUMN default_temp REAL",
     "ALTER TABLE thermostat_configs ADD COLUMN reconciliation_interval_min INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE room_vents ADD COLUMN control_method TEXT NOT NULL DEFAULT 'open_close'",
+    # Cycle diagnostics (Issue #60)
+    "ALTER TABLE cycle_logs ADD COLUMN ended_reason TEXT",
+    "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_start REAL",
+    "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_end REAL",
+    "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_start REAL",
+    "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_end REAL",
+    "ALTER TABLE cycle_logs ADD COLUMN vents_at_start TEXT",
+    "ALTER TABLE cycle_logs ADD COLUMN vents_at_end TEXT",
+    "ALTER TABLE room_cycle_states ADD COLUMN temp_at_start REAL",
+    "ALTER TABLE room_cycle_states ADD COLUMN temp_at_end REAL",
+    "ALTER TABLE room_cycle_states ADD COLUMN trigger_detail TEXT",
+    "ALTER TABLE room_cycle_states ADD COLUMN joined_at TEXT",
 ]
 
 
@@ -656,6 +713,29 @@ async def close_open_cycles_for_rooms(
     return count
 
 
+def _row_to_cycle_log(r) -> CycleLog:
+    keys = r.keys() if hasattr(r, "keys") else []
+
+    def _get(name: str):
+        return r[name] if name in keys else None
+
+    return CycleLog(
+        id=r["id"],
+        thermostat_entity_id=r["thermostat_entity_id"],
+        started_at=datetime.fromisoformat(r["started_at"]),
+        mode=r["mode"],
+        rooms_json=r["rooms_json"],
+        ended_at=_dt(r["ended_at"]),
+        ended_reason=_get("ended_reason"),
+        thermostat_temp_at_start=_get("thermostat_temp_at_start"),
+        thermostat_temp_at_end=_get("thermostat_temp_at_end"),
+        setpoint_at_start=_get("setpoint_at_start"),
+        setpoint_at_end=_get("setpoint_at_end"),
+        vents_at_start=_get("vents_at_start"),
+        vents_at_end=_get("vents_at_end"),
+    )
+
+
 async def get_open_cycle_logs(
     conn: aiosqlite.Connection,
     thermostat_entity_id: str,
@@ -666,22 +746,21 @@ async def get_open_cycle_logs(
         (thermostat_entity_id,),
     ) as cur:
         rows = await cur.fetchall()
-    return [
-        CycleLog(
-            id=r["id"],
-            thermostat_entity_id=r["thermostat_entity_id"],
-            started_at=datetime.fromisoformat(r["started_at"]),
-            mode=r["mode"],
-            rooms_json=r["rooms_json"],
-            ended_at=None,
-        )
-        for r in rows
-    ]
+    return [_row_to_cycle_log(r) for r in rows]
+
+
+async def get_cycle_log(conn: aiosqlite.Connection, cycle_id: str) -> CycleLog | None:
+    async with conn.execute("SELECT * FROM cycle_logs WHERE id=?", (cycle_id,)) as cur:
+        row = await cur.fetchone()
+    return _row_to_cycle_log(row) if row else None
 
 
 async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
     await conn.execute(
-        "INSERT INTO cycle_logs(id,thermostat_entity_id,started_at,ended_at,mode,rooms_json) VALUES(?,?,?,?,?,?)",
+        """INSERT INTO cycle_logs(
+            id, thermostat_entity_id, started_at, ended_at, mode, rooms_json,
+            ended_reason, thermostat_temp_at_start, setpoint_at_start, vents_at_start
+        ) VALUES(?,?,?,?,?,?,?,?,?,?)""",
         (
             log_.id,
             log_.thermostat_entity_id,
@@ -689,14 +768,40 @@ async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
             _dts(log_.ended_at),
             log_.mode,
             log_.rooms_json,
+            log_.ended_reason,
+            log_.thermostat_temp_at_start,
+            log_.setpoint_at_start,
+            log_.vents_at_start,
         ),
     )
     await conn.commit()
 
 
-async def close_cycle_log(conn: aiosqlite.Connection, cycle_id: str, ended_at: datetime) -> None:
+async def close_cycle_log(
+    conn: aiosqlite.Connection,
+    cycle_id: str,
+    ended_at: datetime,
+    ended_reason: str | None = None,
+    thermostat_temp_at_end: float | None = None,
+    setpoint_at_end: float | None = None,
+    vents_at_end: str | None = None,
+) -> None:
     await conn.execute(
-        "UPDATE cycle_logs SET ended_at=? WHERE id=?", (ended_at.isoformat(), cycle_id)
+        """UPDATE cycle_logs SET
+            ended_at=?,
+            ended_reason=COALESCE(?, ended_reason),
+            thermostat_temp_at_end=COALESCE(?, thermostat_temp_at_end),
+            setpoint_at_end=COALESCE(?, setpoint_at_end),
+            vents_at_end=COALESCE(?, vents_at_end)
+           WHERE id=?""",
+        (
+            ended_at.isoformat(),
+            ended_reason,
+            thermostat_temp_at_end,
+            setpoint_at_end,
+            vents_at_end,
+            cycle_id,
+        ),
     )
     await conn.commit()
 
@@ -723,17 +828,7 @@ async def get_cycle_logs(
         params,
     ) as cur:
         rows = await cur.fetchall()
-    return [
-        CycleLog(
-            id=r["id"],
-            thermostat_entity_id=r["thermostat_entity_id"],
-            started_at=datetime.fromisoformat(r["started_at"]),
-            mode=r["mode"],
-            rooms_json=r["rooms_json"],
-            ended_at=_dt(r["ended_at"]),
-        )
-        for r in rows
-    ]
+    return [_row_to_cycle_log(r) for r in rows]
 
 
 async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
@@ -747,11 +842,16 @@ async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> 
 
 async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleState) -> None:
     await conn.execute(
-        """INSERT INTO room_cycle_states(cycle_id,room_id,target_temp,reached_at,vent_closed_at)
-           VALUES(?,?,?,?,?)
+        """INSERT INTO room_cycle_states(
+            cycle_id, room_id, target_temp, reached_at, vent_closed_at,
+            temp_at_start, temp_at_end, trigger_detail, joined_at
+           ) VALUES(?,?,?,?,?,?,?,?,?)
            ON CONFLICT(cycle_id,room_id) DO UPDATE SET
+             target_temp=excluded.target_temp,
              reached_at=excluded.reached_at,
-             vent_closed_at=excluded.vent_closed_at
+             vent_closed_at=excluded.vent_closed_at,
+             temp_at_end=excluded.temp_at_end,
+             trigger_detail=COALESCE(excluded.trigger_detail, room_cycle_states.trigger_detail)
         """,
         (
             rcs.cycle_id,
@@ -759,21 +859,160 @@ async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleStat
             rcs.target_temp,
             _dts(rcs.reached_at),
             _dts(rcs.vent_closed_at),
+            rcs.temp_at_start,
+            rcs.temp_at_end,
+            rcs.trigger_detail,
+            _dts(rcs.joined_at),
         ),
     )
     await conn.commit()
 
 
+def _row_to_room_cycle_state(r) -> RoomCycleState:
+    keys = r.keys() if hasattr(r, "keys") else []
+
+    def _get(name: str):
+        return r[name] if name in keys else None
+
+    return RoomCycleState(
+        cycle_id=r["cycle_id"],
+        room_id=r["room_id"],
+        target_temp=r["target_temp"],
+        reached_at=_dt(r["reached_at"]),
+        vent_closed_at=_dt(r["vent_closed_at"]),
+        temp_at_start=_get("temp_at_start"),
+        temp_at_end=_get("temp_at_end"),
+        trigger_detail=_get("trigger_detail"),
+        joined_at=_dt(_get("joined_at")) if _get("joined_at") else None,
+    )
+
+
 async def get_room_cycle_states(conn: aiosqlite.Connection, cycle_id: str) -> list[RoomCycleState]:
     async with conn.execute("SELECT * FROM room_cycle_states WHERE cycle_id=?", (cycle_id,)) as cur:
         rows = await cur.fetchall()
+    return [_row_to_room_cycle_state(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Cycle diagnostics (Issue #60)
+# ---------------------------------------------------------------------------
+
+
+async def insert_cycle_temp_sample(
+    conn: aiosqlite.Connection,
+    cycle_id: str,
+    room_id: str | None,
+    timestamp: datetime,
+    room_temp: float | None,
+    thermostat_temp: float | None,
+    setpoint: float | None,
+) -> None:
+    await conn.execute(
+        """INSERT INTO cycle_temp_samples(cycle_id,room_id,timestamp,room_temp,thermostat_temp,setpoint)
+           VALUES(?,?,?,?,?,?)""",
+        (cycle_id, room_id, timestamp.isoformat(), room_temp, thermostat_temp, setpoint),
+    )
+    await conn.commit()
+
+
+async def get_cycle_temp_samples(
+    conn: aiosqlite.Connection,
+    cycle_id: str,
+    room_id: str | None = None,
+) -> list[CycleTempSample]:
+    if room_id is None:
+        async with conn.execute(
+            "SELECT * FROM cycle_temp_samples WHERE cycle_id=? ORDER BY timestamp ASC, id ASC",
+            (cycle_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+    else:
+        async with conn.execute(
+            "SELECT * FROM cycle_temp_samples WHERE cycle_id=? AND room_id=? ORDER BY timestamp ASC, id ASC",
+            (cycle_id, room_id),
+        ) as cur:
+            rows = await cur.fetchall()
     return [
-        RoomCycleState(
+        CycleTempSample(
+            id=r["id"],
             cycle_id=r["cycle_id"],
             room_id=r["room_id"],
-            target_temp=r["target_temp"],
-            reached_at=_dt(r["reached_at"]),
-            vent_closed_at=_dt(r["vent_closed_at"]),
+            timestamp=datetime.fromisoformat(r["timestamp"]),
+            room_temp=r["room_temp"],
+            thermostat_temp=r["thermostat_temp"],
+            setpoint=r["setpoint"],
+        )
+        for r in rows
+    ]
+
+
+async def insert_cycle_setpoint_history(
+    conn: aiosqlite.Connection,
+    cycle_id: str,
+    timestamp: datetime,
+    setpoint: float,
+    reason: str | None = None,
+) -> None:
+    await conn.execute(
+        """INSERT INTO cycle_setpoint_history(cycle_id,timestamp,setpoint,reason)
+           VALUES(?,?,?,?)""",
+        (cycle_id, timestamp.isoformat(), setpoint, reason),
+    )
+    await conn.commit()
+
+
+async def get_cycle_setpoint_history(
+    conn: aiosqlite.Connection, cycle_id: str
+) -> list[CycleSetpointHistory]:
+    async with conn.execute(
+        "SELECT * FROM cycle_setpoint_history WHERE cycle_id=? ORDER BY timestamp ASC, id ASC",
+        (cycle_id,),
+    ) as cur:
+        rows = await cur.fetchall()
+    return [
+        CycleSetpointHistory(
+            id=r["id"],
+            cycle_id=r["cycle_id"],
+            timestamp=datetime.fromisoformat(r["timestamp"]),
+            setpoint=r["setpoint"],
+            reason=r["reason"],
+        )
+        for r in rows
+    ]
+
+
+async def insert_cycle_vent_event(
+    conn: aiosqlite.Connection,
+    cycle_id: str,
+    timestamp: datetime,
+    entity_id: str,
+    room_id: str | None,
+    action: str,
+    reason: str | None = None,
+) -> None:
+    await conn.execute(
+        """INSERT INTO cycle_vent_events(cycle_id,timestamp,entity_id,room_id,action,reason)
+           VALUES(?,?,?,?,?,?)""",
+        (cycle_id, timestamp.isoformat(), entity_id, room_id, action, reason),
+    )
+    await conn.commit()
+
+
+async def get_cycle_vent_events(conn: aiosqlite.Connection, cycle_id: str) -> list[CycleVentEvent]:
+    async with conn.execute(
+        "SELECT * FROM cycle_vent_events WHERE cycle_id=? ORDER BY timestamp ASC, id ASC",
+        (cycle_id,),
+    ) as cur:
+        rows = await cur.fetchall()
+    return [
+        CycleVentEvent(
+            id=r["id"],
+            cycle_id=r["cycle_id"],
+            timestamp=datetime.fromisoformat(r["timestamp"]),
+            entity_id=r["entity_id"],
+            room_id=r["room_id"],
+            action=r["action"],
+            reason=r["reason"],
         )
         for r in rows
     ]

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -316,7 +316,7 @@ class CycleEngine:
                             "cycle_id": self._cycle_log.id,
                         },
                     )
-                await self._terminate_cycle(conn)
+                await self._terminate_cycle(conn, reason="timeout")
 
         await self._maybe_reconcile(conn)
         await self._maybe_broadcast()
@@ -329,16 +329,18 @@ class CycleEngine:
     ) -> None:
         tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
 
-        # Load vents for all active rooms
-        self._room_vents = {}
+        # Load vents for all active rooms (new set) — snapshot BEFORE opening
+        # so we can record vents_at_start for fresh cycles.
+        new_room_vents: dict[str, list[RoomVent]] = {}
         for room_id in new_active_map:
-            self._room_vents[room_id] = await db.get_room_vents(conn, room_id)
+            new_room_vents[room_id] = await db.get_room_vents(conn, room_id)
 
         # Newly added rooms mid-cycle
         added = set(new_active_map) - set(self._active_rooms)
         removed = set(self._active_rooms) - set(new_active_map)
 
         self._active_rooms = new_active_map
+        self._room_vents = new_room_vents
 
         if self._state == CycleState.IDLE:
             # Lock in the cycle direction — used by _monitor_rooms for the entire
@@ -408,11 +410,21 @@ class CycleEngine:
                 }
                 for ar in new_active_map.values()
             }
+            # Capture starting thermostat temp, setpoint, and vent states BEFORE
+            # the engine opens any vents or writes a new setpoint.
+            thermo_temp_start, thermo_setpoint_start = self._read_thermo_temp_and_setpoint()
+            vents_at_start_json = self._snapshot_vent_states_json(
+                [v for vl in self._room_vents.values() for v in vl]
+            )
+
             self._cycle_log = CycleLog.create(
                 thermostat_entity_id=self.thermostat_entity_id,
                 mode=hvac_mode,
                 rooms_json=json.dumps(rooms_snapshot),
             )
+            self._cycle_log.thermostat_temp_at_start = thermo_temp_start
+            self._cycle_log.setpoint_at_start = thermo_setpoint_start
+            self._cycle_log.vents_at_start = vents_at_start_json
             await db.insert_cycle_log(conn, self._cycle_log)
             # Transition to RUNNING immediately after the DB insert so that if
             # any subsequent await raises, the next tick takes the running-cycle
@@ -420,13 +432,34 @@ class CycleEngine:
             self._state = CycleState.RUNNING
             self._room_cycle_states = {}
             for ar in new_active_map.values():
+                trigger_detail = await self._build_trigger_detail(conn, ar)
                 rcs = RoomCycleState(
                     cycle_id=self._cycle_log.id,
                     room_id=ar.room.id,
                     target_temp=ar.target_temp,
+                    temp_at_start=self._get_avg_temp(ar.room),
+                    trigger_detail=json.dumps(trigger_detail) if trigger_detail else None,
+                    joined_at=None,
                 )
                 self._room_cycle_states[ar.room.id] = rcs
                 await db.upsert_room_cycle_state(conn, rcs)
+            # Record "opened_at_start" vent events for every vent in the fresh
+            # cycle so the diagnostics view shows the initial open actions.
+            now_ts = datetime.utcnow()
+            for room_id, vents in self._room_vents.items():
+                for v in vents:
+                    try:
+                        await db.insert_cycle_vent_event(
+                            conn,
+                            self._cycle_log.id,
+                            now_ts,
+                            v.entity_id,
+                            room_id,
+                            "opened_at_start",
+                            None,
+                        )
+                    except Exception as exc:
+                        log.debug("Failed to record opened_at_start event: %s", exc)
             room_names = [ar.room.name for ar in new_active_map.values()]
             log.info(
                 "Cycle started for %s — mode=%s rooms=%s",
@@ -450,10 +483,14 @@ class CycleEngine:
             # Update existing cycle (rooms changed mid-cycle)
             for room_id in added:
                 ar = new_active_map[room_id]
+                trigger_detail = await self._build_trigger_detail(conn, ar)
                 rcs = RoomCycleState(
                     cycle_id=self._cycle_log.id,
                     room_id=room_id,
                     target_temp=ar.target_temp,
+                    temp_at_start=self._get_avg_temp(ar.room),
+                    trigger_detail=json.dumps(trigger_detail) if trigger_detail else None,
+                    joined_at=datetime.utcnow(),
                 )
                 self._room_cycle_states[room_id] = rcs
                 await db.upsert_room_cycle_state(conn, rcs)
@@ -516,19 +553,55 @@ class CycleEngine:
                 await self._vent.open_room_vents(vents)
 
         # Set thermostat setpoint
-        await self._set_thermostat_setpoint(tc, hvac_mode)
+        await self._set_thermostat_setpoint(tc, hvac_mode, conn=conn)
 
     async def _monitor_rooms(self, conn: aiosqlite.Connection, hvac_mode: str) -> None:
         tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
         all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
 
         # Safety: check max vent closed duration
-        await self._vent.check_max_closed_duration(
+        force_reopened_rooms = await self._vent.check_max_closed_duration(
             conn,
             self._room_vents,
             self._room_cycle_states,
             tc,
         )
+        # Mirror any force-reopens into the cycle diagnostics stream.
+        if force_reopened_rooms and self._cycle_log:
+            ts = datetime.utcnow()
+            for room_id in force_reopened_rooms:
+                for v in self._room_vents.get(room_id, []):
+                    try:
+                        await db.insert_cycle_vent_event(
+                            conn,
+                            self._cycle_log.id,
+                            ts,
+                            v.entity_id,
+                            room_id,
+                            "force_reopened_max_closed",
+                            f"exceeded max_vent_closed_min={tc.max_vent_closed_min}",
+                        )
+                    except Exception as exc:
+                        log.debug("Failed to record force_reopened event: %s", exc)
+
+        # Per-tick temperature sampling — lets the UI draw a chart per room of
+        # the temperature trajectory alongside the thermostat reading.
+        if self._cycle_log:
+            sample_ts = datetime.utcnow()
+            thermo_cur, thermo_sp = self._read_thermo_temp_and_setpoint()
+            for room_id, ar in self._active_rooms.items():
+                try:
+                    await db.insert_cycle_temp_sample(
+                        conn,
+                        self._cycle_log.id,
+                        room_id,
+                        sample_ts,
+                        self._get_avg_temp(ar.room),
+                        thermo_cur,
+                        thermo_sp,
+                    )
+                except Exception as exc:
+                    log.debug("Failed to record temp sample: %s", exc)
 
         all_at_target = True
         for room_id, ar in self._active_rooms.items():
@@ -600,7 +673,23 @@ class CycleEngine:
                     rcs.vent_closed_at = datetime.utcnow()
                     if rcs.reached_at is None:
                         rcs.reached_at = datetime.utcnow()
+                    rcs.temp_at_end = avg
                     await db.upsert_room_cycle_state(conn, rcs)
+                    if self._cycle_log:
+                        ts = rcs.vent_closed_at
+                        for v in vents:
+                            try:
+                                await db.insert_cycle_vent_event(
+                                    conn,
+                                    self._cycle_log.id,
+                                    ts,
+                                    v.entity_id,
+                                    room_id,
+                                    "closed_reached_target",
+                                    f"avg={avg:.1f} target={rcs.target_temp}",
+                                )
+                            except Exception as exc:
+                                log.debug("Failed to record closed_reached_target event: %s", exc)
                     offset_note = (
                         f", offset={ar.room.temp_offset:+.1f}°F" if ar.room.temp_offset != 0 else ""
                     )
@@ -635,15 +724,40 @@ class CycleEngine:
         if all_at_target and self._active_rooms:
             await self._terminate_cycle(conn)
 
-    async def _terminate_cycle(self, conn: aiosqlite.Connection) -> None:
+    async def _terminate_cycle(self, conn: aiosqlite.Connection, reason: str = "completed") -> None:
         log.info("All rooms at target for %s — terminating cycle", self.thermostat_entity_id)
         self._state = CycleState.TERMINATING
+
+        # Capture end-of-cycle diagnostics before any state mutations or HA calls.
+        thermo_temp_end, thermo_setpoint_end = self._read_thermo_temp_and_setpoint()
+        vents_at_end_json = self._snapshot_vent_states_json(
+            [v for vl in self._room_vents.values() for v in vl]
+        )
+
+        # Persist per-room temp_at_end for rooms that didn't hit target.
+        if self._cycle_log:
+            for room_id, ar in self._active_rooms.items():
+                rcs = self._room_cycle_states.get(room_id)
+                if rcs and rcs.temp_at_end is None:
+                    rcs.temp_at_end = self._get_avg_temp(ar.room)
+                    try:
+                        await db.upsert_room_cycle_state(conn, rcs)
+                    except Exception as exc:
+                        log.debug("Failed to persist end-of-cycle room state: %s", exc)
 
         # Close the DB record FIRST so the cycle log is never left orphaned
         # with ended_at=NULL if subsequent vent/setpoint operations fail.
         if self._cycle_log:
             try:
-                await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
+                await db.close_cycle_log(
+                    conn,
+                    self._cycle_log.id,
+                    datetime.utcnow(),
+                    ended_reason=reason,
+                    thermostat_temp_at_end=thermo_temp_end,
+                    setpoint_at_end=thermo_setpoint_end,
+                    vents_at_end=vents_at_end_json,
+                )
             except Exception as exc:
                 log.error("Failed to close cycle log %s in DB: %s", self._cycle_log.id, exc)
 
@@ -731,11 +845,36 @@ class CycleEngine:
                 },
             )
 
+        # Capture end-of-cycle diagnostics before any state mutations.
+        thermo_temp_end, thermo_setpoint_end = self._read_thermo_temp_and_setpoint()
+        vents_at_end_json = self._snapshot_vent_states_json(
+            [v for vl in self._room_vents.values() for v in vl]
+        )
+
+        # Persist per-room temp_at_end for active rooms that never hit target.
+        if self._cycle_log:
+            for room_id, ar in self._active_rooms.items():
+                rcs = self._room_cycle_states.get(room_id)
+                if rcs and rcs.temp_at_end is None:
+                    rcs.temp_at_end = self._get_avg_temp(ar.room)
+                    try:
+                        await db.upsert_room_cycle_state(conn, rcs)
+                    except Exception as exc:
+                        log.debug("Failed to persist abort room state: %s", exc)
+
         # Close the DB record FIRST so the cycle log is never left orphaned
         # with ended_at=NULL if subsequent vent/setpoint operations fail.
         if self._cycle_log:
             try:
-                await db.close_cycle_log(conn, self._cycle_log.id, datetime.utcnow())
+                await db.close_cycle_log(
+                    conn,
+                    self._cycle_log.id,
+                    datetime.utcnow(),
+                    ended_reason=f"aborted: {reason}",
+                    thermostat_temp_at_end=thermo_temp_end,
+                    setpoint_at_end=thermo_setpoint_end,
+                    vents_at_end=vents_at_end_json,
+                )
             except Exception as exc:
                 log.error(
                     "Abort: failed to close cycle log %s in DB: %s",
@@ -1040,6 +1179,70 @@ class CycleEngine:
             filtered[room_id] = ar
         return filtered
 
+    def _read_thermo_temp_and_setpoint(self) -> tuple[float | None, float | None]:
+        """Read (current_temperature, temperature) from the thermostat state."""
+        state = self._ha.get_state(self.thermostat_entity_id)
+        if not state:
+            return (None, None)
+        attrs = state.get("attributes", {})
+        cur = attrs.get("current_temperature")
+        sp = attrs.get("temperature")
+        try:
+            cur_f = float(cur) if cur is not None else None
+        except (ValueError, TypeError):
+            cur_f = None
+        try:
+            sp_f = float(sp) if sp is not None else None
+        except (ValueError, TypeError):
+            sp_f = None
+        return (cur_f, sp_f)
+
+    def _snapshot_vent_states_json(self, vents: list[RoomVent]) -> str | None:
+        if not vents:
+            return None
+        return json.dumps(self._vent.get_vent_states(vents))
+
+    async def _build_trigger_detail(
+        self, conn: aiosqlite.Connection, ar: ActiveRoom
+    ) -> dict | None:
+        """Build a per-room trigger detail dict for audit/UI display."""
+        detail: dict = {"source": ar.source, "target": ar.target_temp}
+        if ar.source == "override":
+            try:
+                override = await db.get_room_override(conn, ar.room.id)
+            except Exception:
+                override = None
+            if override:
+                detail["expires_at"] = override.expires_at.isoformat()
+        elif ar.source == "schedule":
+            try:
+                schedules = await db.get_schedules_for_room(conn, ar.room.id)
+                from .room_manager import _find_matching_schedule
+
+                match = _find_matching_schedule(schedules, datetime.now())
+                if match:
+                    detail["schedule_id"] = match.id
+                    detail["start_time"] = match.start_time.isoformat()
+                    detail["end_time"] = match.end_time.isoformat()
+                    detail["days_of_week"] = match.days_of_week
+            except Exception:
+                pass
+        elif ar.source == "presence":
+            try:
+                holdover = await db.get_holdover_state(conn, ar.room.id)
+            except Exception:
+                holdover = None
+            if holdover:
+                detail["holdover_expires_at"] = holdover.expires_at.isoformat()
+                detail["last_detected_at"] = holdover.last_detected_at.isoformat()
+            try:
+                sensors = await db.get_room_presence_sensors(conn, ar.room.id)
+                if sensors:
+                    detail["sensor_entity_ids"] = [s.entity_id for s in sensors]
+            except Exception:
+                pass
+        return detail
+
     def _get_avg_temp(self, room: Room) -> float | None:
         readings: list[float] = []
 
@@ -1062,7 +1265,12 @@ class CycleEngine:
             return None
         return sum(readings) / len(readings)
 
-    async def _set_thermostat_setpoint(self, tc: ThermostatConfig, hvac_mode: str) -> None:
+    async def _set_thermostat_setpoint(
+        self,
+        tc: ThermostatConfig,
+        hvac_mode: str,
+        conn: aiosqlite.Connection | None = None,
+    ) -> None:
         targets = [ar.target_temp for ar in self._active_rooms.values()]
         if not targets:
             return
@@ -1169,6 +1377,18 @@ class CycleEngine:
             # Track what we last commanded so reconciliation can detect external drift.
             self._last_setpoint_sent = setpoint
             self._cycle_ha_mode = ha_mode  # track the mode we locked the thermostat into
+            # Record setpoint change in cycle history for diagnostics.
+            if conn is not None and self._cycle_log:
+                try:
+                    await db.insert_cycle_setpoint_history(
+                        conn,
+                        self._cycle_log.id,
+                        datetime.utcnow(),
+                        setpoint,
+                        f"mode={hvac_mode}",
+                    )
+                except Exception as exc:
+                    log.debug("Failed to record setpoint history: %s", exc)
             if self._logger:
                 await self._logger.log(
                     "info",

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -168,6 +168,13 @@ class CycleLog:
     mode: str  # 'heating' | 'cooling'
     rooms_json: str  # JSON snapshot
     ended_at: datetime | None = None
+    ended_reason: str | None = None  # 'completed' | 'timeout' | 'system_disabled' | ...
+    thermostat_temp_at_start: float | None = None
+    thermostat_temp_at_end: float | None = None
+    setpoint_at_start: float | None = None
+    setpoint_at_end: float | None = None
+    vents_at_start: str | None = None  # JSON {entity_id: 'open'|'closed'|'unknown'}
+    vents_at_end: str | None = None
 
     @classmethod
     def create(cls, thermostat_entity_id: str, mode: str, rooms_json: str) -> CycleLog:
@@ -187,6 +194,43 @@ class RoomCycleState:
     target_temp: float
     reached_at: datetime | None = None
     vent_closed_at: datetime | None = None
+    temp_at_start: float | None = None
+    temp_at_end: float | None = None
+    trigger_detail: str | None = None  # JSON: schedule/override/presence metadata
+    joined_at: datetime | None = None  # NULL = present at cycle start
+
+
+@dataclass
+class CycleTempSample:
+    id: int
+    cycle_id: str
+    room_id: str | None  # NULL → thermostat-level sample
+    timestamp: datetime
+    room_temp: float | None
+    thermostat_temp: float | None
+    setpoint: float | None
+
+
+@dataclass
+class CycleSetpointHistory:
+    id: int
+    cycle_id: str
+    timestamp: datetime
+    setpoint: float
+    reason: str | None = None
+
+
+@dataclass
+class CycleVentEvent:
+    id: int
+    cycle_id: str
+    timestamp: datetime
+    entity_id: str
+    room_id: str | None
+    action: (
+        str  # opened_at_start | closed_reached_target | force_reopened_max_closed | closed_at_end
+    )
+    reason: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/tests/test_cycle_diagnostics.py
+++ b/smart_vent/backend/tests/test_cycle_diagnostics.py
@@ -1,0 +1,393 @@
+"""
+Tests for cycle diagnostics (Issue #60).
+
+Covers:
+  - Cycle start captures thermostat_temp_at_start, setpoint_at_start, vents_at_start
+  - Per-room temp_at_start, trigger_detail, joined_at
+  - Cycle termination: ended_reason="completed", end-state snapshots
+  - Cycle abort: ended_reason="aborted: <reason>" prefix
+  - Cycle timeout: ended_reason="timeout"
+  - Temp samples written per tick to cycle_temp_samples
+  - Setpoint history written on each setpoint change
+  - Vent events recorded at cycle start (opened_at_start), on target reach
+    (closed_reached_target), and on safety force-reopen (force_reopened_max_closed)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.engine.cycle_engine import CycleEngine, CycleState
+from backend.engine.room_manager import ActiveRoom
+from backend.engine.vent_controller import VentController
+from backend.models import (
+    CycleLog,
+    Room,
+    RoomCycleState,
+    RoomVent,
+    Schedule,
+    ThermostatConfig,
+)
+
+THERMO_ID = "climate.test_thermostat"
+
+
+def _make_ha(ambient: float = 72.0, setpoint: float = 75.0) -> MagicMock:
+    ha = MagicMock()
+    ha.get_state.return_value = {
+        "state": "cool",
+        "attributes": {
+            "current_temperature": ambient,
+            "temperature": setpoint,
+            "hvac_action": "cooling",
+        },
+    }
+    ha.get_numeric_state.return_value = None
+    ha.set_thermostat_temperature = AsyncMock()
+    ha.open_cover = AsyncMock()
+    ha.close_cover = AsyncMock()
+    ha.set_cover_position = AsyncMock()
+    ha.set_cover_tilt_position = AsyncMock()
+    ha.toggle_cover = AsyncMock()
+    return ha
+
+
+def _make_engine(ha: MagicMock | None = None) -> CycleEngine:
+    if ha is None:
+        ha = _make_ha()
+    return CycleEngine(
+        thermostat_entity_id=THERMO_ID,
+        ha=ha,
+        vent_ctrl=VentController(ha),
+        get_enabled=lambda: True,
+    )
+
+
+async def _setup_db_and_room(room_id: str = "r1", room_name: str = "Bedroom"):
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    room = Room(id=room_id, name=room_name, thermostat_entity_id=THERMO_ID)
+    await db.upsert_room(conn, room)
+    from backend.models import RoomSensor
+
+    sensor = RoomSensor.create(room_id=room.id, entity_id=f"sensor.{room_id}_temp")
+    await db.add_room_sensor(conn, sensor)
+    await db.upsert_thermostat_config(conn, ThermostatConfig(thermostat_entity_id=THERMO_ID))
+    return conn, room
+
+
+# ---------------------------------------------------------------------------
+# Cycle start snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestCycleStartSnapshot:
+    @pytest.mark.asyncio
+    async def test_cycle_start_captures_thermo_temp_setpoint_vents(self):
+        conn, room = await _setup_db_and_room()
+
+        # Add a vent so vents_at_start is populated
+        vent = RoomVent.create(room.id, "cover.vent_1")
+        await db.add_room_vent(conn, vent)
+
+        ha = _make_ha(ambient=78.5, setpoint=76.0)
+        # Pretend the vent is currently open in HA before the engine acts
+        ha.get_state.side_effect = lambda eid: (
+            {
+                "state": "cool",
+                "attributes": {
+                    "current_temperature": 78.5,
+                    "temperature": 76.0,
+                    "hvac_action": "cooling",
+                },
+            }
+            if eid == THERMO_ID
+            else {"state": "open", "attributes": {}}
+        )
+        ha.get_numeric_state.return_value = 78.0  # so temp_at_start is set
+
+        engine = _make_engine(ha)
+        await engine.load_room_sensors(conn, [room.id])
+
+        active_map = {
+            room.id: ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+        }
+        await engine._start_or_update_cycle(conn, active_map, "cooling")
+
+        cycle = engine._cycle_log
+        assert cycle is not None
+        assert cycle.thermostat_temp_at_start == pytest.approx(78.5)
+        assert cycle.setpoint_at_start == pytest.approx(76.0)
+        assert cycle.vents_at_start is not None
+        vents_map = json.loads(cycle.vents_at_start)
+        assert vents_map["cover.vent_1"] == "open"
+
+        # Per-room state
+        rcs = engine._room_cycle_states[room.id]
+        assert rcs.temp_at_start == pytest.approx(78.0)
+        assert rcs.trigger_detail is not None
+        detail = json.loads(rcs.trigger_detail)
+        assert detail["source"] == "schedule"
+        assert detail["target"] == 72.0
+        assert rcs.joined_at is None  # present at start
+
+        # DB was persisted
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.thermostat_temp_at_start == pytest.approx(78.5)
+        assert db_cycle.setpoint_at_start == pytest.approx(76.0)
+        assert db_cycle.vents_at_start is not None
+
+        # Vent events: opened_at_start written
+        events = await db.get_cycle_vent_events(conn, cycle.id)
+        assert any(e.action == "opened_at_start" for e in events)
+        assert any(e.entity_id == "cover.vent_1" for e in events)
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_schedule_trigger_detail_includes_times(self):
+        conn, room = await _setup_db_and_room()
+        # Create a schedule that matches right now so trigger_detail picks it up
+        now = datetime.now()
+        schedule = Schedule.create(
+            room_id=room.id,
+            days_of_week=list(range(7)),
+            start_time=(now - timedelta(hours=1)).time(),
+            end_time=(now + timedelta(hours=1)).time(),
+            target_temp=72.0,
+        )
+        await db.upsert_schedule(conn, schedule)
+
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        await engine.load_room_sensors(conn, [room.id])
+
+        active_map = {
+            room.id: ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+        }
+        await engine._start_or_update_cycle(conn, active_map, "cooling")
+
+        rcs = engine._room_cycle_states[room.id]
+        detail = json.loads(rcs.trigger_detail)
+        assert detail["source"] == "schedule"
+        assert detail["schedule_id"] == schedule.id
+        assert "start_time" in detail
+        assert "end_time" in detail
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Termination / abort / timeout
+# ---------------------------------------------------------------------------
+
+
+async def _running_cycle_with_vent():
+    conn, room = await _setup_db_and_room()
+    vent = RoomVent.create(room.id, "cover.vent_1")
+    await db.add_room_vent(conn, vent)
+
+    ha = _make_ha(ambient=70.0, setpoint=68.0)
+    # Vent is "closed" at end so it shows up in vents_at_end
+    ha.get_state.side_effect = lambda eid: (
+        {
+            "state": "cool",
+            "attributes": {
+                "current_temperature": 70.0,
+                "temperature": 68.0,
+                "hvac_action": "idle",
+            },
+        }
+        if eid == THERMO_ID
+        else {"state": "closed", "attributes": {}}
+    )
+
+    engine = _make_engine(ha)
+    await engine.load_room_sensors(conn, [room.id])
+
+    cycle = CycleLog.create(
+        thermostat_entity_id=THERMO_ID,
+        mode="cooling",
+        rooms_json=json.dumps({room.id: {"name": room.name, "target": 72.0}}),
+    )
+    await db.insert_cycle_log(conn, cycle)
+    rcs = RoomCycleState(cycle_id=cycle.id, room_id=room.id, target_temp=72.0)
+    await db.upsert_room_cycle_state(conn, rcs)
+
+    engine._state = CycleState.RUNNING
+    engine._cycle_log = cycle
+    engine._cycle_mode = "cooling"
+    engine._cycle_ha_mode = "cool"
+    engine._active_rooms = {
+        room.id: ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+    }
+    engine._room_cycle_states = {room.id: rcs}
+    engine._room_vents = {room.id: [vent]}
+    return engine, conn, cycle, room
+
+
+class TestCycleEndReasons:
+    @pytest.mark.asyncio
+    async def test_terminate_writes_completed_reason_and_end_state(self):
+        engine, conn, cycle, _room = await _running_cycle_with_vent()
+
+        await engine._terminate_cycle(conn)
+
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.ended_at is not None
+        assert db_cycle.ended_reason == "completed"
+        assert db_cycle.thermostat_temp_at_end == pytest.approx(70.0)
+        assert db_cycle.setpoint_at_end == pytest.approx(68.0)
+        assert db_cycle.vents_at_end is not None
+        vents_end = json.loads(db_cycle.vents_at_end)
+        assert vents_end["cover.vent_1"] == "closed"
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_terminate_with_reason_param(self):
+        engine, conn, cycle, _room = await _running_cycle_with_vent()
+
+        await engine._terminate_cycle(conn, reason="timeout")
+
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle.ended_reason == "timeout"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_writes_aborted_prefix(self):
+        engine, conn, cycle, _room = await _running_cycle_with_vent()
+
+        await engine._abort_cycle(conn, reason="system disabled")
+
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.ended_reason == "aborted: system disabled"
+        assert db_cycle.vents_at_end is not None
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Temp samples
+# ---------------------------------------------------------------------------
+
+
+class TestTempSampling:
+    @pytest.mark.asyncio
+    async def test_monitor_rooms_inserts_temp_sample(self):
+        engine, conn, cycle, room = await _running_cycle_with_vent()
+        engine._ha.get_numeric_state.return_value = 74.0  # room avg
+
+        await engine._monitor_rooms(conn, "cooling")
+
+        samples = await db.get_cycle_temp_samples(conn, cycle.id, room_id=room.id)
+        assert len(samples) >= 1
+        s = samples[-1]
+        assert s.room_temp == pytest.approx(74.0)
+        assert s.thermostat_temp == pytest.approx(70.0)
+        assert s.setpoint == pytest.approx(68.0)
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Setpoint history
+# ---------------------------------------------------------------------------
+
+
+class TestSetpointHistory:
+    @pytest.mark.asyncio
+    async def test_set_setpoint_writes_history(self):
+        engine, conn, cycle, _room = await _running_cycle_with_vent()
+        tc = ThermostatConfig(thermostat_entity_id=THERMO_ID, overshoot_delta=2.0)
+
+        await engine._set_thermostat_setpoint(tc, "cooling", conn=conn)
+
+        history = await db.get_cycle_setpoint_history(conn, cycle.id)
+        assert len(history) == 1
+        entry = history[0]
+        assert entry.setpoint is not None
+        assert entry.reason == "mode=cooling"
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_set_setpoint_without_conn_does_not_error(self):
+        """Tests that still pass tc alone (no conn) don't fail."""
+        engine, conn, _cycle, _room = await _running_cycle_with_vent()
+        tc = ThermostatConfig(thermostat_entity_id=THERMO_ID, overshoot_delta=2.0)
+
+        # No conn — should not raise
+        await engine._set_thermostat_setpoint(tc, "cooling")
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Vent events
+# ---------------------------------------------------------------------------
+
+
+class TestVentEvents:
+    @pytest.mark.asyncio
+    async def test_closed_reached_target_event(self):
+        engine, conn, cycle, room = await _running_cycle_with_vent()
+        # Simulate room now at target so _monitor_rooms decides to close.
+        engine._ha.get_numeric_state.return_value = 72.0
+        # Vent returns "open" so close_room_vents will actually close it.
+        engine._ha.get_state.side_effect = lambda eid: (
+            {
+                "state": "cool",
+                "attributes": {
+                    "current_temperature": 70.0,
+                    "temperature": 68.0,
+                    "hvac_action": "idle",
+                },
+            }
+            if eid == THERMO_ID
+            else {"state": "open", "attributes": {}}
+        )
+
+        await engine._monitor_rooms(conn, "cooling")
+
+        events = await db.get_cycle_vent_events(conn, cycle.id)
+        assert any(e.action == "closed_reached_target" for e in events)
+
+        # temp_at_end also populated
+        rcs_rows = await db.get_room_cycle_states(conn, cycle.id)
+        assert rcs_rows[0].temp_at_end == pytest.approx(72.0)
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_force_reopened_event(self):
+        engine, conn, cycle, room = await _running_cycle_with_vent()
+        # Configure short max_vent_closed_min so the safety trips.
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_ID, max_vent_closed_min=1, overshoot_delta=2.0
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        # Pretend vent has been closed for >1 min already.
+        rcs = engine._room_cycle_states[room.id]
+        rcs.vent_closed_at = datetime.utcnow() - timedelta(minutes=5)
+        await db.upsert_room_cycle_state(conn, rcs)
+
+        engine._ha.get_numeric_state.return_value = 70.0
+
+        await engine._monitor_rooms(conn, "cooling")
+
+        events = await db.get_cycle_vent_events(conn, cycle.id)
+        assert any(e.action == "force_reopened_max_closed" for e in events)
+
+        await conn.close()

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -94,6 +94,59 @@ export interface CycleLog {
   ended_at: string | null;
   mode: string;
   rooms: Record<string, { name: string; target: number; source: string }>;
+  ended_reason?: string | null;
+  thermostat_temp_at_start?: number | null;
+  thermostat_temp_at_end?: number | null;
+  setpoint_at_start?: number | null;
+  setpoint_at_end?: number | null;
+  vents_at_start?: Record<string, string> | null;
+  vents_at_end?: Record<string, string> | null;
+}
+
+export interface CycleRoomDetail {
+  room_id: string;
+  name: string | null;
+  source: string | null;
+  target_temp: number;
+  reached_at: string | null;
+  vent_closed_at: string | null;
+  temp_at_start: number | null;
+  temp_at_end: number | null;
+  trigger_detail: Record<string, unknown> | null;
+  joined_at: string | null;
+}
+
+export interface CycleVentEvent {
+  id: number;
+  timestamp: string;
+  entity_id: string;
+  room_id: string | null;
+  action: string;
+  reason: string | null;
+}
+
+export interface CycleSetpointEvent {
+  id: number;
+  timestamp: string;
+  setpoint: number;
+  reason: string | null;
+}
+
+export interface CycleDetail {
+  cycle: CycleLog;
+  rooms: CycleRoomDetail[];
+  vent_events: CycleVentEvent[];
+  setpoint_history: CycleSetpointEvent[];
+}
+
+export interface CycleTempSample {
+  id: number;
+  cycle_id: string;
+  room_id: string | null;
+  timestamp: string;
+  room_temp: number | null;
+  thermostat_temp: number | null;
+  setpoint: number | null;
 }
 
 export interface HAEntity {
@@ -283,6 +336,18 @@ export const getLogs = (params: CycleLogParams = {}) => {
   if (params.since) p.set("since", params.since);
   if (params.until) p.set("until", params.until);
   return api<CycleLog[]>(`/api/logs?${p}`);
+};
+
+export const getCycleDetail = (cycleId: string) =>
+  api<CycleDetail>(`/api/logs/${encodeURIComponent(cycleId)}/detail`);
+
+export const getCycleTempSamples = (cycleId: string, roomId?: string) => {
+  const p = new URLSearchParams();
+  if (roomId) p.set("room_id", roomId);
+  const q = p.toString();
+  return api<CycleTempSample[]>(
+    `/api/logs/${encodeURIComponent(cycleId)}/temp-samples${q ? `?${q}` : ""}`
+  );
 };
 
 export const getEventLogs = (params: EventLogParams = {}) => {

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getLogs,
   getEventLogs,
   clearEventLogs,
   getLogRetention,
   setLogRetention,
+  getCycleDetail,
+  getCycleTempSamples,
   connectWS,
   type CycleLog,
+  type CycleDetail,
+  type CycleTempSample,
   type EventLogEntry,
   type LogRetentionSettings,
 } from "../api";
@@ -136,8 +140,203 @@ function duration(start: string, end: string | null): string {
   return `${(mins / 60).toFixed(1)}h`;
 }
 
+function fmtTemp(v: number | null | undefined, digits = 1): string {
+  if (v === null || v === undefined || Number.isNaN(v)) return "—";
+  return `${v.toFixed(digits)}°F`;
+}
+
+function fmtTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso + "Z").toLocaleTimeString();
+}
+
+type OutcomeKind = "active" | "completed" | "timeout" | "aborted" | "unknown";
+
+function outcomeOf(log: CycleLog): { kind: OutcomeKind; label: string; color: string } {
+  if (!log.ended_at) return { kind: "active", label: "Active", color: "green" };
+  const reason = log.ended_reason ?? "";
+  if (reason === "completed") return { kind: "completed", label: "Completed", color: "blue" };
+  if (reason === "timeout") return { kind: "timeout", label: "Timeout", color: "orange" };
+  if (reason.startsWith("aborted"))
+    return {
+      kind: "aborted",
+      label: reason.replace(/^aborted:\s*/, "Aborted: "),
+      color: "red",
+    };
+  return { kind: "unknown", label: reason || "Ended", color: "gray" };
+}
+
+function triggerSummary(detail: Record<string, unknown> | null): string {
+  if (!detail) return "";
+  const source = detail.source as string | undefined;
+  if (source === "schedule") {
+    const start = detail.start_time as string | undefined;
+    const end = detail.end_time as string | undefined;
+    if (start && end) return `schedule ${start.slice(0, 5)}–${end.slice(0, 5)}`;
+    return "schedule";
+  }
+  if (source === "override") {
+    const exp = detail.expires_at as string | undefined;
+    return exp ? `override, expires ${new Date(exp + "Z").toLocaleString()}` : "override";
+  }
+  if (source === "presence") {
+    const exp = detail.holdover_expires_at as string | undefined;
+    return exp ? `presence, holdover ends ${new Date(exp + "Z").toLocaleString()}` : "presence";
+  }
+  return source ?? "";
+}
+
+function TempChartModal({
+  cycleId,
+  roomId,
+  roomName,
+  onClose,
+}: {
+  cycleId: string;
+  roomId: string;
+  roomName: string;
+  onClose: () => void;
+}) {
+  const [samples, setSamples] = useState<CycleTempSample[] | null>(null);
+  const [err, setErr] = useState<string>("");
+
+  useEffect(() => {
+    getCycleTempSamples(cycleId, roomId)
+      .then(setSamples)
+      .catch((e) => setErr(e instanceof Error ? e.message : "Failed to load"));
+  }, [cycleId, roomId]);
+
+  const svg = useMemo(() => {
+    if (!samples || samples.length === 0) return null;
+    const W = 720;
+    const H = 320;
+    const PAD = 40;
+    const t0 = new Date(samples[0].timestamp + "Z").getTime();
+    const tN = new Date(samples[samples.length - 1].timestamp + "Z").getTime();
+    const dt = Math.max(1, tN - t0);
+    const values: number[] = [];
+    for (const s of samples) {
+      if (s.room_temp != null) values.push(s.room_temp);
+      if (s.thermostat_temp != null) values.push(s.thermostat_temp);
+      if (s.setpoint != null) values.push(s.setpoint);
+    }
+    if (values.length === 0) return null;
+    const minV = Math.min(...values) - 1;
+    const maxV = Math.max(...values) + 1;
+    const dv = Math.max(0.01, maxV - minV);
+    const x = (ts: string) => PAD + ((new Date(ts + "Z").getTime() - t0) / dt) * (W - 2 * PAD);
+    const y = (v: number) => H - PAD - ((v - minV) / dv) * (H - 2 * PAD);
+
+    const series = (key: "room_temp" | "thermostat_temp" | "setpoint") =>
+      samples
+        .filter((s) => s[key] != null)
+        .map((s) => `${x(s.timestamp).toFixed(1)},${y(s[key] as number).toFixed(1)}`)
+        .join(" ");
+
+    const roomPts = series("room_temp");
+    const thermoPts = series("thermostat_temp");
+    const setpointPts = series("setpoint");
+
+    return { W, H, PAD, roomPts, thermoPts, setpointPts, minV, maxV };
+  }, [samples]);
+
+  return (
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal" style={{ maxWidth: 800 }}>
+        <div className="modal-title">Temperature — {roomName}</div>
+        {err && <div className="badge badge-red">{err}</div>}
+        {!err && samples === null && (
+          <div className="loading">
+            <div className="spinner" /> Loading samples…
+          </div>
+        )}
+        {samples && samples.length === 0 && (
+          <div className="empty-state">
+            <p>No temperature samples recorded for this room in this cycle.</p>
+          </div>
+        )}
+        {svg && (
+          <>
+            <svg
+              width="100%"
+              viewBox={`0 0 ${svg.W} ${svg.H}`}
+              style={{ background: "var(--gray-50)", borderRadius: 4 }}
+            >
+              <line
+                x1={svg.PAD}
+                y1={svg.H - svg.PAD}
+                x2={svg.W - svg.PAD}
+                y2={svg.H - svg.PAD}
+                stroke="var(--gray-400)"
+              />
+              <line
+                x1={svg.PAD}
+                y1={svg.PAD}
+                x2={svg.PAD}
+                y2={svg.H - svg.PAD}
+                stroke="var(--gray-400)"
+              />
+              <text x={svg.PAD} y={svg.PAD - 8} fontSize="10" fill="var(--gray-600)">
+                {svg.maxV.toFixed(1)}°F
+              </text>
+              <text x={svg.PAD} y={svg.H - svg.PAD + 16} fontSize="10" fill="var(--gray-600)">
+                {svg.minV.toFixed(1)}°F
+              </text>
+              {svg.roomPts && (
+                <polyline fill="none" stroke="#2563eb" strokeWidth="2" points={svg.roomPts} />
+              )}
+              {svg.thermoPts && (
+                <polyline
+                  fill="none"
+                  stroke="#f97316"
+                  strokeWidth="2"
+                  strokeDasharray="4 3"
+                  points={svg.thermoPts}
+                />
+              )}
+              {svg.setpointPts && (
+                <polyline
+                  fill="none"
+                  stroke="#6b7280"
+                  strokeWidth="1.5"
+                  strokeDasharray="2 3"
+                  points={svg.setpointPts}
+                />
+              )}
+            </svg>
+            <div style={{ display: "flex", gap: "1rem", marginTop: ".5rem", fontSize: ".8rem" }}>
+              <span style={{ color: "#2563eb" }}>■ Room avg</span>
+              <span style={{ color: "#f97316" }}>■ Thermostat</span>
+              <span style={{ color: "#6b7280" }}>■ Setpoint</span>
+            </div>
+          </>
+        )}
+        <div className="modal-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function LogRow({ log }: { log: CycleLog }) {
   const [expanded, setExpanded] = useState(false);
+  const [detail, setDetail] = useState<CycleDetail | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [chartRoom, setChartRoom] = useState<{ id: string; name: string } | null>(null);
+  const outcome = outcomeOf(log);
+
+  useEffect(() => {
+    if (expanded && !detail && !loadingDetail) {
+      setLoadingDetail(true);
+      getCycleDetail(log.id)
+        .then(setDetail)
+        .finally(() => setLoadingDetail(false));
+    }
+  }, [expanded, detail, loadingDetail, log.id]);
+
   const rooms = Object.values(log.rooms);
 
   return (
@@ -154,12 +353,15 @@ function LogRow({ log }: { log: CycleLog }) {
             {log.mode}
           </span>
         </td>
+        <td>
+          <span className={`badge badge-${outcome.color}`}>{outcome.label}</span>
+        </td>
         <td>{new Date(log.started_at + "Z").toLocaleString()}</td>
         <td>
           {log.ended_at ? (
             new Date(log.ended_at + "Z").toLocaleString()
           ) : (
-            <span className="badge badge-green">Active</span>
+            <span className="text-sm text-muted">—</span>
           )}
         </td>
         <td>{duration(log.started_at, log.ended_at)}</td>
@@ -168,26 +370,213 @@ function LogRow({ log }: { log: CycleLog }) {
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={8} style={{ background: "var(--gray-50)", padding: ".75rem 1rem" }}>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-                gap: ".5rem",
-              }}
-            >
-              {rooms.map((r, i) => (
-                <div key={i} className="card" style={{ padding: ".75rem" }}>
-                  <div style={{ fontWeight: 600, marginBottom: ".25rem" }}>{r.name}</div>
-                  <div className="text-sm text-muted">Target: {r.target}°F</div>
-                  <div className="text-sm text-muted">Source: {r.source}</div>
-                </div>
-              ))}
-            </div>
+          <td colSpan={9} style={{ background: "var(--gray-50)", padding: ".75rem 1rem" }}>
+            <CycleExpanded
+              log={log}
+              detail={detail}
+              loading={loadingDetail}
+              onShowChart={(id, name) => setChartRoom({ id, name })}
+            />
           </td>
         </tr>
       )}
+      {chartRoom && (
+        <TempChartModal
+          cycleId={log.id}
+          roomId={chartRoom.id}
+          roomName={chartRoom.name}
+          onClose={() => setChartRoom(null)}
+        />
+      )}
     </>
+  );
+}
+
+function CycleExpanded({
+  log,
+  detail,
+  loading,
+  onShowChart,
+}: {
+  log: CycleLog;
+  detail: CycleDetail | null;
+  loading: boolean;
+  onShowChart: (roomId: string, roomName: string) => void;
+}) {
+  const ventStart = log.vents_at_start ?? {};
+  const ventEnd = log.vents_at_end ?? {};
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: ".75rem" }}>
+      {/* Zone summary */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+          gap: ".5rem",
+        }}
+      >
+        <div className="card" style={{ padding: ".6rem .75rem" }}>
+          <div className="text-sm text-muted">Thermostat temp</div>
+          <div style={{ fontWeight: 600 }}>
+            {fmtTemp(log.thermostat_temp_at_start)} → {fmtTemp(log.thermostat_temp_at_end)}
+          </div>
+        </div>
+        <div className="card" style={{ padding: ".6rem .75rem" }}>
+          <div className="text-sm text-muted">Setpoint</div>
+          <div style={{ fontWeight: 600 }}>
+            {fmtTemp(log.setpoint_at_start)} → {fmtTemp(log.setpoint_at_end)}
+          </div>
+        </div>
+        <div className="card" style={{ padding: ".6rem .75rem" }}>
+          <div className="text-sm text-muted">Ended reason</div>
+          <div style={{ fontWeight: 600 }}>
+            {log.ended_reason ?? (log.ended_at ? "—" : "running")}
+          </div>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="loading">
+          <div className="spinner" /> Loading detail…
+        </div>
+      )}
+
+      {/* Rooms table */}
+      {detail && (
+        <div className="card" style={{ padding: 0 }}>
+          <div
+            style={{
+              padding: ".5rem .75rem",
+              fontWeight: 600,
+              borderBottom: "1px solid var(--gray-200)",
+            }}
+          >
+            Rooms
+          </div>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Trigger</th>
+                  <th>Target</th>
+                  <th>Start → End</th>
+                  <th>Reached</th>
+                  <th>Vent closed</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {detail.rooms.map((r) => (
+                  <tr key={r.room_id}>
+                    <td style={{ fontWeight: 500 }}>{r.name ?? r.room_id.slice(0, 8)}</td>
+                    <td>
+                      <span className="text-sm">{r.source ?? "—"}</span>
+                      {r.trigger_detail && (
+                        <div className="text-sm text-muted">{triggerSummary(r.trigger_detail)}</div>
+                      )}
+                      {r.joined_at && (
+                        <div className="text-sm text-muted">
+                          joined {new Date(r.joined_at + "Z").toLocaleTimeString()}
+                        </div>
+                      )}
+                    </td>
+                    <td>{r.target_temp.toFixed(1)}°F</td>
+                    <td>
+                      {fmtTemp(r.temp_at_start)} → {fmtTemp(r.temp_at_end)}
+                    </td>
+                    <td>{fmtTime(r.reached_at)}</td>
+                    <td>{fmtTime(r.vent_closed_at)}</td>
+                    <td>
+                      <button
+                        className="btn btn-sm btn-secondary"
+                        onClick={() => onShowChart(r.room_id, r.name ?? r.room_id.slice(0, 8))}
+                      >
+                        View chart
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Vent activity */}
+      {detail && detail.vent_events.length > 0 && (
+        <div className="card" style={{ padding: 0 }}>
+          <div
+            style={{
+              padding: ".5rem .75rem",
+              fontWeight: 600,
+              borderBottom: "1px solid var(--gray-200)",
+            }}
+          >
+            Vent activity ({detail.vent_events.length})
+          </div>
+          <div
+            style={{
+              maxHeight: 200,
+              overflowY: "auto",
+              padding: ".5rem .75rem",
+              fontSize: ".8rem",
+            }}
+          >
+            {detail.vent_events.map((ev) => (
+              <div key={ev.id} style={{ display: "flex", gap: ".75rem" }}>
+                <span className="font-mono text-muted">{fmtTime(ev.timestamp)}</span>
+                <span style={{ minWidth: 160 }} className="font-mono">
+                  {ev.entity_id}
+                </span>
+                <span className="badge badge-gray">{ev.action}</span>
+                {ev.reason && <span className="text-muted">{ev.reason}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setpoint history */}
+      {detail && detail.setpoint_history.length > 0 && (
+        <div className="card" style={{ padding: 0 }}>
+          <div
+            style={{
+              padding: ".5rem .75rem",
+              fontWeight: 600,
+              borderBottom: "1px solid var(--gray-200)",
+            }}
+          >
+            Setpoint history ({detail.setpoint_history.length})
+          </div>
+          <div
+            style={{
+              maxHeight: 160,
+              overflowY: "auto",
+              padding: ".5rem .75rem",
+              fontSize: ".8rem",
+            }}
+          >
+            {detail.setpoint_history.map((sp) => (
+              <div key={sp.id} style={{ display: "flex", gap: ".75rem" }}>
+                <span className="font-mono text-muted">{fmtTime(sp.timestamp)}</span>
+                <span style={{ fontWeight: 600 }}>{sp.setpoint.toFixed(1)}°F</span>
+                {sp.reason && <span className="text-muted">{sp.reason}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Fallback: vent start/end maps if detail not yet loaded but snapshot present */}
+      {!detail && (Object.keys(ventStart).length > 0 || Object.keys(ventEnd).length > 0) && (
+        <div className="text-sm text-muted">
+          Vents at start: {Object.keys(ventStart).length} • Vents at end:{" "}
+          {Object.keys(ventEnd).length}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -278,6 +667,7 @@ function CycleHistory() {
                   <th>ID</th>
                   <th>Thermostat</th>
                   <th>Mode</th>
+                  <th>Outcome</th>
                   <th>Started</th>
                   <th>Ended</th>
                   <th>Duration</th>


### PR DESCRIPTION
…+ chart modal (#60)

Capture and surface richer per-cycle diagnostics in the Logs view:

Backend
- Extend CycleLog/RoomCycleState with start/end thermostat temp, setpoint, vent state snapshots, and per-room temp_at_start/temp_at_end, trigger_detail (source + schedule/override/presence info), joined_at.
- Add cycle_temp_samples, cycle_setpoint_history, cycle_vent_events tables (idempotent CREATE + ALTER migrations, FK ON DELETE CASCADE).
- CycleEngine now captures thermostat temp, setpoint, and vent states at cycle start before opening vents; records opened_at_start vent events; samples per-room temps each monitor tick; writes closed_reached_target and force_reopened_max_closed events; persists setpoint history on each change; and records ended_reason (completed / timeout / aborted: <why>) plus end-state snapshots on terminate and abort.
- API: /api/logs returns new fields; add /api/logs/{id}/detail returning rooms, vent events, and setpoint history; add /api/logs/{id}/temp-samples for chart data.

Frontend
- Add Outcome column with colour-coded badge (completed / timeout / aborted / active).
- Enrich the expanded row with zone summary, trigger detail, start→end temps per room, vent activity, and setpoint history.
- Add per-room "View chart" button opening a modal with an SVG line chart of room / thermostat / setpoint temps over the cycle.

Tests
- Add test_cycle_diagnostics.py covering start snapshot, end reasons, abort prefix, temp sampling, setpoint history, and vent events.