### PR TITLE
fix: close idle-room vents when restoring a running cycle after reboot

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -592,63 +592,77 @@ class CycleEngine:
             # We captured is_fresh_start=True before mutating self._state so
             # this block only runs when starting a brand-new cycle, not when
             # rooms are added/removed mid-cycle.
-            all_zone_rooms = await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id)
-            active_ids = set(self._active_rooms.keys())
-            for zone_room in all_zone_rooms:
-                if zone_room.id in active_ids:
-                    continue
-                idle_vents = await db.get_room_vents(conn, zone_room.id)
-                if not idle_vents:
-                    continue
-                # Respect min_open_vents: count open vents across ALL zone vents
-                # (active + idle) before deciding whether to close.
-                all_zone_vents_now = [
-                    v for room_id in self._active_rooms for v in self._room_vents.get(room_id, [])
-                ] + idle_vents
-                can_close = True
-                if tc.min_open_vents > 0:
-                    open_count = self._vent._count_open_vents(all_zone_vents_now)
-                    would_close = sum(1 for v in idle_vents if self._vent._is_open(v.entity_id))
-                    if open_count - would_close < tc.min_open_vents:
-                        can_close = False
-                        log.warning(
-                            "Cannot close idle room %s vents at cycle start"
-                            " — would violate min_open_vents=%d",
-                            zone_room.name,
-                            tc.min_open_vents,
-                        )
-                if can_close:
-                    for v in idle_vents:
-                        try:
-                            await self._ha.close_cover(v.entity_id)
-                        except Exception as exc:
-                            log.error(
-                                "Error closing idle room %s vent %s at cycle start: %s",
-                                zone_room.name,
-                                v.entity_id,
-                                exc,
-                            )
-                    log.info(
-                        "Closed idle room %s vents at cycle start for %s",
-                        zone_room.name,
-                        self.thermostat_entity_id,
-                    )
-                    if self._logger:
-                        await self._logger.log(
-                            "info",
-                            "engine",
-                            f"Closed idle room {zone_room.name} vents at cycle start"
-                            f" for {self.thermostat_entity_id}",
-                            {
-                                "thermostat": self.thermostat_entity_id,
-                                "room_id": zone_room.id,
-                                "room_name": zone_room.name,
-                                "cycle_id": self._cycle_log.id if self._cycle_log else None,
-                            },
-                        )
+            await self._close_idle_room_vents(conn, tc)
 
         # Set thermostat setpoint
         await self._set_thermostat_setpoint(tc, hvac_mode, conn=conn)
+
+    async def _close_idle_room_vents(
+        self,
+        conn: aiosqlite.Connection,
+        tc: ThermostatConfig,
+    ) -> None:
+        """Close vents for rooms on this zone that are NOT in ``self._active_rooms``.
+
+        Used at fresh cycle start (see ``_start_or_update_cycle``) and on
+        restart recovery (see ``restore_from_db``).  ``_terminate_cycle``
+        re-opens every zone vent at cycle end, so any tick that resumes a
+        running cycle (including DB restore after a reboot) must re-assert
+        closure on idle-room vents.  Otherwise they stay open into the cycle
+        and dilute airflow to the active rooms.  (Issue #67 / reboot regression)
+        """
+        all_zone_rooms = await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id)
+        active_ids = set(self._active_rooms.keys())
+        for zone_room in all_zone_rooms:
+            if zone_room.id in active_ids:
+                continue
+            idle_vents = await db.get_room_vents(conn, zone_room.id)
+            if not idle_vents:
+                continue
+            # Respect min_open_vents: count open vents across ALL zone vents
+            # (active + idle) before deciding whether to close.
+            all_zone_vents_now = [
+                v for room_id in self._active_rooms for v in self._room_vents.get(room_id, [])
+            ] + idle_vents
+            can_close = True
+            if tc.min_open_vents > 0:
+                open_count = self._vent._count_open_vents(all_zone_vents_now)
+                would_close = sum(1 for v in idle_vents if self._vent._is_open(v.entity_id))
+                if open_count - would_close < tc.min_open_vents:
+                    can_close = False
+                    log.warning(
+                        "Cannot close idle room %s vents — would violate min_open_vents=%d",
+                        zone_room.name,
+                        tc.min_open_vents,
+                    )
+            if can_close:
+                for v in idle_vents:
+                    try:
+                        await self._ha.close_cover(v.entity_id)
+                    except Exception as exc:
+                        log.error(
+                            "Error closing idle room %s vent %s: %s",
+                            zone_room.name,
+                            v.entity_id,
+                            exc,
+                        )
+                log.info(
+                    "Closed idle room %s vents for %s",
+                    zone_room.name,
+                    self.thermostat_entity_id,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Closed idle room {zone_room.name} vents for {self.thermostat_entity_id}",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room_id": zone_room.id,
+                            "room_name": zone_room.name,
+                            "cycle_id": self._cycle_log.id if self._cycle_log else None,
+                        },
+                    )
 
     async def _monitor_rooms(self, conn: aiosqlite.Connection, hvac_mode: str) -> None:
         tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
@@ -1914,6 +1928,16 @@ class CycleEngine:
         # Force reconciliation on first tick — _last_setpoint_sent can't be
         # recovered from DB, so setpoint won't be checked, but mode drift will be.
         self._last_reconciled_at = None
+
+        # Re-assert idle-room vent closure. _terminate_cycle re-opens every
+        # zone vent at cycle end, so before the server went down the idle
+        # rooms' vents were closed by the original _start_or_update_cycle
+        # call. But nothing in the restore path re-runs that logic, so after
+        # a reboot idle vents would stay open and dilute airflow until the
+        # cycle naturally ends. Close them now so the restored cycle behaves
+        # identically to the pre-restart one.
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+        await self._close_idle_room_vents(conn, tc)
 
         room_names = [ar.room.name for ar in self._active_rooms.values()]
         log.info(

--- a/smart_vent/backend/tests/integration/test_idle_vents_closed_on_restore.py
+++ b/smart_vent/backend/tests/integration/test_idle_vents_closed_on_restore.py
@@ -1,0 +1,131 @@
+"""
+Regression test: idle-room vents must be re-closed after a container reboot
+that resumes a running cycle via ``restore_from_db``.
+
+Scenario (the original bug report):
+  - Room A is active via schedule; Room B is idle on the same thermostat zone.
+  - A cycle starts → Room B's vent is closed by ``_start_or_update_cycle``.
+  - The container reboots mid-cycle.  The open cycle log is in DB, but
+    something external (an HA automation, a manual override, or HA itself
+    reloading with defaults) has re-opened Room B's vent.
+  - On startup, the scheduler creates a fresh ``CycleEngine`` and calls
+    ``restore_from_db``.  Before the fix, restore only rebuilt in-memory
+    state and left idle vents open until the cycle naturally ended.  After
+    the fix, restore re-asserts idle-vent closure so the restored cycle
+    behaves identically to the pre-restart one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend.engine.cycle_engine import CycleEngine, CycleState
+
+
+@pytest.mark.asyncio
+async def test_restore_closes_idle_room_vents(client, fake_ha, tick) -> None:
+    thermostat = "climate.test_thermostat"
+    sensor_a = "sensor.room_a_temp"
+    vent_a = "cover.room_a_vent"
+    sensor_b = "sensor.room_b_temp"
+    vent_b = "cover.room_b_vent"
+
+    # Cooling scenario: ambient warm, both rooms start with vents open
+    # (the state _terminate_cycle leaves the zone in between cycles).
+    fake_ha.seed_state(
+        thermostat,
+        "cool",
+        {"current_temperature": 76.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(sensor_a, "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(vent_a, "open", {})
+    fake_ha.seed_state(sensor_b, "73.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(vent_b, "open", {})
+
+    # Room A: has a schedule active now → will drive the cycle.
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room A", "thermostat_entity_id": thermostat},
+    )
+    room_a_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_a_id}/sensors", json={"entity_id": sensor_a})
+    await client.post(
+        f"/api/rooms/{room_a_id}/vents",
+        json={"entity_id": vent_a, "control_method": "open_close"},
+    )
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_a_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+
+    # Room B: idle on the same zone (no schedule, no presence).
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room B", "thermostat_entity_id": thermostat},
+    )
+    room_b_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_b_id}/sensors", json={"entity_id": sensor_b})
+    await client.post(
+        f"/api/rooms/{room_b_id}/vents",
+        json={"entity_id": vent_b, "control_method": "open_close"},
+    )
+
+    # Start a cycle.  The existing fresh-start sweep closes vent B.
+    await tick()
+    assert fake_ha.get_state(vent_b)["state"] == "closed", (
+        "precondition: fresh-start sweep should have closed idle room B's vent"
+    )
+
+    # Sanity: exactly one open cycle log in DB.
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1
+    assert logs[0]["ended_at"] is None
+
+    # ------------------------------------------------------------------
+    # Simulate a container reboot mid-cycle.
+    #
+    # In real life the whole process dies, then a new one starts.  The DB
+    # still has the open cycle log; HA state may have drifted.  For the
+    # regression we reproduce the exact failure condition: vent B is open
+    # again at the moment ``restore_from_db`` runs.
+    # ------------------------------------------------------------------
+    await fake_ha.set_entity_state(vent_b, "open", {})
+    fake_ha.reset_calls()
+
+    scheduler = client.app["scheduler"]
+    new_engine = CycleEngine(
+        thermostat_entity_id=thermostat,
+        ha=fake_ha,
+        vent_ctrl=scheduler._vent_ctrl,
+        broadcast=None,
+        event_logger=scheduler._event_logger,
+        get_enabled=lambda: True,
+    )
+    await new_engine.restore_from_db(scheduler._db_conn)
+
+    # Engine should be RUNNING (cycle was restored, not discarded).
+    assert new_engine.cycle_state == CycleState.RUNNING, (
+        f"restored cycle should be RUNNING; state={new_engine.cycle_state}"
+    )
+
+    # The key assertion: vent B must have been closed as part of restore.
+    close_calls = fake_ha.calls_for("close_cover")
+    closed_entities = {c.data["entity_id"] for c in close_calls}
+    assert vent_b in closed_entities, (
+        f"restore_from_db must close idle room B's vent; "
+        f"close calls: {close_calls}, all calls: {fake_ha.calls}"
+    )
+    assert vent_a not in closed_entities, "active room A vent must not be closed on restore"
+    assert fake_ha.get_state(vent_b)["state"] == "closed", (
+        "vent B state should reflect the close_cover call"
+    )


### PR DESCRIPTION
When the container reboots mid-cycle, restore_from_db rebuilt in-memory cycle state from DB but never re-ran the idle-room vent-closing sweep. HA or external automations can re-open those vents during the outage, so the restored cycle resumed with idle rooms leaking airflow until it naturally ended.

Extracted the fresh-start idle-sweep out of _start_or_update_cycle into _close_idle_room_vents(conn, tc) and call it from restore_from_db after the state transitions to RUNNING. Behavior on fresh cycle starts is unchanged; restored cycles now enforce the same zone-vent invariant.

https://claude.ai/code/session_01GnVLWTykZ2BYGhuBtvExAM