### PR TITLE
Rename add-on from flair-replacement to plenum

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -251,7 +251,7 @@ Exposes all room/schedule/thermostat management as MCP tools for Claude.
 ```json
 {
   "mcpServers": {
-    "flair-replacement": {
+    "plenum": {
       "command": "python",
       "args": ["/path/to/addon/backend/mcp_server.py"],
       "env": {

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ All configuration lives in a single SQLite file (`app.db` in the `DATA_DIR`). To
 
 1. Stop the add-on
 2. Copy your local `app.db` (default: `/tmp/flair-dev/app.db`) to the add-on data directory:
-   - **HA OS / Supervised**: the real host path is `/mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/app.db`. Find your exact path via SSH with `docker inspect $(docker ps -q --filter name=flair) --format '{{ json .Mounts }}'` and look for the mount whose `Destination` is `/data`. Note: `/root/addon_configs` (the Samba share) is for add-on *configuration* files, not this data directory.
+   - **HA OS / Supervised**: the real host path is `/mnt/data/supervisor/addons/data/<repo_id>_plenum/app.db`. Find your exact path via SSH with `docker inspect $(docker ps -q --filter name=plenum) --format '{{ json .Mounts }}'` and look for the mount whose `Destination` is `/data`. Note: `/root/addon_configs` (the Samba share) is for add-on *configuration* files, not this data directory.
    - **Docker**: wherever you mounted `/data` with `-v`
 3. Start the add-on — it will apply any pending migrations automatically
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -25,19 +25,19 @@ The database location depends on how Plenum is installed.
 The on-disk path is not `/addon_configs` (that Samba share holds add-on *configuration* files). The data lives under the Supervisor's data tree. To find the exact path, run from the HAOS SSH terminal:
 
 ```bash
-docker inspect $(docker ps -q --filter name=flair) --format '{{ json .Mounts }}' | python3 -m json.tool
+docker inspect $(docker ps -q --filter name=plenum) --format '{{ json .Mounts }}' | python3 -m json.tool
 ```
 
 Look for the entry where `"Destination": "/data"` — the `"Source"` field is the host path, typically:
 
 ```
-/mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/
+/mnt/data/supervisor/addons/data/<repo_id>_plenum/
 ```
 
 Confirm the database is there:
 
 ```bash
-ls -lh /mnt/data/supervisor/addons/data/<repo_id>_flair_replacement/
+ls -lh /mnt/data/supervisor/addons/data/<repo_id>_plenum/
 ```
 
 **Docker**

--- a/smart_vent/backend/mcp_server.py
+++ b/smart_vent/backend/mcp_server.py
@@ -7,7 +7,7 @@ Each tool is a thin wrapper over the shared db layer.
 Usage (Claude Code mcp config):
   {
     "mcpServers": {
-      "flair-replacement": {
+      "plenum": {
         "command": "python",
         "args": ["-m", "backend.mcp_server"],
         "env": {
@@ -38,7 +38,7 @@ DB_PATH = os.path.join(DATA_DIR, "app.db")
 
 
 async def main() -> None:
-    server = Server("flair-replacement")
+    server = Server("plenum")
 
     os.makedirs(DATA_DIR, exist_ok=True)
     _migrate_db_filename(DATA_DIR)

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -1,7 +1,7 @@
 name: "Plenum"
 description: "HVAC zoning controller — drives HA cover entities and climate thermostats for per-room comfort"
 version: "0.8.0"
-slug: "flair_replacement"
+slug: "plenum"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"
 arch:
   - aarch64


### PR DESCRIPTION
## Summary
This PR updates all references to the add-on name from "flair-replacement" to "plenum" across documentation, configuration, and code files.

## Key Changes
- Updated `config.yaml` slug from `flair_replacement` to `plenum`
- Updated MCP server configuration name from `flair-replacement` to `plenum` in `mcp_server.py`
- Updated all documentation references in `backup-restore.md`, `DESIGN.md`, and `README.md` to use the new `plenum` name
- Updated Docker container filter names and data directory paths to reference `plenum` instead of `flair_replacement`

## Notable Details
- All path references in documentation now correctly point to `/mnt/data/supervisor/addons/data/<repo_id>_plenum/` instead of the old `flair_replacement` paths
- Docker inspection commands updated to filter by `name=plenum` instead of `name=flair`
- MCP server initialization now uses the correct server name for Claude integration

https://claude.ai/code/session_01Qp7x7qcPnjXY5KK91utc38