### PR TITLE
fix: schedule preempts running presence cycle + restore room-status countdowns

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -266,6 +266,33 @@ class CycleEngine:
             await self._maybe_broadcast()
             return
 
+        # Detect trigger transitions on rooms that persist across ticks — e.g.
+        # presence holdover giving way to a schedule block for the same room
+        # (priority 2 > 3 in _resolve_room). The room id set doesn't change, so
+        # `rooms_changed` would stay False and the cycle would keep running with
+        # the stale target and source. Terminate cleanly here so the next tick
+        # starts a fresh cycle whose cycle_log / trigger_detail reflect the new
+        # source, and whose mode is re-inferred from current temps vs the new
+        # target (direction can flip, e.g. presence 70°F → schedule 68°F when
+        # the room is already at 71°F turns heating into cooling).
+        trigger_changed = self._state == CycleState.RUNNING and any(
+            room_id in self._active_rooms
+            and (
+                new_active_map[room_id].source != self._active_rooms[room_id].source
+                or new_active_map[room_id].target_temp != self._active_rooms[room_id].target_temp
+            )
+            for room_id in new_active_map
+        )
+        if trigger_changed:
+            log.info(
+                "Trigger changed mid-cycle for %s — terminating so the new "
+                "source takes over on the next evaluation",
+                self.thermostat_entity_id,
+            )
+            await self._terminate_cycle(conn, reason="trigger changed")
+            await self._maybe_broadcast()
+            return
+
         # If rooms changed, update and recompute setpoint.
         # For mid-cycle updates, preserve the original cycle direction so that a
         # momentary hvac_action="idle" (common on heat_cool thermostats) does not

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -179,8 +179,12 @@ def schedules_overlap(a: Schedule, b: Schedule) -> bool:
 
 def _seconds_until_schedule_end(s: Schedule, now: datetime) -> float:
     """Return seconds until the currently-active block of schedule s ends."""
-    current_time = now.time()
-    today = now.date()
+    # Schedules are stored as wall-clock / local-time. `datetime.combine(...)`
+    # below produces a naive datetime, so normalize `now` to naive-local too —
+    # subtracting a naive from a tz-aware datetime raises TypeError.
+    local_now = now.astimezone().replace(tzinfo=None) if now.tzinfo else now
+    current_time = local_now.time()
+    today = local_now.date()
 
     is_overnight = s.end_time <= s.start_time
     if not is_overnight:
@@ -193,7 +197,7 @@ def _seconds_until_schedule_end(s: Schedule, now: datetime) -> float:
             # Morning portion → ends today at end_time
             end_dt = datetime.combine(today, s.end_time)
 
-    return max(0.0, (end_dt - now).total_seconds())
+    return max(0.0, (end_dt - local_now).total_seconds())
 
 
 def _next_schedule_start(
@@ -211,6 +215,10 @@ def _next_schedule_start(
     if not schedules:
         return None
 
+    # Schedules are local wall-clock; do all arithmetic in naive-local so the
+    # naive datetime.combine(...) below lines up with `now`.
+    local_now = now.astimezone().replace(tzinfo=None) if now.tzinfo else now
+
     candidates: list[tuple[float, float, str]] = []
 
     for s in schedules:
@@ -218,14 +226,14 @@ def _next_schedule_start(
             continue
         # Look ahead up to 7 days (day_offset=0 is today, 6 is 6 days from now)
         for day_offset in range(7):
-            candidate_date = now.date() + timedelta(days=day_offset)
+            candidate_date = local_now.date() + timedelta(days=day_offset)
             candidate_weekday = candidate_date.weekday()
             if candidate_weekday not in s.days_of_week:
                 continue
             start_dt = datetime.combine(candidate_date, s.start_time)
-            if start_dt <= now:
+            if start_dt <= local_now:
                 continue  # already passed
-            secs = (start_dt - now).total_seconds()
+            secs = (start_dt - local_now).total_seconds()
             h = s.start_time.hour
             m = s.start_time.minute
             am_pm = "AM" if h < 12 else "PM"

--- a/smart_vent/backend/tests/integration/test_presence_to_schedule_swap.py
+++ b/smart_vent/backend/tests/integration/test_presence_to_schedule_swap.py
@@ -1,0 +1,113 @@
+"""
+Regression test: a schedule block must preempt an in-flight presence cycle.
+
+Scenario:
+  - Room has presence_holdover_hours>0 and a system_wide_temp (presence target).
+  - Presence fires → cycle starts with source=presence at the presence target.
+  - A schedule with a different target becomes active for the same room.
+  - The cycle engine must terminate the presence cycle and start a fresh one
+    with source=schedule. Without this the old engine kept running at the
+    presence target because `rooms_changed` only compared room id sets.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_schedule_preempts_running_presence_cycle(client, fake_ha, tick) -> None:
+    # Heating scenario: ambient below both presence (70) and schedule (68) targets.
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "heat",
+        {
+            "current_temperature": 65.0,
+            "temperature": 65.0,
+            "hvac_action": "idle",
+        },
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "65.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+    fake_ha.seed_state("binary_sensor.test_room_presence", "off", {})
+
+    # Room with presence target 70 and no schedule yet.
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Bedroom",
+            "thermostat_entity_id": "climate.test_thermostat",
+            "system_wide_temp": 70.0,
+            "presence_holdover_hours": 2.0,
+        },
+    )
+    room_id = (await resp.json())["id"]
+
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
+    )
+    await client.post(
+        f"/api/rooms/{room_id}/presence",
+        json={"entity_id": "binary_sensor.test_room_presence"},
+    )
+
+    # Trigger presence → scheduler picks it up via subscribe_all and starts a
+    # cycle with source=presence at the 70°F presence target.
+    await fake_ha.set_entity_state("binary_sensor.test_room_presence", "on", {})
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "presence should have started exactly one cycle"
+    presence_cycle_id = logs[0]["id"]
+    assert logs[0]["ended_at"] is None
+    # rooms is a dict keyed by room_id → {name, target, source}.
+    presence_rooms = logs[0]["rooms"]
+    assert next(iter(presence_rooms.values()))["source"] == "presence"
+    assert next(iter(presence_rooms.values()))["target"] == 70.0
+
+    # Now add a schedule covering "now" with a lower target. Schedule has higher
+    # priority than presence in _resolve_room, so the next tick should detect
+    # the trigger change and terminate the presence cycle.
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 68.0,
+        },
+    )
+
+    await tick()
+
+    # Presence cycle must be closed with a "trigger changed" reason.
+    logs = await (await client.get("/api/logs")).json()
+    presence_log = next(entry for entry in logs if entry["id"] == presence_cycle_id)
+    assert presence_log["ended_at"] is not None, "old presence cycle must be closed"
+    assert "trigger changed" in (presence_log.get("ended_reason") or "")
+
+    # Next tick: fresh cycle starts with source=schedule at the new target.
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    open_cycles = [entry for entry in logs if entry["ended_at"] is None]
+    assert len(open_cycles) == 1, "a fresh schedule cycle must be open"
+    new_cycle_id = open_cycles[0]["id"]
+    assert new_cycle_id != presence_cycle_id
+
+    # Latest setpoint write should reflect the schedule target (68°F),
+    # not the old presence target (70°F). In heating the engine writes
+    # target + overshoot_delta (default 2.0) so expect 70.0.
+    setpoint_calls = fake_ha.calls_for("set_temperature")
+    assert setpoint_calls, "engine should write a setpoint for the new cycle"
+    last_setpoint = setpoint_calls[-1].data["temperature"]
+    assert last_setpoint == pytest.approx(70.0, abs=0.5), (
+        f"setpoint {last_setpoint} should match schedule target 68 + overshoot"
+    )

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -23,6 +23,7 @@ from backend.engine.room_manager import (
     _schedule_active,
     expire_holdovers,
     get_active_rooms,
+    get_room_active_status,
     handle_presence_event,
     schedules_overlap,
 )
@@ -484,4 +485,82 @@ class TestExpireHoldovers:
         conn = await _setup_db()
         expired = await expire_holdovers(conn)
         assert expired == []
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# get_room_active_status — countdowns and next-schedule lookup
+# Regression coverage for UTC-aware `now` mixing with naive datetime.combine()
+# inside _seconds_until_schedule_end / _next_schedule_start (would previously
+# raise "can't subtract offset-naive and offset-aware datetimes").
+# ---------------------------------------------------------------------------
+
+
+class TestGetRoomActiveStatus:
+    @pytest.mark.asyncio
+    async def test_utc_now_does_not_raise_with_active_schedule(self):
+        """UTC-aware now against naive schedule datetimes must not raise."""
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=[0],
+            start_time=time(8, 0),
+            end_time=time(17, 0),
+            target_temp=74.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        now = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)  # Monday noon UTC
+        status = await get_room_active_status(conn, room, [sched], now=now)
+
+        assert status["source"] == "schedule"
+        assert status["target_temp"] == 74.0
+        assert status["ends_in_seconds"] is not None
+        assert status["ends_in_seconds"] > 0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_next_schedule_populated_when_idle(self):
+        """Outside any schedule, next_schedule_* fields must be set, not crash."""
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom")
+
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=[0],  # Monday only
+            start_time=time(8, 0),
+            end_time=time(17, 0),
+            target_temp=74.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        # Sunday 10:00 UTC — no schedule active; next is Monday 08:00
+        now = datetime(2026, 4, 12, 10, 0, tzinfo=UTC)
+        status = await get_room_active_status(conn, room, [sched], now=now)
+
+        assert status["source"] == "idle"
+        assert status["next_schedule_in_seconds"] is not None
+        assert status["next_schedule_target"] == 74.0
+        assert status["next_schedule_label"] is not None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_presence_ends_in_seconds_with_utc_now(self):
+        """Presence holdover countdown must work with UTC-aware now."""
+        conn = await _setup_db()
+        room = await _insert_room(conn, "r1", "Bedroom", system_wide_temp=70.0)
+
+        now = datetime(2026, 4, 18, 12, 0, tzinfo=UTC)  # Saturday, no schedules
+        await handle_presence_event(conn, room, now=now)
+
+        check_time = now + timedelta(minutes=30)
+        status = await get_room_active_status(conn, room, [], now=check_time)
+
+        assert status["source"] == "presence"
+        assert status["target_temp"] == 70.0
+        # holdover_hours=2.0, 30 min in → ~90 min left (± tick jitter)
+        assert status["ends_in_seconds"] is not None
+        assert 5000 < status["ends_in_seconds"] < 5500
         await conn.close()


### PR DESCRIPTION
Two regressions surfaced together after the UTC migration in #66:

1. Schedules no longer took precedence over an in-flight presence cycle.
   `_resolve_room` correctly returned source=schedule for a room already
   running under a presence holdover, but `_do_tick` only compared the
   room-id set (`rooms_changed = set(new) != set(old)`), so the engine
   never noticed the source/target flipped. The cycle kept running at
   the presence target. Fix: detect when a persisting room's source or
   target_temp changed mid-cycle and terminate the cycle cleanly — the
   next tick starts a fresh cycle with the new trigger recorded in its
   own cycle_log and mode re-inferred against the new target.

2. Room cards stopped showing "ends in …" and the next upcoming schedule.
   `get_room_active_status` passes a UTC-aware `now` (post-#66), but
   `_seconds_until_schedule_end` and `_next_schedule_start` still built
   `datetime.combine(date, schedule.time)` as naive — subtracting the
   two raised "can't subtract offset-naive and offset-aware datetimes"
   and the endpoint 500'd. Fix: normalize `now` to naive-local inside
   both helpers so all arithmetic runs in the schedule's own
   wall-clock frame.

Tests:
- integration/test_presence_to_schedule_swap: exercises the real flow
  (presence fires → cycle starts → schedule added → trigger swap →
  fresh schedule cycle with correct setpoint).
- test_room_manager::TestGetRoomActiveStatus: covers UTC-aware `now`
  against active/idle/presence rooms, including next-schedule lookup.