### PR TITLE
feat: migrate data dir to addon_config for Samba visibility

### DIFF
--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -34,6 +34,7 @@ schema:
   ssl_verify: bool
   timezone: str
 environment:
-  DATA_DIR: /data
+  DATA_DIR: /addon_config
 map:
   - data
+  - addon_config:rw

--- a/smart_vent/run.sh
+++ b/smart_vent/run.sh
@@ -55,11 +55,29 @@ fi
 export HA_USE_WSS="${USE_WSS}"
 export HA_SSL_VERIFY="${SSL_VERIFY}"
 export TZ="${TIMEZONE:-UTC}"
-export DATA_DIR="${DATA_DIR:-/data}"
+export DATA_DIR="${DATA_DIR:-/addon_config}"
 export PORT="${PORT:-8099}"
 
 bashio::log.info "HA_URL=${HA_URL} USE_WSS=${HA_USE_WSS} SSL_VERIFY=${HA_SSL_VERIFY} TZ=${TZ}"
 
 mkdir -p "${DATA_DIR}"
+
+# ---------------------------------------------------------------------------
+# One-time migration: copy database from legacy /data to /addon_config so it
+# becomes accessible via the Samba addon_configs share.  Only runs when the
+# new location has no database yet.  options.json stays in /data — that is
+# written by the Supervisor and is not ours to move.
+# ---------------------------------------------------------------------------
+if [ ! -f "${DATA_DIR}/app.db" ] && [ ! -f "${DATA_DIR}/flair.db" ]; then
+    for _src in flair.db app.db; do
+        if [ -f "/data/${_src}" ]; then
+            bashio::log.info "Migrating ${_src} from /data to ${DATA_DIR}"
+            cp "/data/${_src}" "${DATA_DIR}/${_src}"
+            [ -f "/data/${_src}-wal" ] && cp "/data/${_src}-wal" "${DATA_DIR}/${_src}-wal"
+            [ -f "/data/${_src}-shm" ] && cp "/data/${_src}-shm" "${DATA_DIR}/${_src}-shm"
+            break
+        fi
+    done
+fi
 
 exec python3 -m backend.main


### PR DESCRIPTION
## Summary

- Switches `DATA_DIR` from `/data` to `/addon_config` so the database is visible in the Samba `addon_configs` share at `\\<haos-ip>\addon_configs\<slug>\app.db`
- Keeps `map: - data` so the Supervisor can still write `options.json` to `/data`
- Adds `map: - addon_config:rw` — the same pattern used by Node-RED and Zigbee2MQTT
- Adds a one-time startup migration in `run.sh` that copies `flair.db` or `app.db` (plus WAL/SHM sidecars) from `/data` to `/addon_config` on first boot if the new location is empty

## Test plan

- [ ] Fresh HAOS install — confirm `app.db` appears at `\\<haos-ip>\addon_configs\<slug>\` after first start
- [ ] Existing HAOS install with `flair.db` in `/data` — confirm migration log line appears and `flair.db` is copied to `/addon_config`, then renamed to `app.db` by the normal v0.7 migration
- [ ] Existing HAOS install with `app.db` in `/data` — confirm `app.db` is copied to `/addon_config` and all data is intact
- [ ] Docker install — confirm `DATA_DIR` env override still works (`-e DATA_DIR=/data` with `-v /path/to/data:/data`)
- [ ] Confirm `options.json` is still read correctly from `/data` after the change

## Related

Closes #92

https://claude.ai/code/session_015HZmbmN7iiSDy38GcnMJDP

---
_Generated by [Claude Code](https://claude.ai/code/session_015HZmbmN7iiSDy38GcnMJDP)_