### PR TITLE
Fix: Require reaching exact target temp without deadband to end cycles

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -692,7 +692,7 @@ class CycleEngine:
             # drift (e.g. a room that overcools by 3°F gets offset=+3 so its vent
             # closes 3°F before the actual target, and it drifts to target).
             effective_avg = avg + ar.room.temp_offset
-            at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode, tc.deadband)
+            at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode)
 
             if at_target and rcs.vent_closed_at is None:
                 # Try to close the vent.
@@ -1946,11 +1946,11 @@ class CycleEngine:
             self._sensor_map[room_id] = [s.entity_id for s in sensors]
 
 
-def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str, deadband: float) -> bool:
+def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:
     if hvac_mode == "cooling":
-        return avg_temp <= target_temp + deadband
+        return avg_temp <= target_temp
     if hvac_mode == "heating":
-        return avg_temp >= target_temp - deadband
+        return avg_temp >= target_temp
     # Unexpected mode — return False (not at target) so vents stay open
     # rather than closing prematurely.  (Issue #48 Bug 6)
     log.warning("_is_at_target called with unexpected mode %r — returning False", hvac_mode)

--- a/smart_vent/backend/tests/integration/test_cycle_flow.py
+++ b/smart_vent/backend/tests/integration/test_cycle_flow.py
@@ -211,3 +211,48 @@ async def test_fake_ha_mirrors_real_client_public_api(fake_ha) -> None:
     }
     missing = real_public - fake_public
     assert not missing, f"FakeHomeAssistant missing public methods: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_cycle_start_respects_deadband(client, fake_ha, tick) -> None:
+    """A cycle only starts if room temp exceeds target +/- deadband.
+
+    If target is 72.0 and deadband is 1.0, a temp of 72.5 does NOT start a cycle,
+    but a temp of 73.1 does.
+    """
+    _, entities = await _create_room_with_schedule(client, target_temp=72.0)
+
+    # Explicitly set deadband to 1.0 for the thermostat
+    await client.put(
+        f"/api/thermostats/{entities.thermostat}/config",
+        json={"overshoot_delta": 2.0, "deadband": 1.0, "min_open_vents": 1},
+    )
+
+    # 1. Inside deadband (72.5 <= 72.0 + 1.0) -> No cycle expected
+    fake_ha.seed_state(
+        entities.thermostat,
+        "cool",
+        {"current_temperature": 75.0, "temperature": 75.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(entities.sensor, "72.5", {"unit_of_measurement": "°F"})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 0, "No cycle should start when room is within deadband"
+    calls = fake_ha.calls_for("set_temperature")
+    assert len(calls) == 1, "Thermostat is reset to ambient when idle"
+    assert calls[0].data["temperature"] == 75.0, (
+        "Thermostat should be set to ambient to keep it off"
+    )
+    fake_ha.reset_calls()
+
+    # 2. Outside deadband (73.1 > 72.0 + 1.0) -> Cycle starts
+    await fake_ha.set_entity_state(entities.sensor, "73.1", {"unit_of_measurement": "°F"})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "Cycle should start when room temp exceeds deadband"
+    assert logs[0]["ended_at"] is None
+    assert len(fake_ha.calls_for("set_temperature")) > 0, "Thermostat should be activated"

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -452,50 +452,37 @@ class TestCrossThermoDuplicatePrevention:
 
 
 class TestIsAtTarget:
-    """_is_at_target must handle modes explicitly."""
+    """_is_at_target must handle modes explicitly and not use deadband."""
 
     def test_cooling_at_target(self):
-        assert _is_at_target(73.0, 74.0, "cooling", 0.5) is True  # 73 <= 74.5
+        assert _is_at_target(73.0, 74.0, "cooling") is True  # 73 <= 74
 
     def test_cooling_not_at_target(self):
-        assert _is_at_target(76.0, 74.0, "cooling", 0.5) is False  # 76 > 74.5
+        """Cooling above target -> not at target (even if within deadband)."""
+        assert _is_at_target(74.5, 74.0, "cooling") is False  # 74.5 > 74
 
     def test_heating_at_target(self):
-        assert _is_at_target(74.0, 74.0, "heating", 0.5) is True  # 74 >= 73.5
+        assert _is_at_target(75.0, 74.0, "heating") is True  # 75 >= 74
 
     def test_heating_not_at_target(self):
-        assert _is_at_target(72.0, 74.0, "heating", 0.5) is False  # 72 < 73.5
+        """Heating below target -> not at target (even if within deadband)."""
+        assert _is_at_target(73.5, 74.0, "heating") is False  # 73.5 < 74
 
     def test_off_mode_returns_false(self):
         """Unexpected mode 'off' should return False (safe — vents stay open)."""
-        assert _is_at_target(74.0, 74.0, "off", 0.5) is False
+        assert _is_at_target(74.0, 74.0, "off") is False
 
     def test_unknown_mode_returns_false(self):
         """Unexpected mode 'unknown' should return False."""
-        assert _is_at_target(74.0, 74.0, "unknown", 0.5) is False
+        assert _is_at_target(74.0, 74.0, "unknown") is False
 
     def test_cooling_exact_boundary(self):
-        """Cooling at exactly target+deadband → at target (inclusive)."""
-        assert _is_at_target(74.5, 74.0, "cooling", 0.5) is True
-
-    def test_cooling_just_above_boundary(self):
-        """Cooling just above target+deadband → not at target."""
-        assert _is_at_target(74.6, 74.0, "cooling", 0.5) is False
+        """Cooling at exactly target → at target (inclusive)."""
+        assert _is_at_target(74.0, 74.0, "cooling") is True
 
     def test_heating_exact_boundary(self):
-        """Heating at exactly target-deadband → at target (inclusive)."""
-        assert _is_at_target(73.5, 74.0, "heating", 0.5) is True
-
-    def test_heating_just_below_boundary(self):
-        """Heating just below target-deadband → not at target."""
-        assert _is_at_target(73.4, 74.0, "heating", 0.5) is False
-
-    def test_zero_deadband(self):
-        """Deadband of 0: must hit target exactly."""
-        assert _is_at_target(74.0, 74.0, "cooling", 0.0) is True
-        assert _is_at_target(74.1, 74.0, "cooling", 0.0) is False
-        assert _is_at_target(74.0, 74.0, "heating", 0.0) is True
-        assert _is_at_target(73.9, 74.0, "heating", 0.0) is False
+        """Heating at exactly target → at target (inclusive)."""
+        assert _is_at_target(74.0, 74.0, "heating") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #70.

The deadband is used to prevent short-cycling by delaying the start of a cycle. However, ending an active cycle at the deadband boundary causes the HVAC system to stop prematurely and not actually reach the requested temperature. 

This PR removes the deadband from the target evaluation in `_is_at_target()`. Cycles will now continue running until the exact target temperature is reached without the deadband offset.

### Changes:
- Modified `_is_at_target` signature and implementation to remove `deadband`.
- Updated caller in `cycle_engine.py` to drop the deadband parameter.
- Updated comprehensive tests in `test_cycle_engine.py` to assert precise boundary comparisons without the deadband.