### PR TITLE
Fix blank screen when accessed via Home Assistant ingress

### DIFF
--- a/smart_vent/frontend/src/main.tsx
+++ b/smart_vent/frontend/src/main.tsx
@@ -239,9 +239,12 @@ function Nav() {
 // Root render
 // ---------------------------------------------------------------------------
 
+const _ingressMatch = location.pathname.match(/^(\/api\/hassio_ingress\/[^/]+)/);
+const _ingressBasename = _ingressMatch ? _ingressMatch[1] : "";
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={_ingressBasename}>
       <AppRoot>
         <Nav />
         <main className="main">


### PR DESCRIPTION
## Summary

- Fixes #74 — blank screen when opening the addon via HA ingress panel
- HA ingress serves the app at a dynamic path (`/api/hassio_ingress/<TOKEN>/`); `BrowserRouter` had no `basename`, so React Router matched no routes and rendered nothing
- Detects the ingress prefix at startup (same regex already used in `api.ts`) and passes it as `basename` to `BrowserRouter`

## Changes

**`smart_vent/frontend/src/main.tsx`**
```diff
+const _ingressMatch = location.pathname.match(/^(\/api\/hassio_ingress\/[^/]+)/);
+const _ingressBasename = _ingressMatch ? _ingressMatch[1] : "";

 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={_ingressBasename}>
```

## Test plan

- [ ] Open addon via HA ingress panel — dashboard renders correctly
- [ ] Navigate between routes (Rooms, Schedules, Thermostats, Logs) via ingress — all load correctly
- [ ] Open addon directly via `http://homeassistant.local:8099` — still works (basename is `""`)

https://claude.ai/code/session_018G1KdHgJwTuTsGqRyJK5CN