### PR TITLE
Fix cycle not terminating when schedule-triggered rooms drift past target after vent close

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -827,7 +827,7 @@ class CycleEngine:
                         )
                 else:
                     all_at_target = False  # deferred
-            elif not at_target:
+            elif not at_target and rcs.vent_closed_at is None:
                 all_at_target = False
 
         if all_at_target and self._active_rooms:


### PR DESCRIPTION
Post-closure temperature drift (expected when a vent stops delivering conditioned air)
was incorrectly blocking cycle termination. The `elif not at_target` branch set
`all_at_target = False` for rooms whose vents were already closed, preventing
`_terminate_cycle` from ever being called during an active schedule block.

Guard the condition on `vent_closed_at is None` so only rooms still waiting for their
vent to close can block termination. Rooms already served are ignored regardless of drift.

Fixes #86
https://claude.ai/code/session_01LFJYZQYEB527Gs73aWaMr5