### PR TITLE
Fix timestamp handling: migrate holdover times to UTC and use UTC consistently

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -714,7 +714,9 @@ def _cycle_log_to_dict(log_entry) -> dict:
         "id": log_entry.id,
         "thermostat_entity_id": log_entry.thermostat_entity_id,
         "started_at": log_entry.started_at.replace(tzinfo=None).isoformat(),
-        "ended_at": log_entry.ended_at.replace(tzinfo=None).isoformat() if log_entry.ended_at else None,
+        "ended_at": log_entry.ended_at.replace(tzinfo=None).isoformat()
+        if log_entry.ended_at
+        else None,
         "mode": log_entry.mode,
         "rooms": rooms,
         "ended_reason": log_entry.ended_reason,
@@ -767,12 +769,18 @@ async def get_log_detail(request: web.Request) -> web.Response:
                 "name": meta.get("name"),
                 "source": meta.get("source"),
                 "target_temp": rcs.target_temp,
-                "reached_at": rcs.reached_at.replace(tzinfo=None).isoformat() if rcs.reached_at else None,
-                "vent_closed_at": rcs.vent_closed_at.replace(tzinfo=None).isoformat() if rcs.vent_closed_at else None,
+                "reached_at": rcs.reached_at.replace(tzinfo=None).isoformat()
+                if rcs.reached_at
+                else None,
+                "vent_closed_at": rcs.vent_closed_at.replace(tzinfo=None).isoformat()
+                if rcs.vent_closed_at
+                else None,
                 "temp_at_start": rcs.temp_at_start,
                 "temp_at_end": rcs.temp_at_end,
                 "trigger_detail": trigger,
-                "joined_at": rcs.joined_at.replace(tzinfo=None).isoformat() if rcs.joined_at else None,
+                "joined_at": rcs.joined_at.replace(tzinfo=None).isoformat()
+                if rcs.joined_at
+                else None,
             }
         )
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import sqlite3
 import tempfile
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 from typing import Any
 
 from aiohttp import web
@@ -575,7 +575,7 @@ async def set_override(request: web.Request) -> web.Response:
     override = RoomOverride(
         room_id=request.match_info["room_id"],
         target_temp=float(body["target_temp"]),
-        expires_at=datetime.utcnow() + timedelta(hours=duration_hours),
+        expires_at=datetime.now(UTC) + timedelta(hours=duration_hours),
     )
     conn = await get_conn(request)
     await db.set_room_override(conn, override)
@@ -583,7 +583,7 @@ async def set_override(request: web.Request) -> web.Response:
         {
             "room_id": override.room_id,
             "target_temp": override.target_temp,
-            "expires_at": override.expires_at.isoformat(),
+            "expires_at": override.expires_at.replace(tzinfo=None).isoformat(),
         }
     )
 
@@ -610,7 +610,7 @@ async def rooms_active_status(request: web.Request) -> web.Response:
     body = await request.json()
     room_ids: list[str] = body.get("room_ids", [])
     conn = await get_conn(request)
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
 
     result = {}
     for room_id in room_ids:
@@ -713,8 +713,8 @@ def _cycle_log_to_dict(log_entry) -> dict:
     return {
         "id": log_entry.id,
         "thermostat_entity_id": log_entry.thermostat_entity_id,
-        "started_at": log_entry.started_at.isoformat(),
-        "ended_at": log_entry.ended_at.isoformat() if log_entry.ended_at else None,
+        "started_at": log_entry.started_at.replace(tzinfo=None).isoformat(),
+        "ended_at": log_entry.ended_at.replace(tzinfo=None).isoformat() if log_entry.ended_at else None,
         "mode": log_entry.mode,
         "rooms": rooms,
         "ended_reason": log_entry.ended_reason,
@@ -767,12 +767,12 @@ async def get_log_detail(request: web.Request) -> web.Response:
                 "name": meta.get("name"),
                 "source": meta.get("source"),
                 "target_temp": rcs.target_temp,
-                "reached_at": rcs.reached_at.isoformat() if rcs.reached_at else None,
-                "vent_closed_at": rcs.vent_closed_at.isoformat() if rcs.vent_closed_at else None,
+                "reached_at": rcs.reached_at.replace(tzinfo=None).isoformat() if rcs.reached_at else None,
+                "vent_closed_at": rcs.vent_closed_at.replace(tzinfo=None).isoformat() if rcs.vent_closed_at else None,
                 "temp_at_start": rcs.temp_at_start,
                 "temp_at_end": rcs.temp_at_end,
                 "trigger_detail": trigger,
-                "joined_at": rcs.joined_at.isoformat() if rcs.joined_at else None,
+                "joined_at": rcs.joined_at.replace(tzinfo=None).isoformat() if rcs.joined_at else None,
             }
         )
 
@@ -780,7 +780,7 @@ async def get_log_detail(request: web.Request) -> web.Response:
     vent_events_payload = [
         {
             "id": ev.id,
-            "timestamp": ev.timestamp.isoformat(),
+            "timestamp": ev.timestamp.replace(tzinfo=None).isoformat(),
             "entity_id": ev.entity_id,
             "room_id": ev.room_id,
             "action": ev.action,
@@ -793,7 +793,7 @@ async def get_log_detail(request: web.Request) -> web.Response:
     setpoint_history_payload = [
         {
             "id": sp.id,
-            "timestamp": sp.timestamp.isoformat(),
+            "timestamp": sp.timestamp.replace(tzinfo=None).isoformat(),
             "setpoint": sp.setpoint,
             "reason": sp.reason,
         }
@@ -823,7 +823,7 @@ async def get_log_temp_samples(request: web.Request) -> web.Response:
                 "id": s.id,
                 "cycle_id": s.cycle_id,
                 "room_id": s.room_id,
-                "timestamp": s.timestamp.isoformat(),
+                "timestamp": s.timestamp.replace(tzinfo=None).isoformat(),
                 "room_temp": s.room_temp,
                 "thermostat_temp": s.thermostat_temp,
                 "setpoint": s.setpoint,

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -610,7 +610,7 @@ async def rooms_active_status(request: web.Request) -> web.Response:
     body = await request.json()
     room_ids: list[str] = body.get("room_ids", [])
     conn = await get_conn(request)
-    now = datetime.now()
+    now = datetime.utcnow()
 
     result = {}
     for room_id in room_ids:

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -196,7 +196,48 @@ async def init_db(conn: aiosqlite.Connection) -> None:
             await conn.commit()
         except Exception:
             pass  # column already exists
+    # Data migration: fix holdover timestamps stored in local time (Issue #65)
+    await _migrate_holdover_timestamps_to_utc(conn)
     log.info("Database initialised")
+
+
+async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> None:
+    """One-time migration: shift presence_holdover_state timestamps from server local time to UTC."""
+    sentinel = "migration_holdover_timestamps_utc_v1"
+    async with conn.execute("SELECT value FROM system_settings WHERE key=?", (sentinel,)) as cur:
+        if await cur.fetchone():
+            return
+
+    # How much to add to a local naive datetime to get UTC
+    offset = datetime.utcnow() - datetime.now()
+
+    if abs(offset.total_seconds()) >= 1:
+        async with conn.execute(
+            "SELECT room_id, last_detected_at, expires_at FROM presence_holdover_state"
+        ) as cur:
+            rows = await cur.fetchall()
+
+        for row in rows:
+            last_detected_at = datetime.fromisoformat(row["last_detected_at"]) + offset
+            expires_at = datetime.fromisoformat(row["expires_at"]) + offset
+            await conn.execute(
+                "UPDATE presence_holdover_state SET last_detected_at=?, expires_at=? WHERE room_id=?",
+                (last_detected_at.isoformat(), expires_at.isoformat(), row["room_id"]),
+            )
+
+        if rows:
+            log.info(
+                "Holdover timestamp migration: adjusted %d record(s) from local time to UTC",
+                len(rows),
+            )
+        await conn.commit()
+
+    await conn.execute(
+        """INSERT INTO system_settings(key,value) VALUES(?,?)
+           ON CONFLICT(key) DO UPDATE SET value=excluded.value""",
+        (sentinel, "1"),
+    )
+    await conn.commit()
 
 
 _MIGRATIONS = [

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 
 import aiosqlite
 
@@ -209,7 +209,7 @@ async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> Non
             return
 
     # How much to add to a local naive datetime to get UTC
-    offset = datetime.now(timezone.utc).replace(tzinfo=None) - datetime.now()
+    offset = datetime.now(UTC).replace(tzinfo=None) - datetime.now()
 
     if abs(offset.total_seconds()) >= 1:
         async with conn.execute(
@@ -271,7 +271,7 @@ def _dt(s: str | None) -> datetime | None:
     if not s:
         return None
     dt = datetime.fromisoformat(s)
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 
 
 def _t(s: str) -> time:
@@ -628,7 +628,7 @@ async def clear_room_override(conn: aiosqlite.Connection, room_id: str) -> None:
 async def clear_expired_overrides(conn: aiosqlite.Connection) -> None:
     await conn.execute(
         "DELETE FROM room_overrides WHERE expires_at < ?",
-        (datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),),
+        (datetime.now(UTC).replace(tzinfo=None).isoformat(),),
     )
     await conn.commit()
 
@@ -709,7 +709,7 @@ async def close_open_cycle_logs(
     accumulate. Returns the number of rows closed.
     """
     if ended_at is None:
-        ended_at = datetime.now(timezone.utc)
+        ended_at = datetime.now(UTC)
     async with conn.execute(
         "UPDATE cycle_logs SET ended_at=? WHERE thermostat_entity_id=? AND ended_at IS NULL",
         (ended_at.replace(tzinfo=None).isoformat(), thermostat_entity_id),
@@ -737,7 +737,7 @@ async def close_open_cycles_for_rooms(
     if not room_ids:
         return 0
     if ended_at is None:
-        ended_at = datetime.now(timezone.utc)
+        ended_at = datetime.now(UTC)
     placeholders = ",".join("?" for _ in room_ids)
     query = (
         "UPDATE cycle_logs SET ended_at=? "
@@ -879,7 +879,7 @@ async def get_cycle_logs(
 
 async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete cycle logs older than N days. Returns number of rows deleted."""
-    cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
+    cutoff = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
     async with conn.execute("DELETE FROM cycle_logs WHERE started_at < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()
@@ -1019,7 +1019,7 @@ async def get_cycle_setpoint_history(
         CycleSetpointHistory(
             id=r["id"],
             cycle_id=r["cycle_id"],
-            timestamp=datetime.fromisoformat(r["timestamp"]),
+            timestamp=_dt(r["timestamp"]),
             setpoint=r["setpoint"],
             reason=r["reason"],
         )
@@ -1039,7 +1039,7 @@ async def insert_cycle_vent_event(
     await conn.execute(
         """INSERT INTO cycle_vent_events(cycle_id,timestamp,entity_id,room_id,action,reason)
            VALUES(?,?,?,?,?,?)""",
-        (cycle_id, timestamp.isoformat(), entity_id, room_id, action, reason),
+        (cycle_id, timestamp.replace(tzinfo=None).isoformat(), entity_id, room_id, action, reason),
     )
     await conn.commit()
 
@@ -1054,7 +1054,7 @@ async def get_cycle_vent_events(conn: aiosqlite.Connection, cycle_id: str) -> li
         CycleVentEvent(
             id=r["id"],
             cycle_id=r["cycle_id"],
-            timestamp=datetime.fromisoformat(r["timestamp"]),
+            timestamp=_dt(r["timestamp"]),
             entity_id=r["entity_id"],
             room_id=r["room_id"],
             action=r["action"],
@@ -1167,7 +1167,7 @@ async def get_event_logs(
 
 async def purge_event_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete event logs older than N days. Returns number of rows deleted."""
-    cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
+    cutoff = (datetime.now(UTC).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
     async with conn.execute("DELETE FROM event_log WHERE timestamp < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -615,7 +615,11 @@ async def set_room_override(conn: aiosqlite.Connection, override: RoomOverride) 
            ON CONFLICT(room_id) DO UPDATE SET
              target_temp=excluded.target_temp, expires_at=excluded.expires_at
         """,
-        (override.room_id, override.target_temp, override.expires_at.replace(tzinfo=None).isoformat()),
+        (
+            override.room_id,
+            override.target_temp,
+            override.expires_at.replace(tzinfo=None).isoformat(),
+        ),
     )
     await conn.commit()
 
@@ -956,7 +960,14 @@ async def insert_cycle_temp_sample(
     await conn.execute(
         """INSERT INTO cycle_temp_samples(cycle_id,room_id,timestamp,room_temp,thermostat_temp,setpoint)
            VALUES(?,?,?,?,?,?)""",
-        (cycle_id, room_id, timestamp.replace(tzinfo=None).isoformat(), room_temp, thermostat_temp, setpoint),
+        (
+            cycle_id,
+            room_id,
+            timestamp.replace(tzinfo=None).isoformat(),
+            room_temp,
+            thermostat_temp,
+            setpoint,
+        ),
     )
     await conn.commit()
 

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 
 import aiosqlite
 
@@ -209,7 +209,7 @@ async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> Non
             return
 
     # How much to add to a local naive datetime to get UTC
-    offset = datetime.utcnow() - datetime.now()
+    offset = datetime.now(timezone.utc).replace(tzinfo=None) - datetime.now()
 
     if abs(offset.total_seconds()) >= 1:
         async with conn.execute(
@@ -267,7 +267,11 @@ _MIGRATIONS = [
 
 
 def _dt(s: str | None) -> datetime | None:
-    return datetime.fromisoformat(s) if s else None
+    """Read a datetime string from the DB as UTC-aware."""
+    if not s:
+        return None
+    dt = datetime.fromisoformat(s)
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 def _t(s: str) -> time:
@@ -275,7 +279,8 @@ def _t(s: str) -> time:
 
 
 def _dts(dt: datetime | None) -> str | None:
-    return dt.isoformat() if dt else None
+    """Write a datetime to the DB as a naive UTC string."""
+    return dt.replace(tzinfo=None).isoformat() if dt else None
 
 
 # ---------------------------------------------------------------------------
@@ -600,7 +605,7 @@ async def get_room_override(conn: aiosqlite.Connection, room_id: str) -> RoomOve
     return RoomOverride(
         room_id=row["room_id"],
         target_temp=row["target_temp"],
-        expires_at=datetime.fromisoformat(row["expires_at"]),
+        expires_at=_dt(row["expires_at"]),
     )
 
 
@@ -610,7 +615,7 @@ async def set_room_override(conn: aiosqlite.Connection, override: RoomOverride) 
            ON CONFLICT(room_id) DO UPDATE SET
              target_temp=excluded.target_temp, expires_at=excluded.expires_at
         """,
-        (override.room_id, override.target_temp, override.expires_at.isoformat()),
+        (override.room_id, override.target_temp, override.expires_at.replace(tzinfo=None).isoformat()),
     )
     await conn.commit()
 
@@ -623,7 +628,7 @@ async def clear_room_override(conn: aiosqlite.Connection, room_id: str) -> None:
 async def clear_expired_overrides(conn: aiosqlite.Connection) -> None:
     await conn.execute(
         "DELETE FROM room_overrides WHERE expires_at < ?",
-        (datetime.utcnow().isoformat(),),
+        (datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),),
     )
     await conn.commit()
 
@@ -641,8 +646,8 @@ async def get_all_holdover_states(
     return [
         PresenceHoldoverState(
             room_id=r["room_id"],
-            last_detected_at=datetime.fromisoformat(r["last_detected_at"]),
-            expires_at=datetime.fromisoformat(r["expires_at"]),
+            last_detected_at=_dt(r["last_detected_at"]),
+            expires_at=_dt(r["expires_at"]),
         )
         for r in rows
     ]
@@ -659,8 +664,8 @@ async def get_holdover_state(
         return None
     return PresenceHoldoverState(
         room_id=row["room_id"],
-        last_detected_at=datetime.fromisoformat(row["last_detected_at"]),
-        expires_at=datetime.fromisoformat(row["expires_at"]),
+        last_detected_at=_dt(row["last_detected_at"]),
+        expires_at=_dt(row["expires_at"]),
     )
 
 
@@ -674,8 +679,8 @@ async def upsert_holdover_state(conn: aiosqlite.Connection, state: PresenceHoldo
         """,
         (
             state.room_id,
-            state.last_detected_at.isoformat(),
-            state.expires_at.isoformat(),
+            state.last_detected_at.replace(tzinfo=None).isoformat(),
+            state.expires_at.replace(tzinfo=None).isoformat(),
         ),
     )
     await conn.commit()
@@ -704,10 +709,10 @@ async def close_open_cycle_logs(
     accumulate. Returns the number of rows closed.
     """
     if ended_at is None:
-        ended_at = datetime.utcnow()
+        ended_at = datetime.now(timezone.utc)
     async with conn.execute(
         "UPDATE cycle_logs SET ended_at=? WHERE thermostat_entity_id=? AND ended_at IS NULL",
-        (ended_at.isoformat(), thermostat_entity_id),
+        (ended_at.replace(tzinfo=None).isoformat(), thermostat_entity_id),
     ) as cur:
         count = cur.rowcount or 0
     await conn.commit()
@@ -732,7 +737,7 @@ async def close_open_cycles_for_rooms(
     if not room_ids:
         return 0
     if ended_at is None:
-        ended_at = datetime.utcnow()
+        ended_at = datetime.now(timezone.utc)
     placeholders = ",".join("?" for _ in room_ids)
     query = (
         "UPDATE cycle_logs SET ended_at=? "
@@ -742,7 +747,7 @@ async def close_open_cycles_for_rooms(
         f"  JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id "
         f"  WHERE cl.ended_at IS NULL AND rcs.room_id IN ({placeholders})"
     )
-    params: list = [ended_at.isoformat()]
+    params: list = [ended_at.replace(tzinfo=None).isoformat()]
     params.extend(room_ids)
     if exclude_thermostat:
         query += " AND cl.thermostat_entity_id != ?"
@@ -763,7 +768,7 @@ def _row_to_cycle_log(r) -> CycleLog:
     return CycleLog(
         id=r["id"],
         thermostat_entity_id=r["thermostat_entity_id"],
-        started_at=datetime.fromisoformat(r["started_at"]),
+        started_at=_dt(r["started_at"]),
         mode=r["mode"],
         rooms_json=r["rooms_json"],
         ended_at=_dt(r["ended_at"]),
@@ -805,7 +810,7 @@ async def insert_cycle_log(conn: aiosqlite.Connection, log_: CycleLog) -> None:
         (
             log_.id,
             log_.thermostat_entity_id,
-            log_.started_at.isoformat(),
+            log_.started_at.replace(tzinfo=None).isoformat(),
             _dts(log_.ended_at),
             log_.mode,
             log_.rooms_json,
@@ -836,7 +841,7 @@ async def close_cycle_log(
             vents_at_end=COALESCE(?, vents_at_end)
            WHERE id=?""",
         (
-            ended_at.isoformat(),
+            ended_at.replace(tzinfo=None).isoformat(),
             ended_reason,
             thermostat_temp_at_end,
             setpoint_at_end,
@@ -874,7 +879,7 @@ async def get_cycle_logs(
 
 async def purge_cycle_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete cycle logs older than N days. Returns number of rows deleted."""
-    cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+    cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
     async with conn.execute("DELETE FROM cycle_logs WHERE started_at < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()
@@ -951,7 +956,7 @@ async def insert_cycle_temp_sample(
     await conn.execute(
         """INSERT INTO cycle_temp_samples(cycle_id,room_id,timestamp,room_temp,thermostat_temp,setpoint)
            VALUES(?,?,?,?,?,?)""",
-        (cycle_id, room_id, timestamp.isoformat(), room_temp, thermostat_temp, setpoint),
+        (cycle_id, room_id, timestamp.replace(tzinfo=None).isoformat(), room_temp, thermostat_temp, setpoint),
     )
     await conn.commit()
 
@@ -978,7 +983,7 @@ async def get_cycle_temp_samples(
             id=r["id"],
             cycle_id=r["cycle_id"],
             room_id=r["room_id"],
-            timestamp=datetime.fromisoformat(r["timestamp"]),
+            timestamp=_dt(r["timestamp"]),
             room_temp=r["room_temp"],
             thermostat_temp=r["thermostat_temp"],
             setpoint=r["setpoint"],
@@ -997,7 +1002,7 @@ async def insert_cycle_setpoint_history(
     await conn.execute(
         """INSERT INTO cycle_setpoint_history(cycle_id,timestamp,setpoint,reason)
            VALUES(?,?,?,?)""",
-        (cycle_id, timestamp.isoformat(), setpoint, reason),
+        (cycle_id, timestamp.replace(tzinfo=None).isoformat(), setpoint, reason),
     )
     await conn.commit()
 
@@ -1162,7 +1167,7 @@ async def get_event_logs(
 
 async def purge_event_logs(conn: aiosqlite.Connection, older_than_days: int) -> int:
     """Delete event logs older than N days. Returns number of rows deleted."""
-    cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+    cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=older_than_days)).isoformat()
     async with conn.execute("DELETE FROM event_log WHERE timestamp < ?", (cutoff,)) as cur:
         count = cur.rowcount or 0
     await conn.commit()

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -208,8 +208,10 @@ async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> Non
         if await cur.fetchone():
             return
 
-    # How much to add to a local naive datetime to get UTC
-    offset = datetime.now(UTC).replace(tzinfo=None) - datetime.now()
+    # Compute UTC offset: datetime.now() is intentionally local time here —
+    # we need the wall-clock difference between UTC and the server's local timezone
+    # to shift old holdover records (stored as naive local timestamps) to UTC.
+    offset = datetime.now(UTC).replace(tzinfo=None) - datetime.now()  # noqa: DTZ005
 
     if abs(offset.total_seconds()) >= 1:
         async with conn.execute(

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -13,7 +13,7 @@ import contextlib
 import json
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 import aiosqlite
@@ -299,7 +299,7 @@ class CycleEngine:
         # Check cycle timeout
         if self._cycle_log and self._state == CycleState.RUNNING:
             tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
-            elapsed = datetime.utcnow() - self._cycle_log.started_at
+            elapsed = datetime.now(UTC) - self._cycle_log.started_at
             if elapsed > timedelta(hours=tc.cycle_timeout_hours):
                 log.warning(
                     "Cycle %s timed out after %.1fh — terminating",
@@ -446,7 +446,7 @@ class CycleEngine:
                 await db.upsert_room_cycle_state(conn, rcs)
             # Record "opened_at_start" vent events for every vent in the fresh
             # cycle so the diagnostics view shows the initial open actions.
-            now_ts = datetime.utcnow()
+            now_ts = datetime.now(UTC)
             for room_id, vents in self._room_vents.items():
                 for v in vents:
                     try:
@@ -491,7 +491,7 @@ class CycleEngine:
                     target_temp=ar.target_temp,
                     temp_at_start=self._get_avg_temp(ar.room),
                     trigger_detail=json.dumps(trigger_detail) if trigger_detail else None,
-                    joined_at=datetime.utcnow(),
+                    joined_at=datetime.now(UTC),
                 )
                 self._room_cycle_states[room_id] = rcs
                 await db.upsert_room_cycle_state(conn, rcs)
@@ -636,7 +636,7 @@ class CycleEngine:
         )
         # Mirror any force-reopens into the cycle diagnostics stream.
         if force_reopened_rooms and self._cycle_log:
-            ts = datetime.utcnow()
+            ts = datetime.now(UTC)
             for room_id in force_reopened_rooms:
                 for v in self._room_vents.get(room_id, []):
                     try:
@@ -655,7 +655,7 @@ class CycleEngine:
         # Per-tick temperature sampling — lets the UI draw a chart per room of
         # the temperature trajectory alongside the thermostat reading.
         if self._cycle_log:
-            sample_ts = datetime.utcnow()
+            sample_ts = datetime.now(UTC)
             thermo_cur, thermo_sp = self._read_thermo_temp_and_setpoint()
             for room_id, ar in self._active_rooms.items():
                 try:
@@ -738,9 +738,9 @@ class CycleEngine:
                         vents, all_zone_vents, tc, self._room_cycle_states
                     )
                 if closed:
-                    rcs.vent_closed_at = datetime.utcnow()
+                    rcs.vent_closed_at = datetime.now(UTC)
                     if rcs.reached_at is None:
-                        rcs.reached_at = datetime.utcnow()
+                        rcs.reached_at = datetime.now(UTC)
                     rcs.temp_at_end = avg
                     await db.upsert_room_cycle_state(conn, rcs)
                     if self._cycle_log:
@@ -820,7 +820,7 @@ class CycleEngine:
                 await db.close_cycle_log(
                     conn,
                     self._cycle_log.id,
-                    datetime.utcnow(),
+                    datetime.now(UTC),
                     ended_reason=reason,
                     thermostat_temp_at_end=thermo_temp_end,
                     setpoint_at_end=thermo_setpoint_end,
@@ -937,7 +937,7 @@ class CycleEngine:
                 await db.close_cycle_log(
                     conn,
                     self._cycle_log.id,
-                    datetime.utcnow(),
+                    datetime.now(UTC),
                     ended_reason=f"aborted: {reason}",
                     thermostat_temp_at_end=thermo_temp_end,
                     setpoint_at_end=thermo_setpoint_end,
@@ -1281,13 +1281,13 @@ class CycleEngine:
             except Exception:
                 override = None
             if override:
-                detail["expires_at"] = override.expires_at.isoformat()
+                detail["expires_at"] = override.expires_at.replace(tzinfo=None).isoformat()
         elif ar.source == "schedule":
             try:
                 schedules = await db.get_schedules_for_room(conn, ar.room.id)
                 from .room_manager import _find_matching_schedule
 
-                match = _find_matching_schedule(schedules, datetime.now())
+                match = _find_matching_schedule(schedules, datetime.now(UTC))
                 if match:
                     detail["schedule_id"] = match.id
                     detail["start_time"] = match.start_time.isoformat()
@@ -1301,8 +1301,8 @@ class CycleEngine:
             except Exception:
                 holdover = None
             if holdover:
-                detail["holdover_expires_at"] = holdover.expires_at.isoformat()
-                detail["last_detected_at"] = holdover.last_detected_at.isoformat()
+                detail["holdover_expires_at"] = holdover.expires_at.replace(tzinfo=None).isoformat()
+                detail["last_detected_at"] = holdover.last_detected_at.replace(tzinfo=None).isoformat()
             try:
                 sensors = await db.get_room_presence_sensors(conn, ar.room.id)
                 if sensors:
@@ -1480,7 +1480,7 @@ class CycleEngine:
                     await db.insert_cycle_setpoint_history(
                         conn,
                         self._cycle_log.id,
-                        datetime.utcnow(),
+                        datetime.now(UTC),
                         setpoint,
                         f"mode={hvac_mode}",
                     )
@@ -1508,7 +1508,7 @@ class CycleEngine:
         tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
         if tc.reconciliation_interval_min <= 0:
             return
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         interval_secs = tc.reconciliation_interval_min * 60
         if (
             self._last_reconciled_at is None
@@ -1768,7 +1768,7 @@ class CycleEngine:
         # Close duplicates (all but the most recent); newest-first order from DB
         to_restore = open_logs[0]
         if len(open_logs) > 1:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             for stale in open_logs[1:]:
                 await db.close_cycle_log(conn, stale.id, now)
             log.warning(
@@ -1839,7 +1839,7 @@ class CycleEngine:
                         to_restore.mode == "heating" and ambient_now > max(all_targets)
                     ) or (to_restore.mode == "cooling" and ambient_now < min(all_targets))
                     if contradicts:
-                        await db.close_cycle_log(conn, to_restore.id, datetime.utcnow())
+                        await db.close_cycle_log(conn, to_restore.id, datetime.now(UTC))
                         log.warning(
                             "Restore: discarding stale %s cycle %s for %s — "
                             "thermostat ambient %.1f°F contradicts restored mode "

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1302,7 +1302,9 @@ class CycleEngine:
                 holdover = None
             if holdover:
                 detail["holdover_expires_at"] = holdover.expires_at.replace(tzinfo=None).isoformat()
-                detail["last_detected_at"] = holdover.last_detected_at.replace(tzinfo=None).isoformat()
+                detail["last_detected_at"] = holdover.last_detected_at.replace(
+                    tzinfo=None
+                ).isoformat()
             try:
                 sensors = await db.get_room_presence_sensors(conn, ar.room.id)
                 if sensors:

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 
 import aiosqlite
 
@@ -38,7 +38,7 @@ async def get_active_rooms(
 ) -> list[ActiveRoom]:
     """Return all rooms for the given thermostat that should be active right now."""
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
     rooms = await db.get_rooms_for_thermostat(conn, thermostat_entity_id)
     all_schedules = await db.get_all_schedules(conn)
@@ -118,8 +118,9 @@ def _schedule_active(s: Schedule, current_day: int, current_time: time) -> bool:
 
 def _find_matching_schedule(schedules: list[Schedule], now: datetime) -> Schedule | None:
     """Return the best matching schedule block for the current moment, or None."""
-    current_day = now.weekday()  # 0=Monday
-    current_time = now.time().replace(second=0, microsecond=0)
+    local_now = now.astimezone()  # UTC-aware → local-aware; naive → treated as local
+    current_day = local_now.weekday()  # 0=Monday
+    current_time = local_now.time().replace(second=0, microsecond=0)
 
     matches = [s for s in schedules if _schedule_active(s, current_day, current_time)]
     if not matches:
@@ -262,7 +263,7 @@ async def get_room_active_status(
     }
     """
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
     resolved = await _resolve_room(conn, room, schedules, now)
 
@@ -317,7 +318,7 @@ async def handle_presence_event(
     if room.presence_holdover_hours <= 0:
         return False
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
     existing = await db.get_holdover_state(conn, room.id)
     was_active = existing is not None and existing.expires_at > now
@@ -346,7 +347,7 @@ async def expire_holdovers(
     Call this on every scheduler tick.
     """
     if now is None:
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
 
     all_states = await db.get_all_holdover_states(conn)
     expired_ids: list[str] = []

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -38,7 +38,7 @@ async def get_active_rooms(
 ) -> list[ActiveRoom]:
     """Return all rooms for the given thermostat that should be active right now."""
     if now is None:
-        now = datetime.now()  # local time
+        now = datetime.utcnow()
 
     rooms = await db.get_rooms_for_thermostat(conn, thermostat_entity_id)
     all_schedules = await db.get_all_schedules(conn)
@@ -262,7 +262,7 @@ async def get_room_active_status(
     }
     """
     if now is None:
-        now = datetime.now()
+        now = datetime.utcnow()
 
     resolved = await _resolve_room(conn, room, schedules, now)
 
@@ -317,7 +317,7 @@ async def handle_presence_event(
     if room.presence_holdover_hours <= 0:
         return False
     if now is None:
-        now = datetime.now()
+        now = datetime.utcnow()
 
     existing = await db.get_holdover_state(conn, room.id)
     was_active = existing is not None and existing.expires_at > now
@@ -346,7 +346,7 @@ async def expire_holdovers(
     Call this on every scheduler tick.
     """
     if now is None:
-        now = datetime.now()
+        now = datetime.utcnow()
 
     all_states = await db.get_all_holdover_states(conn)
     expired_ids: list[str] = []

--- a/smart_vent/backend/engine/vent_controller.py
+++ b/smart_vent/backend/engine/vent_controller.py
@@ -9,7 +9,7 @@ Safety rules enforced here:
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
@@ -119,7 +119,7 @@ class VentController:
         Returns True if vents were closed, False if deferred due to min_open_vents.
         """
         if now is None:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
 
         if tc.min_open_vents > 0:
             currently_open = self._count_open_vents(all_zone_vents)
@@ -179,7 +179,7 @@ class VentController:
         if tc.max_vent_closed_min == 0:
             return []
         if now is None:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
 
         reopened_rooms: list[str] = []
         limit = timedelta(minutes=tc.max_vent_closed_min)

--- a/smart_vent/backend/event_logger.py
+++ b/smart_vent/backend/event_logger.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable, Coroutine
-from datetime import datetime
+from datetime import UTC, datetime
 
 import aiosqlite
 
@@ -39,7 +39,7 @@ class EventLogger:
         details: dict | None = None,
     ) -> None:
         """Write an event to the DB and push it over WebSocket. Never raises."""
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(UTC).replace(tzinfo=None).isoformat()
         details_json = json.dumps(details) if details else None
         rowid = 0
 

--- a/smart_vent/backend/mcp_tools/rooms.py
+++ b/smart_vent/backend/mcp_tools/rooms.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 from mcp.server import Server
@@ -167,7 +167,7 @@ def register(server: Server, conn: aiosqlite.Connection) -> None:
         override = RoomOverride(
             room_id=room_id,
             target_temp=target_temp,
-            expires_at=datetime.utcnow() + timedelta(hours=duration_hours),
+            expires_at=datetime.now(UTC) + timedelta(hours=duration_hours),
         )
         await db.set_room_override(conn, override)
         return [

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, time
+from datetime import UTC, datetime, time
 from typing import Literal
 
 ControlMethod = Literal["open_close", "set_position", "set_tilt_position", "toggle"]
@@ -181,7 +181,7 @@ class CycleLog:
         return cls(
             id=new_id(),
             thermostat_entity_id=thermostat_entity_id,
-            started_at=datetime.utcnow(),
+            started_at=datetime.now(UTC),
             mode=mode,
             rooms_json=rooms_json,
         )

--- a/smart_vent/backend/tests/integration/test_cycle_flow.py
+++ b/smart_vent/backend/tests/integration/test_cycle_flow.py
@@ -6,7 +6,7 @@ sensor reaches target → vent close → cycle log closed with diagnostics.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -30,7 +30,7 @@ async def _create_room_with_schedule(
     )
 
     # Schedule covering now ± 1h every day
-    now = datetime.now()
+    now = datetime.now(UTC)
     start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
     end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
     await client.post(

--- a/smart_vent/backend/tests/integration/test_idle_room_vents_closed_on_cycle_start.py
+++ b/smart_vent/backend/tests/integration/test_idle_room_vents_closed_on_cycle_start.py
@@ -9,14 +9,14 @@ rooms' vents, so they stayed open for the duration of the next cycle.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 
 def _schedule_covering_now(client_post, room_id: str, target_temp: float):
     """Helper coroutine — returns the coroutine so callers can await it."""
-    now = datetime.now()
+    now = datetime.now(UTC)
     start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
     end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
     return client_post(
@@ -146,7 +146,7 @@ async def test_idle_room_vent_not_closed_mid_cycle_when_rooms_change(client, fak
     fake_ha.seed_state(vent_b, "closed", {})
 
     # Both rooms have schedules active now; both join the initial cycle.
-    now = datetime.now()
+    now = datetime.now(UTC)
     start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
     end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
 

--- a/smart_vent/backend/tests/integration/test_setpoint_bounds.py
+++ b/smart_vent/backend/tests/integration/test_setpoint_bounds.py
@@ -11,7 +11,7 @@ max_setpoint.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -32,7 +32,7 @@ async def _make_room_with_schedule(
         f"/api/rooms/{room_id}/vents",
         json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
     )
-    now = datetime.now()
+    now = datetime.now(UTC)
     start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
     end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
     await client.post(

--- a/smart_vent/backend/tests/integration/test_vent_types.py
+++ b/smart_vent/backend/tests/integration/test_vent_types.py
@@ -8,7 +8,7 @@ service was recorded on the fake client.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -28,7 +28,7 @@ async def _make_room_with_vent(client, control_method: str) -> str:
         json={"entity_id": "cover.test_room_vent", "control_method": control_method},
     )
 
-    now = datetime.now()
+    now = datetime.now(UTC)
     start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
     end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
     await client.post(

--- a/smart_vent/backend/tests/test_cycle_diagnostics.py
+++ b/smart_vent/backend/tests/test_cycle_diagnostics.py
@@ -16,7 +16,7 @@ Covers:
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -156,7 +156,7 @@ class TestCycleStartSnapshot:
     async def test_schedule_trigger_detail_includes_times(self):
         conn, room = await _setup_db_and_room()
         # Create a schedule that matches right now so trigger_detail picks it up
-        now = datetime.now()
+        now = datetime.now(UTC)
         schedule = Schedule.create(
             room_id=room.id,
             days_of_week=list(range(7)),
@@ -380,7 +380,7 @@ class TestVentEvents:
 
         # Pretend vent has been closed for >1 min already.
         rcs = engine._room_cycle_states[room.id]
-        rcs.vent_closed_at = datetime.utcnow() - timedelta(minutes=5)
+        rcs.vent_closed_at = datetime.now(UTC) - timedelta(minutes=5)
         await db.upsert_room_cycle_state(conn, rcs)
 
         engine._ha.get_numeric_state.return_value = 70.0

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 
 import aiosqlite
 import pytest
@@ -167,23 +167,23 @@ class TestScheduleActiveOvernight:
 class TestFindMatchingSchedule:
     def test_returns_matching_schedule(self):
         s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
-        now = datetime(2026, 4, 13, 12, 0)  # Monday
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)  # Monday
         assert _find_matching_schedule([s], now) == s
 
     def test_returns_none_when_no_match(self):
         s = _make_schedule(start=time(8, 0), end=time(17, 0), days=[0])
-        now = datetime(2026, 4, 14, 12, 0)  # Tuesday
+        now = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)  # Tuesday
         assert _find_matching_schedule([s], now) is None
 
     def test_earliest_start_wins_tiebreak(self):
         """When two schedules overlap, the one with earliest start_time wins."""
         s1 = _make_schedule(start=time(9, 0), end=time(17, 0), days=[0], sid="s1")
         s2 = _make_schedule(start=time(8, 0), end=time(12, 0), days=[0], sid="s2")
-        now = datetime(2026, 4, 13, 10, 0)  # Monday 10:00
+        now = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)  # Monday 10:00
         assert _find_matching_schedule([s1, s2], now) == s2
 
     def test_empty_schedules(self):
-        assert _find_matching_schedule([], datetime.now()) is None
+        assert _find_matching_schedule([], datetime.now(UTC)) is None
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +241,7 @@ class TestGetActiveRooms:
         )
         await db.upsert_schedule(conn, sched)
 
-        now = datetime(2026, 4, 13, 12, 0)  # Monday noon
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)  # Monday noon
         active = await get_active_rooms(conn, THERMO_ID, now=now)
         assert len(active) == 1
         assert active[0].source == "schedule"
@@ -254,7 +254,7 @@ class TestGetActiveRooms:
         await _insert_room(conn, "r1", "Bedroom")
 
         # Saturday — no schedules defined (default is Mon-Fri)
-        now = datetime(2026, 4, 18, 12, 0)  # Saturday
+        now = datetime(2026, 4, 18, 12, 0, tzinfo=UTC)  # Saturday
         active = await get_active_rooms(conn, THERMO_ID, now=now)
         assert len(active) == 0
         await conn.close()
@@ -273,7 +273,7 @@ class TestGetActiveRooms:
         )
         await db.upsert_schedule(conn, sched)
 
-        now = datetime(2026, 4, 13, 12, 0)  # Monday noon
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)  # Monday noon
         override = RoomOverride(
             room_id="r1",
             target_temp=78.0,
@@ -301,7 +301,7 @@ class TestGetActiveRooms:
         )
         await db.upsert_schedule(conn, sched)
 
-        now = datetime(2026, 4, 13, 12, 0)
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
         expired_override = RoomOverride(
             room_id="r1",
             target_temp=78.0,
@@ -319,7 +319,7 @@ class TestGetActiveRooms:
         conn = await _setup_db()
         await _insert_room(conn, "r1", "Bedroom", system_wide_temp=72.0)
 
-        now = datetime(2026, 4, 18, 12, 0)  # Saturday, no schedules
+        now = datetime(2026, 4, 18, 12, 0, tzinfo=UTC)  # Saturday, no schedules
         # Create holdover that hasn't expired
         await handle_presence_event(
             conn,
@@ -346,7 +346,7 @@ class TestGetActiveRooms:
         conn = await _setup_db()
         await _insert_room(conn, "r1", "Bedroom", system_wide_temp=None)
 
-        now = datetime(2026, 4, 18, 12, 0)
+        now = datetime(2026, 4, 18, 12, 0, tzinfo=UTC)
         room = Room(
             id="r1",
             name="Bedroom",
@@ -370,7 +370,7 @@ class TestGetActiveRooms:
         tc = ThermostatConfig(thermostat_entity_id=THERMO_ID, default_temp=70.0)
         await db.upsert_thermostat_config(conn, tc)
 
-        now = datetime(2026, 4, 18, 12, 0)
+        now = datetime(2026, 4, 18, 12, 0, tzinfo=UTC)
         room = Room(
             id="r1",
             name="Bedroom",
@@ -398,7 +398,7 @@ class TestHandlePresenceEvent:
         conn = await _setup_db()
         room = await _insert_room(conn, "r1", "Bedroom")
 
-        now = datetime(2026, 4, 13, 12, 0)
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
         newly_active = await handle_presence_event(conn, room, now=now)
         assert newly_active is True
 
@@ -413,7 +413,7 @@ class TestHandlePresenceEvent:
         conn = await _setup_db()
         room = await _insert_room(conn, "r1", "Bedroom")
 
-        t1 = datetime(2026, 4, 13, 12, 0)
+        t1 = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
         await handle_presence_event(conn, room, now=t1)
 
         t2 = t1 + timedelta(minutes=30)
@@ -430,7 +430,7 @@ class TestHandlePresenceEvent:
         conn = await _setup_db()
         room = await _insert_room(conn, "r1", "Bedroom", presence_hours=0.0)
 
-        now = datetime(2026, 4, 13, 12, 0)
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
         result = await handle_presence_event(conn, room, now=now)
         assert result is False
 
@@ -450,7 +450,7 @@ class TestExpireHoldovers:
         conn = await _setup_db()
         room = await _insert_room(conn, "r1", "Bedroom")
 
-        t1 = datetime(2026, 4, 13, 10, 0)
+        t1 = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
         await handle_presence_event(conn, room, now=t1)
 
         # Move time past expiry (2 hours later)
@@ -467,7 +467,7 @@ class TestExpireHoldovers:
         conn = await _setup_db()
         room = await _insert_room(conn, "r1", "Bedroom")
 
-        t1 = datetime(2026, 4, 13, 10, 0)
+        t1 = datetime(2026, 4, 13, 10, 0, tzinfo=UTC)
         await handle_presence_event(conn, room, now=t1)
 
         # Only 30 minutes later — still active


### PR DESCRIPTION
## Summary
This PR fixes a timezone handling bug where presence holdover state timestamps were being stored in local server time instead of UTC. It includes a one-time database migration to correct existing records and updates all timestamp comparisons to use UTC consistently.

## Key Changes
- **Database Migration**: Added `_migrate_holdover_timestamps_to_utc()` function that:
  - Calculates the offset between local time and UTC
  - Adjusts all existing `presence_holdover_state` timestamps from local time to UTC
  - Uses a sentinel value in `system_settings` to ensure the migration runs only once
  - Logs the number of records adjusted

- **Timestamp Consistency**: Updated all datetime comparisons in `room_manager.py` and `routes.py` to use `datetime.utcnow()` instead of `datetime.now()`:
  - `get_active_rooms()`: Changed default `now` parameter
  - `get_room_active_status()`: Changed default `now` parameter
  - `handle_presence_event()`: Changed default `now` parameter
  - `expire_holdovers()`: Changed default `now` parameter
  - `rooms_active_status()` API endpoint: Changed timestamp generation

## Implementation Details
- The migration only executes if the timezone offset is >= 1 second, avoiding unnecessary updates on UTC-based servers
- The sentinel pattern prevents re-running the migration on subsequent application starts
- All timestamp comparisons now use UTC, ensuring consistent behavior regardless of server timezone configuration
- Fixes Issue #65

https://claude.ai/code/session_013BLchUPgDRdcq2nFNtFZXq