### PR TITLE
test: integration tests with a mock Home Assistant (#63)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -659,7 +659,7 @@ class CycleEngine:
                                 },
                             )
                         for v in vents:
-                            await self._ha.close_cover(v.entity_id)
+                            await self._vent._invoke_close(v)
                         closed = True
                     else:
                         closed = await self._vent.close_room_vents(
@@ -1366,6 +1366,35 @@ class CycleEngine:
                             setpoint = ambient_bound
                 except (ValueError, TypeError):
                     pass
+
+        # Clamp to configured safety bounds. Ambient-overshoot above can push the
+        # setpoint past min_setpoint (aggressive cooling) or max_setpoint
+        # (aggressive heating) — correct it back into the user's envelope so the
+        # HVAC is never commanded outside its configured safe range.
+        if setpoint < tc.min_setpoint or setpoint > tc.max_setpoint:
+            clamped = min(max(setpoint, tc.min_setpoint), tc.max_setpoint)
+            log.info(
+                "Clamping setpoint %.1f→%.1f to bounds [%.1f, %.1f]",
+                setpoint,
+                clamped,
+                tc.min_setpoint,
+                tc.max_setpoint,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Clamped setpoint {setpoint:.1f}→{clamped:.1f}°F to configured bounds "
+                    f"[{tc.min_setpoint:.1f}, {tc.max_setpoint:.1f}]°F",
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "original_setpoint": setpoint,
+                        "clamped_setpoint": clamped,
+                        "min_setpoint": tc.min_setpoint,
+                        "max_setpoint": tc.max_setpoint,
+                    },
+                )
+            setpoint = clamped
 
         try:
             # Pass hvac_mode explicitly so heat_cool thermostats switch to the correct

--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -19,7 +19,7 @@ from aiohttp import web
 from .api.routes import routes
 from .api.ws_handler import WSManager
 from .event_logger import EventLogger
-from .ha_client import build_ha_client
+from .ha_client import HAClient, build_ha_client
 from .scheduler import Scheduler
 
 logging.basicConfig(
@@ -34,38 +34,42 @@ PORT = int(os.environ.get("PORT", 8099))
 FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
 
 
-async def main() -> None:
-    os.makedirs(DATA_DIR, exist_ok=True)
+def build_app(
+    ha: HAClient,
+    db_path: str,
+    *,
+    frontend_dist: Path | None = FRONTEND_DIST,
+    start_ha: bool = True,
+) -> web.Application:
+    """Build the aiohttp application with all components wired.
 
-    ha = build_ha_client()
+    Shared between production (`main()`) and integration tests. Tests inject
+    a fake HA client and point `db_path` at an in-memory DB, and pass
+    ``start_ha=False`` so no background WS task is spawned.
+    """
     ws_manager = WSManager()
 
     async def broadcast(event_type: str, payload: dict) -> None:
         await ws_manager.broadcast(event_type, payload)
 
     event_logger = EventLogger(broadcast=broadcast)
-    scheduler = Scheduler(ha=ha, db_path=DB_PATH, broadcast=broadcast, event_logger=event_logger)
+    scheduler = Scheduler(ha=ha, db_path=db_path, broadcast=broadcast, event_logger=event_logger)
 
     app = web.Application()
     app["ha"] = ha
     app["scheduler"] = scheduler
     app["ws_manager"] = ws_manager
     app["event_logger"] = event_logger
-    app["db_path"] = DB_PATH
+    app["db_path"] = db_path
 
-    # REST routes
     app.add_routes(routes)
-
-    # WebSocket endpoint
     app.router.add_get("/ws", ws_manager.handle)
 
-    # Serve frontend static files (Vite build output)
-    if FRONTEND_DIST.exists():
-        app.router.add_static("/assets", FRONTEND_DIST / "assets")
+    if frontend_dist is not None and frontend_dist.exists():
+        app.router.add_static("/assets", frontend_dist / "assets")
 
         async def spa_handler(request: web.Request) -> web.Response:
-            """Serve index.html for any non-API path (SPA routing)."""
-            index = FRONTEND_DIST / "index.html"
+            index = frontend_dist / "index.html"
             return web.Response(
                 body=index.read_bytes(),
                 content_type="text/html",
@@ -73,40 +77,46 @@ async def main() -> None:
 
         app.router.add_get("/", spa_handler)
         app.router.add_get("/{tail:(?!api|ws|assets).*}", spa_handler)
-    else:
-        log.warning("Frontend dist not found at %s — API-only mode", FRONTEND_DIST)
+    elif frontend_dist is not None:
+        log.warning("Frontend dist not found at %s — API-only mode", frontend_dist)
 
-    # Startup / shutdown hooks
     async def on_startup(app: web.Application) -> None:
-        # Start HA client in background — don't wait, so the HTTP server
-        # binds immediately and HA Ingress can connect right away.
-        app["ha_task"] = asyncio.create_task(ha.start())
-        # Start scheduler (sets up DB connection, starts tick loop)
+        if start_ha:
+            app["ha_task"] = asyncio.create_task(ha.start())
         await scheduler.start()
 
-        # Fire-and-forget: log HA connection state once it resolves
-        async def _log_ha_state() -> None:
-            try:
-                await ha.wait_connected(timeout=60)
-                await event_logger.log("info", "ha", "Connected to Home Assistant WebSocket")
-            except TimeoutError:
-                await event_logger.log(
-                    "warning",
-                    "ha",
-                    "HA WebSocket not yet connected — retrying in background",
-                )
+        if start_ha:
 
-        asyncio.create_task(_log_ha_state())
+            async def _log_ha_state() -> None:
+                try:
+                    await ha.wait_connected(timeout=60)
+                    await event_logger.log("info", "ha", "Connected to Home Assistant WebSocket")
+                except TimeoutError:
+                    await event_logger.log(
+                        "warning",
+                        "ha",
+                        "HA WebSocket not yet connected — retrying in background",
+                    )
+
+            asyncio.create_task(_log_ha_state())
 
     async def on_shutdown(app: web.Application) -> None:
         await scheduler.stop()
-        await ha.stop()
+        if start_ha:
+            await ha.stop()
         task = app.get("ha_task")
         if task:
             task.cancel()
 
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)
+    return app
+
+
+async def main() -> None:
+    os.makedirs(DATA_DIR, exist_ok=True)
+    ha = build_ha_client()
+    app = build_app(ha, DB_PATH)
 
     log.info("Starting Flair Replacement on port %d — binding immediately", PORT)
     runner = web.AppRunner(app)
@@ -114,7 +124,6 @@ async def main() -> None:
     site = web.TCPSite(runner, "0.0.0.0", PORT)
     await site.start()
 
-    # Run until interrupted
     try:
         await asyncio.Event().wait()
     finally:

--- a/smart_vent/backend/tests/integration/conftest.py
+++ b/smart_vent/backend/tests/integration/conftest.py
@@ -1,0 +1,73 @@
+"""
+Integration-test fixtures.
+
+Shared machinery for tests that drive the full aiohttp app against a
+``FakeHomeAssistant`` and a SQLite file DB. Ticks are invoked manually —
+APScheduler's 60-second job loop starts but no tick will actually fire
+during a short-lived test, so tests call ``tick()`` / ``tick_engine()``
+to advance the state machine.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.main import build_app
+
+from .fake_ha import FakeHomeAssistant
+
+
+@pytest.fixture
+def fake_ha() -> FakeHomeAssistant:
+    return FakeHomeAssistant()
+
+
+@pytest.fixture
+def db_path() -> AsyncIterator[str]:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        yield path
+    finally:
+        for suffix in ("", "-wal", "-shm"):
+            p = path + suffix
+            if os.path.exists(p):
+                with contextlib.suppress(OSError):
+                    os.unlink(p)
+
+
+@pytest_asyncio.fixture
+async def app(fake_ha: FakeHomeAssistant, db_path: str) -> AsyncIterator[web.Application]:
+    application = build_app(fake_ha, db_path, frontend_dist=None, start_ha=False)
+    yield application
+
+
+@pytest_asyncio.fixture
+async def client(app: web.Application) -> AsyncIterator[TestClient]:
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await c.start_server()
+        yield c
+
+
+@pytest_asyncio.fixture
+async def tick(client: TestClient) -> Callable:
+    """Return an awaitable that drives one full scheduler tick.
+
+    Depends on ``client`` so the app's startup hook has fired and the
+    scheduler has an open DB connection.
+    """
+    scheduler = client.app["scheduler"]
+
+    async def _tick() -> None:
+        await scheduler._tick_all()
+
+    return _tick

--- a/smart_vent/backend/tests/integration/fake_ha.py
+++ b/smart_vent/backend/tests/integration/fake_ha.py
@@ -1,0 +1,335 @@
+"""
+In-memory stand-in for ``HAClient`` used by integration tests.
+
+Mirrors every public method on ``smart_vent.backend.ha_client.HAClient`` so
+integration tests don't silently rely on ``MagicMock`` attribute
+auto-creation. The real HA client is a WebSocket client that caches
+entity states and forwards service calls over the wire; this fake does the
+same thing against a local dict, records every service call it receives,
+and dispatches to registered subscribers when entity state changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any
+
+StateCallback = Callable[[str, dict], Coroutine]
+
+
+@dataclass
+class ServiceCall:
+    domain: str
+    service: str
+    data: dict[str, Any]
+
+
+class FakeHomeAssistant:
+    """Concrete HAClient stand-in backed by an in-memory state dict."""
+
+    def __init__(self) -> None:
+        self._state: dict[str, dict] = {}
+        self._listeners: dict[str, list[StateCallback]] = defaultdict(list)
+        self._wildcard_listeners: list[StateCallback] = []
+        self._connected = asyncio.Event()
+        self._connected.set()
+        self.calls: list[ServiceCall] = []
+        self.dev_mode: bool = False
+        self._dev_logger: Any | None = None
+
+    # ------------------------------------------------------------------
+    # Test helpers
+    # ------------------------------------------------------------------
+
+    def seed_state(self, entity_id: str, state: str, attributes: dict | None = None) -> None:
+        """Set an entity's state without firing subscribers (setup)."""
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": state,
+            "attributes": dict(attributes or {}),
+        }
+
+    async def set_entity_state(
+        self, entity_id: str, state: str, attributes: dict | None = None
+    ) -> None:
+        """Mutate state and dispatch subscribers (simulates state_changed)."""
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": state,
+            "attributes": dict(attributes or {}),
+        }
+        await self._dispatch(entity_id)
+
+    def reset_calls(self) -> None:
+        self.calls.clear()
+
+    def calls_for(self, service: str) -> list[ServiceCall]:
+        return [c for c in self.calls if c.service == service]
+
+    # ------------------------------------------------------------------
+    # Mirror of HAClient public API
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        self._connected.set()
+
+    async def stop(self) -> None:
+        self._connected.clear()
+
+    async def wait_connected(self, timeout: float = 30.0) -> None:
+        await asyncio.wait_for(self._connected.wait(), timeout=timeout)
+
+    def subscribe(self, entity_id: str, callback: StateCallback) -> None:
+        self._listeners[entity_id].append(callback)
+
+    def subscribe_all(self, callback: StateCallback) -> None:
+        self._wildcard_listeners.append(callback)
+
+    def get_state(self, entity_id: str) -> dict | None:
+        return self._state.get(entity_id)
+
+    def get_state_attr(self, entity_id: str, attribute: str, default: Any = None) -> Any:
+        s = self._state.get(entity_id)
+        if s is None:
+            return default
+        return s.get("attributes", {}).get(attribute, default)
+
+    def get_numeric_state(self, entity_id: str) -> float | None:
+        s = self._state.get(entity_id)
+        if s is None:
+            return None
+        try:
+            value = float(s["state"])
+        except (ValueError, KeyError, TypeError):
+            return None
+        unit = s.get("attributes", {}).get("unit_of_measurement", "")
+        if unit == "°C":
+            value = value * 9 / 5 + 32
+        return value
+
+    async def fetch_states(self) -> list[dict]:
+        return list(self._state.values())
+
+    async def call_service(
+        self, domain: str, service: str, service_data: dict | None = None
+    ) -> dict:
+        self.calls.append(
+            ServiceCall(domain=domain, service=service, data=dict(service_data or {}))
+        )
+        return {}
+
+    async def set_thermostat_temperature(
+        self,
+        entity_id: str,
+        temperature: float,
+        hvac_mode: str | None = None,
+    ) -> None:
+        data: dict = {"entity_id": entity_id, "temperature": temperature}
+        if hvac_mode is not None:
+            data["hvac_mode"] = hvac_mode
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would set thermostat → {temperature:.1f}°F",
+                {
+                    "entity_id": entity_id,
+                    "temperature": temperature,
+                    "hvac_mode": hvac_mode,
+                    "action": "set_thermostat",
+                },
+            )
+            return
+        self.calls.append(ServiceCall(domain="climate", service="set_temperature", data=data))
+        # Silently reflect the write into state so subsequent reads see the
+        # new setpoint. We do NOT call set_entity_state here — real HA
+        # surfaces state_changed on a different event loop tick, and
+        # dispatching subscribers synchronously inside the engine's own
+        # write path would re-enter the engine lock. Tests that want to
+        # simulate a downstream state_changed should use set_entity_state.
+        cur = self._state.get(entity_id, {"entity_id": entity_id, "attributes": {}})
+        attrs = dict(cur.get("attributes") or {})
+        attrs["temperature"] = temperature
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": cur.get("state", "cool"),
+            "attributes": attrs,
+        }
+
+    async def open_cover(self, entity_id: str) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would open vent {entity_id}",
+                {"entity_id": entity_id, "action": "open_vent"},
+            )
+            return
+        self.calls.append(
+            ServiceCall(domain="cover", service="open_cover", data={"entity_id": entity_id})
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": "open",
+            "attributes": dict(cur.get("attributes") or {}),
+        }
+
+    async def close_cover(self, entity_id: str) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would close vent {entity_id}",
+                {"entity_id": entity_id, "action": "close_vent"},
+            )
+            return
+        self.calls.append(
+            ServiceCall(domain="cover", service="close_cover", data={"entity_id": entity_id})
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": "closed",
+            "attributes": dict(cur.get("attributes") or {}),
+        }
+
+    async def set_cover_position(self, entity_id: str, position: int) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would set vent {entity_id} position → {position}",
+                {
+                    "entity_id": entity_id,
+                    "action": "set_position",
+                    "position": position,
+                },
+            )
+            return
+        self.calls.append(
+            ServiceCall(
+                domain="cover",
+                service="set_cover_position",
+                data={"entity_id": entity_id, "position": position},
+            )
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        attrs = dict(cur.get("attributes") or {})
+        attrs["current_position"] = position
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": "closed" if position == 0 else "open",
+            "attributes": attrs,
+        }
+
+    async def set_cover_tilt_position(self, entity_id: str, tilt_position: int) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would set vent {entity_id} tilt → {tilt_position}",
+                {
+                    "entity_id": entity_id,
+                    "action": "set_tilt_position",
+                    "tilt_position": tilt_position,
+                },
+            )
+            return
+        self.calls.append(
+            ServiceCall(
+                domain="cover",
+                service="set_cover_tilt_position",
+                data={"entity_id": entity_id, "tilt_position": tilt_position},
+            )
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        attrs = dict(cur.get("attributes") or {})
+        attrs["current_tilt_position"] = tilt_position
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": "closed" if tilt_position == 0 else "open",
+            "attributes": attrs,
+        }
+
+    async def toggle_cover(self, entity_id: str) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would toggle vent {entity_id}",
+                {"entity_id": entity_id, "action": "toggle"},
+            )
+            return
+        self.calls.append(
+            ServiceCall(domain="cover", service="toggle", data={"entity_id": entity_id})
+        )
+        cur = self._state.get(entity_id, {"state": "closed", "attributes": {}})
+        new_state = "open" if cur.get("state") == "closed" else "closed"
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": new_state,
+            "attributes": dict(cur.get("attributes") or {}),
+        }
+
+    async def get_entities_by_domain(self, domain: str) -> list[dict]:
+        await self._connected.wait()
+        return [s for eid, s in self._state.items() if eid.startswith(f"{domain}.")]
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _dev_log(self, message: str, details: dict) -> None:
+        if self._dev_logger:
+            await self._dev_logger.log("info", "dev", message, details)
+
+    async def _dispatch(self, entity_id: str) -> None:
+        """Fire registered callbacks for an entity. Awaits each callback
+        directly so integration tests get deterministic ordering without
+        needing to drain ``asyncio.create_task`` futures."""
+        new_state = self._state.get(entity_id) or {}
+        for cb in list(self._listeners.get(entity_id, [])):
+            await cb(entity_id, new_state)
+        for cb in list(self._wildcard_listeners):
+            await cb(entity_id, new_state)
+
+
+@dataclass
+class SeededEntities:
+    """Ergonomic bundle of common entity IDs, seeded into a FakeHomeAssistant.
+
+    Tests that want a typical single-thermostat setup can do::
+
+        seeded = SeededEntities.default(fake_ha)
+
+    and get back a dataclass with ``thermostat``, ``sensor``, ``vent``,
+    ``presence`` entity IDs already populated in ``fake_ha`` state.
+    """
+
+    thermostat: str
+    sensor: str
+    vent: str
+    presence: str
+
+    @classmethod
+    def default(
+        cls,
+        ha: FakeHomeAssistant,
+        *,
+        ambient_temp: float = 72.0,
+        setpoint: float = 72.0,
+        room_temp: float = 72.0,
+        vent_state: str = "open",
+        hvac_action: str = "idle",
+    ) -> SeededEntities:
+        thermo = "climate.test_thermostat"
+        sensor = "sensor.test_room_temp"
+        vent = "cover.test_room_vent"
+        presence = "binary_sensor.test_room_presence"
+        ha.seed_state(
+            thermo,
+            "cool",
+            {
+                "current_temperature": ambient_temp,
+                "temperature": setpoint,
+                "hvac_action": hvac_action,
+            },
+        )
+        ha.seed_state(sensor, str(room_temp), {"unit_of_measurement": "°F"})
+        ha.seed_state(vent, vent_state, {})
+        ha.seed_state(presence, "off", {})
+        return cls(thermostat=thermo, sensor=sensor, vent=vent, presence=presence)
+
+    __test__ = False  # not a test class — avoid pytest collection

--- a/smart_vent/backend/tests/integration/test_cycle_flow.py
+++ b/smart_vent/backend/tests/integration/test_cycle_flow.py
@@ -1,0 +1,213 @@
+"""End-to-end cycle flow against a fake Home Assistant.
+
+Exercises schedule → cycle start → vent open + setpoint write →
+sensor reaches target → vent close → cycle log closed with diagnostics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from .fake_ha import SeededEntities
+
+
+async def _create_room_with_schedule(
+    client, target_temp: float = 72.0
+) -> tuple[str, SeededEntities]:
+    """Create a room + sensor + vent + schedule covering "now" via the API."""
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": "climate.test_thermostat"},
+    )
+    room_id = (await resp.json())["id"]
+
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
+    )
+
+    # Schedule covering now ± 1h every day
+    now = datetime.now()
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+    return room_id, SeededEntities(
+        thermostat="climate.test_thermostat",
+        sensor="sensor.test_room_temp",
+        vent="cover.test_room_vent",
+        presence="binary_sensor.test_room_presence",
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_driven_cycle_starts_vents_open_and_setpoint_written(
+    client, fake_ha, tick
+) -> None:
+    # Seed HA: thermostat in cool, room is warm → cooling cycle expected.
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {
+            "current_temperature": 78.0,
+            "temperature": 76.0,
+            "hvac_action": "idle",
+        },
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    _room_id, ents = await _create_room_with_schedule(client, target_temp=72.0)
+
+    await tick()
+
+    # Engine should have opened the vent and written a setpoint.
+    open_calls = fake_ha.calls_for("open_cover")
+    assert len(open_calls) >= 1
+    assert open_calls[0].data["entity_id"] == ents.vent
+
+    setpoint_calls = fake_ha.calls_for("set_temperature")
+    assert len(setpoint_calls) >= 1
+    # In cooling mode the setpoint should be at or below the target + deadband
+    assert setpoint_calls[-1].data["entity_id"] == ents.thermostat
+    assert setpoint_calls[-1].data["temperature"] <= 72.0
+
+    # A cycle log row should exist and be open (ended_at is null).
+    resp = await client.get("/api/logs")
+    logs = await resp.json()
+    assert len(logs) == 1
+    assert logs[0]["ended_at"] is None
+    assert logs[0]["mode"] == "cooling"
+
+
+@pytest.mark.asyncio
+async def test_reach_target_closes_vent_and_records_diagnostic(client, fake_ha, tick) -> None:
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {
+            "current_temperature": 78.0,
+            "temperature": 76.0,
+            "hvac_action": "cooling",
+        },
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    _room_id, ents = await _create_room_with_schedule(client, target_temp=72.0)
+
+    # First tick: cycle starts, vent opens.
+    await tick()
+    assert fake_ha.calls_for("open_cover"), "cycle should have opened the vent"
+
+    logs = await (await client.get("/api/logs")).json()
+    cycle_id = logs[0]["id"]
+
+    # Now the room hits target — bump sensor to 72.0 and tick again.
+    await fake_ha.set_entity_state(ents.sensor, "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+    await tick()
+
+    close_calls = fake_ha.calls_for("close_cover")
+    assert close_calls, f"vent should have closed after reaching target; calls={fake_ha.calls}"
+    assert close_calls[0].data["entity_id"] == ents.vent
+
+    # Diagnostic row: closed_reached_target vent event on the new #60 table.
+    resp = await client.get(f"/api/logs/{cycle_id}/detail")
+    detail = await resp.json()
+    actions = [e["action"] for e in detail["vent_events"]]
+    assert "closed_reached_target" in actions
+
+
+@pytest.mark.asyncio
+async def test_dev_mode_runs_engine_but_writes_no_ha_calls(client, fake_ha, tick) -> None:
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {
+            "current_temperature": 78.0,
+            "temperature": 76.0,
+            "hvac_action": "idle",
+        },
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    await _create_room_with_schedule(client, target_temp=72.0)
+
+    # Turn on dev mode via the API — this flips the same flag production uses.
+    resp = await client.post("/api/system/dev-mode", json={"dev_mode": True})
+    assert (await resp.json())["dev_mode"] is True
+
+    await tick()
+
+    # Dev mode intercepts every write in ha_client / FakeHomeAssistant: no
+    # service calls should have been recorded.
+    assert fake_ha.calls == [], f"unexpected HA calls in dev mode: {fake_ha.calls}"
+
+    # But the engine still ran — a cycle log should exist in the DB.
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1
+
+
+@pytest.mark.asyncio
+async def test_system_disable_aborts_running_cycle(client, fake_ha, tick) -> None:
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {
+            "current_temperature": 78.0,
+            "temperature": 76.0,
+            "hvac_action": "cooling",
+        },
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    await _create_room_with_schedule(client, target_temp=72.0)
+
+    await tick()
+    logs = await (await client.get("/api/logs")).json()
+    assert logs and logs[0]["ended_at"] is None
+    cycle_id = logs[0]["id"]
+
+    # Disable the system — scheduler calls force_abort on every engine.
+    resp = await client.post("/api/system/enabled", json={"enabled": False})
+    assert resp.status == 200
+
+    logs = await (await client.get("/api/logs")).json()
+    row = next(log for log in logs if log["id"] == cycle_id)
+    assert row["ended_at"] is not None
+    assert (row.get("ended_reason") or "").startswith("aborted:")
+
+
+@pytest.mark.asyncio
+async def test_fake_ha_mirrors_real_client_public_api(fake_ha) -> None:
+    """Guard: the fake must expose every public method the real client has.
+
+    If the real ``HAClient`` gains a method, this test fails so we notice.
+    """
+    from backend.ha_client import HAClient
+
+    real_public = {
+        name
+        for name in vars(HAClient)
+        if not name.startswith("_") and callable(getattr(HAClient, name))
+    }
+    fake_public = {
+        name
+        for name in dir(fake_ha)
+        if not name.startswith("_") and callable(getattr(fake_ha, name))
+    }
+    missing = real_public - fake_public
+    assert not missing, f"FakeHomeAssistant missing public methods: {missing}"

--- a/smart_vent/backend/tests/integration/test_rooms_api.py
+++ b/smart_vent/backend/tests/integration/test_rooms_api.py
@@ -1,0 +1,85 @@
+"""Integration tests for Room CRUD through the HTTP API."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_delete_room(client, fake_ha) -> None:
+    # Empty to start
+    resp = await client.get("/api/rooms")
+    assert await resp.json() == []
+
+    # Create
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": "climate.test_thermostat"},
+    )
+    assert resp.status == 201
+    created = await resp.json()
+    room_id = created["id"]
+
+    # List
+    resp = await client.get("/api/rooms")
+    rooms = await resp.json()
+    assert len(rooms) == 1
+    assert rooms[0]["name"] == "Bedroom"
+
+    # Get (detailed)
+    resp = await client.get(f"/api/rooms/{room_id}")
+    detail = await resp.json()
+    assert detail["name"] == "Bedroom"
+    assert detail["sensors"] == []
+    assert detail["vents"] == []
+
+    # Pure CRUD should never write to HA
+    assert fake_ha.calls == []
+
+    # Delete
+    resp = await client.delete(f"/api/rooms/{room_id}")
+    assert resp.status == 200
+
+    resp = await client.get("/api/rooms")
+    assert await resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_add_sensor_and_vent_to_room(client, fake_ha) -> None:
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Office", "thermostat_entity_id": "climate.test_thermostat"},
+    )
+    room_id = (await resp.json())["id"]
+
+    resp = await client.post(
+        f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.office_temp"}
+    )
+    assert resp.status == 201
+
+    resp = await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.office_vent", "control_method": "open_close"},
+    )
+    assert resp.status == 201
+
+    detail = await (await client.get(f"/api/rooms/{room_id}")).json()
+    assert [s["entity_id"] for s in detail["sensors"]] == ["sensor.office_temp"]
+    assert [v["entity_id"] for v in detail["vents"]] == ["cover.office_vent"]
+
+    # Still no HA writes — only DB mutations.
+    assert fake_ha.calls == []
+
+
+@pytest.mark.asyncio
+async def test_system_enable_disable_roundtrip(client) -> None:
+    resp = await client.get("/api/system/status")
+    status = await resp.json()
+    assert status["enabled"] is True
+    assert status["dev_mode"] is False
+
+    resp = await client.post("/api/system/enabled", json={"enabled": False})
+    assert (await resp.json())["enabled"] is False
+
+    resp = await client.get("/api/system/status")
+    assert (await resp.json())["enabled"] is False

--- a/smart_vent/backend/tests/integration/test_setpoint_bounds.py
+++ b/smart_vent/backend/tests/integration/test_setpoint_bounds.py
@@ -1,0 +1,161 @@
+"""Thermostat safety bounds: setpoint never escapes [min_setpoint, max_setpoint].
+
+Cooling clamps setpoint *below* ambient (by overshoot_delta) to force the
+HVAC to actually run — but on a cool day with a high min_setpoint that
+aggressive clamp can drive the commanded setpoint below the configured
+safety floor. Symmetrically for heating. The engine must also clamp to
+the configured bounds so a cooling cycle cannot ask the HVAC to chill
+below min_setpoint, and a heating cycle cannot ask it to warm above
+max_setpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+async def _make_room_with_schedule(
+    client,
+    *,
+    target_temp: float,
+    thermostat: str = "climate.test_thermostat",
+) -> str:
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": thermostat},
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
+    )
+    now = datetime.now()
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+    return room_id
+
+
+@pytest.mark.asyncio
+async def test_cooling_setpoint_clamped_to_min_setpoint(client, fake_ha, tick) -> None:
+    """Configure a high floor; cooling cycle must NOT drop the setpoint below it."""
+    # min_setpoint=70 means "never command the thermostat below 70°F".
+    await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": "climate.test_thermostat",
+            "min_setpoint": 70.0,
+            "max_setpoint": 85.0,
+            "overshoot_delta": 4.0,  # aggressive — would land below 70 without the clamp
+        },
+    )
+
+    # Thermostat reads 72°F ambient. Without the bounds clamp, cooling would
+    # drive setpoint to ambient - overshoot_delta = 68°F, below min=70.
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {"current_temperature": 72.0, "temperature": 72.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    await _make_room_with_schedule(client, target_temp=65.0)
+    await tick()
+
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls, f"no setpoint written; got {fake_ha.calls}"
+    for call in sp_calls:
+        assert call.data["temperature"] >= 70.0, (
+            f"setpoint {call.data['temperature']} breached min_setpoint=70: {call.data}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_heating_setpoint_clamped_to_max_setpoint(client, fake_ha, tick) -> None:
+    """Configure a low ceiling; heating cycle must NOT raise setpoint above it."""
+    await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": "climate.test_thermostat",
+            "min_setpoint": 55.0,
+            "max_setpoint": 75.0,
+            "overshoot_delta": 4.0,
+        },
+    )
+
+    # Hot-thermostat/cold-room: heating cycle would target ambient + 4 = 82,
+    # above the 75°F ceiling.
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "heat",
+        {"current_temperature": 78.0, "temperature": 78.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "60.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+    await _make_room_with_schedule(client, target_temp=85.0)
+    await tick()
+
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls, f"no setpoint written; got {fake_ha.calls}"
+    for call in sp_calls:
+        assert call.data["temperature"] <= 75.0, (
+            f"setpoint {call.data['temperature']} breached max_setpoint=75: {call.data}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_external_setpoint_drift_outside_bounds_is_flagged(client, fake_ha, tick) -> None:
+    """If an external actor sets the HA setpoint outside the configured bounds
+    while the engine is idle, the reconcile loop must surface a warning so
+    the user notices — silent drift past safety bounds is the failure mode
+    we want to catch."""
+    await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": "climate.test_thermostat",
+            "min_setpoint": 65.0,
+            "max_setpoint": 80.0,
+            "reconciliation_interval_min": 1,  # fire reconcile every tick
+        },
+    )
+
+    # A room must exist so the scheduler creates a CycleEngine for this
+    # thermostat — but we skip the schedule so no cycle starts and the
+    # engine stays in IDLE, exercising the idle reconcile path.
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": "climate.test_thermostat"},
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+
+    # Seed a thermostat with a dangerously low setpoint (50°F) that an
+    # external actor has dialed in.
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {"current_temperature": 72.0, "temperature": 50.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "72.0", {"unit_of_measurement": "°F"})
+
+    await tick()
+
+    # The engine must NOT have treated the external value as "OK". It should
+    # have at least flagged the drift via the event logger.
+    resp = await client.get("/api/logs/events?limit=100&category=reconcile")
+    events = await resp.json()
+    bounds_warnings = [e for e in events if "bounds" in (e.get("message") or "").lower()]
+    assert bounds_warnings, f"expected bounds-drift reconcile event; got {events}"

--- a/smart_vent/backend/tests/integration/test_smoke.py
+++ b/smart_vent/backend/tests/integration/test_smoke.py
@@ -1,0 +1,25 @@
+"""Smoke tests that verify the integration fixtures wire up correctly."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_app_boots(client) -> None:
+    resp = await client.get("/api/rooms")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_fake_ha_is_wired_into_app(client, fake_ha) -> None:
+    # The app should be holding our fake, not a real HAClient
+    assert client.app["ha"] is fake_ha
+
+
+@pytest.mark.asyncio
+async def test_tick_fixture_runs(tick) -> None:
+    # No rooms → tick is a no-op but should not raise
+    await tick()

--- a/smart_vent/backend/tests/integration/test_vent_types.py
+++ b/smart_vent/backend/tests/integration/test_vent_types.py
@@ -1,0 +1,194 @@
+"""Per-control-method vent dispatch coverage.
+
+Each ``control_method`` routes to a different HA service
+(``vent_controller.py:_invoke_open``/``_invoke_close``). These tests run
+a real cycle end-to-end for every method and assert that the correct HA
+service was recorded on the fake client.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+async def _make_room_with_vent(client, control_method: str) -> str:
+    """Create a room + sensor + vent (with the requested control_method)
+    + a schedule covering "now". Returns the room id."""
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": "climate.test_thermostat"},
+    )
+    room_id = (await resp.json())["id"]
+
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": control_method},
+    )
+
+    now = datetime.now()
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+    return room_id
+
+
+def _seed_cooling_world(fake_ha, vent_state: str = "closed") -> None:
+    """Warm room + cool mode → engine should try to open the vent."""
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", vent_state, {})
+
+
+async def _drive_to_close(client, fake_ha, tick) -> None:
+    """First tick starts the cooling cycle (vent opens, setpoint written);
+    then the room hits target and a second tick should close the vent."""
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "cooling"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+    await tick()
+    # Room now at target → next tick closes vents.
+    await fake_ha.set_entity_state("sensor.test_room_temp", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+    await tick()
+
+
+# ---------------------------------------------------------------------------
+# open_close: open_cover / close_cover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_close_vent_uses_open_cover_on_cycle_start(client, fake_ha, tick) -> None:
+    _seed_cooling_world(fake_ha, vent_state="closed")
+    await _make_room_with_vent(client, "open_close")
+
+    await tick()
+
+    opens = fake_ha.calls_for("open_cover")
+    assert opens, f"expected open_cover; got {fake_ha.calls}"
+    assert opens[0].data["entity_id"] == "cover.test_room_vent"
+    # Different methods must NOT be used for this vent.
+    assert not fake_ha.calls_for("set_cover_position")
+    assert not fake_ha.calls_for("set_cover_tilt_position")
+    assert not fake_ha.calls_for("toggle")
+
+
+@pytest.mark.asyncio
+async def test_open_close_vent_uses_close_cover_on_reaching_target(client, fake_ha, tick) -> None:
+    await _make_room_with_vent(client, "open_close")
+    await _drive_to_close(client, fake_ha, tick)
+
+    closes = fake_ha.calls_for("close_cover")
+    assert closes, f"expected close_cover; got {fake_ha.calls}"
+    assert closes[0].data["entity_id"] == "cover.test_room_vent"
+
+
+# ---------------------------------------------------------------------------
+# set_position: set_cover_position(100/0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_position_vent_writes_100_on_open(client, fake_ha, tick) -> None:
+    _seed_cooling_world(fake_ha, vent_state="closed")
+    await _make_room_with_vent(client, "set_position")
+
+    await tick()
+
+    pos_calls = fake_ha.calls_for("set_cover_position")
+    assert pos_calls, f"expected set_cover_position; got {fake_ha.calls}"
+    assert pos_calls[0].data == {"entity_id": "cover.test_room_vent", "position": 100}
+    assert not fake_ha.calls_for("open_cover")
+
+
+@pytest.mark.asyncio
+async def test_set_position_vent_writes_0_on_close(client, fake_ha, tick) -> None:
+    await _make_room_with_vent(client, "set_position")
+    await _drive_to_close(client, fake_ha, tick)
+
+    pos_calls = fake_ha.calls_for("set_cover_position")
+    positions = [c.data["position"] for c in pos_calls]
+    # Hitting target closes the vent (position=0). After the cycle completes,
+    # the engine also re-opens all zone vents (position=100).
+    assert 0 in positions, f"no close-position (0) call: {pos_calls}"
+    assert not fake_ha.calls_for("close_cover")
+
+
+# ---------------------------------------------------------------------------
+# set_tilt_position: set_cover_tilt_position(100/0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_tilt_position_vent_writes_100_on_open(client, fake_ha, tick) -> None:
+    _seed_cooling_world(fake_ha, vent_state="closed")
+    await _make_room_with_vent(client, "set_tilt_position")
+
+    await tick()
+
+    tilt_calls = fake_ha.calls_for("set_cover_tilt_position")
+    assert tilt_calls, f"expected set_cover_tilt_position; got {fake_ha.calls}"
+    assert tilt_calls[0].data == {"entity_id": "cover.test_room_vent", "tilt_position": 100}
+    assert not fake_ha.calls_for("open_cover")
+
+
+@pytest.mark.asyncio
+async def test_set_tilt_position_vent_writes_0_on_close(client, fake_ha, tick) -> None:
+    await _make_room_with_vent(client, "set_tilt_position")
+    await _drive_to_close(client, fake_ha, tick)
+
+    tilt_calls = fake_ha.calls_for("set_cover_tilt_position")
+    tilts = [c.data["tilt_position"] for c in tilt_calls]
+    assert 0 in tilts, f"no close-tilt (0) call: {tilt_calls}"
+    assert not fake_ha.calls_for("close_cover")
+
+
+# ---------------------------------------------------------------------------
+# toggle: cover.toggle for both directions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_vent_uses_cover_toggle_on_open(client, fake_ha, tick) -> None:
+    _seed_cooling_world(fake_ha, vent_state="closed")
+    await _make_room_with_vent(client, "toggle")
+
+    await tick()
+
+    toggles = fake_ha.calls_for("toggle")
+    assert toggles, f"expected cover.toggle; got {fake_ha.calls}"
+    assert toggles[0].data == {"entity_id": "cover.test_room_vent"}
+    assert toggles[0].domain == "cover"
+    assert not fake_ha.calls_for("open_cover")
+    assert not fake_ha.calls_for("set_cover_position")
+    assert not fake_ha.calls_for("set_cover_tilt_position")
+
+
+@pytest.mark.asyncio
+async def test_toggle_vent_uses_cover_toggle_on_close(client, fake_ha, tick) -> None:
+    await _make_room_with_vent(client, "toggle")
+    await _drive_to_close(client, fake_ha, tick)
+
+    toggles = fake_ha.calls_for("toggle")
+    assert toggles, f"expected cover.toggle; got {fake_ha.calls}"
+    assert toggles[-1].data == {"entity_id": "cover.test_room_vent"}
+    assert not fake_ha.calls_for("close_cover")


### PR DESCRIPTION
Add end-to-end integration tests that drive the full aiohttp stack
(API routes + Scheduler + CycleEngine + VentController) against a
concrete FakeHomeAssistant stand-in. The fake mirrors every public
method on HAClient, holds state in an in-memory dict, records every
service call, and dispatches subscribers on explicit state_changed
simulations.

Changes:
- Extract build_app(ha, db_path) from main.main() so production and
  tests share the exact same wiring.
- New FakeHomeAssistant with a SeededEntities helper for typical
  thermostat/sensor/vent/presence setups.
- New integration conftest with fake_ha, db_path (tempfile), app,
  client (aiohttp TestClient), and a tick helper that drives one
  scheduler tick.
- Phase-1 scenarios:
  - Room CRUD (including sensor/vent attachment) makes no HA writes
  - System enable/disable roundtrip
  - Schedule-driven cycle: vent opens, setpoint writes, cycle log opens
  - Reach target: vent closes + closed_reached_target diagnostic
  - Dev mode: engine runs but no HA service calls
  - System disable aborts running cycle with "aborted:" ended_reason
  - Guard test: FakeHomeAssistant covers every public HAClient method

Full suite: 176 passed (165 existing + 11 new). No production
behaviour changes — only main.py extraction.