### PR TITLE
docs: fix HAOS data directory path and Docker volume warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ docker run -d \
   ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
 ```
 
+> **Important:** the `-v /path/to/data:/data` volume mount is required. Without it, `app.db` is written inside the ephemeral container layer and **all configuration is lost when the container restarts**.
+
 Open `http://localhost:8099` in your browser.
 
 ### Option C — Local development
@@ -223,8 +225,8 @@ All configuration lives in a single SQLite file (`app.db` in the `DATA_DIR`). To
 
 1. Stop the add-on
 2. Copy your local `app.db` (default: `/tmp/flair-dev/app.db`) to the add-on data directory:
-   - **HA OS / Supervised**: accessible via SSH at `/addon_data/<slug>/data/app.db`, or via the Samba share under `addon_configs`
-   - **Docker**: wherever you mounted `/data`
+   - **HA OS / Supervised**: the real host path is `/mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/app.db`. Find your exact path via SSH with `docker inspect $(docker ps -q --filter name=flair) --format '{{ json .Mounts }}'` and look for the mount whose `Destination` is `/data`. Note: `/root/addon_configs` (the Samba share) is for add-on *configuration* files, not this data directory.
+   - **Docker**: wherever you mounted `/data` with `-v`
 3. Start the add-on — it will apply any pending migrations automatically
 
 **Upgrading from ≤0.6.x:** the on-disk database was previously named `flair.db`. The add-on renames it to `app.db` automatically on first boot after upgrade — no manual steps required.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -16,6 +16,36 @@ The **Settings** page also has a **Restore** button that accepts an `app.db` fil
 2. The current DB is swapped for the uploaded one.
 3. The database connection is reloaded in place — the scheduler keeps running, so you don't need to restart the add-on.
 
+## Finding the data directory
+
+The database location depends on how Plenum is installed.
+
+**HA OS / Supervised**
+
+The on-disk path is not `/addon_configs` (that Samba share holds add-on *configuration* files). The data lives under the Supervisor's data tree. To find the exact path, run from the HAOS SSH terminal:
+
+```bash
+docker inspect $(docker ps -q --filter name=flair) --format '{{ json .Mounts }}' | python3 -m json.tool
+```
+
+Look for the entry where `"Destination": "/data"` — the `"Source"` field is the host path, typically:
+
+```
+/mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/
+```
+
+Confirm the database is there:
+
+```bash
+ls -lh /mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/
+```
+
+**Docker**
+
+The database is at whatever host path you bound to `/data` with `-v /path/to/data:/data`. If you did not specify a `-v` mount, the file exists only inside the ephemeral container layer and is lost on restart.
+
+---
+
 ## Upgrading from ≤0.6.x
 
 Older installs stored the database as `flair.db`. On first boot after upgrade, Plenum automatically renames `flair.db` → `app.db` (along with any `-wal` / `-shm` sidecars) before opening any connection. The rename is idempotent — re-running startup after migration is a no-op.


### PR DESCRIPTION
The documented path /addon_data/<slug>/data/ does not exist on HAOS.
The real host path is /mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/
and /root/addon_configs is the Samba share for config files, not data.

- README: correct HAOS data path, add docker inspect command to find it,
  clarify addon_configs is not the data dir, add warning that -v is
  required for Docker persistence
- docs/backup-restore.md: add "Finding the data directory" section with
  exact commands for both HAOS and Docker

https://claude.ai/code/session_015HZmbmN7iiSDy38GcnMJDP