### PR TITLE
Fix participation count calculation in room metrics query

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -1788,7 +1788,7 @@ async def compute_room_metrics(
         SELECT
             r.id AS room_id,
             r.name AS room_name,
-            COUNT(rcs.cycle_id) AS participation_count,
+            COUNT(CASE WHEN cl.id IS NOT NULL THEN rcs.cycle_id END) AS participation_count,
             CAST(ROUND(COALESCE(SUM(CASE WHEN cl.mode='heating'
                 THEN (julianday(COALESCE(rcs.vent_closed_at, cl.ended_at)) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0 END), 0)) AS INTEGER) AS heating_seconds,
             CAST(ROUND(COALESCE(SUM(CASE WHEN cl.mode='cooling'


### PR DESCRIPTION
## Summary
Fixed a bug in the `compute_room_metrics` function where the participation count was being calculated incorrectly when joining with the cycle_logs table.

## Key Changes
- Modified the `participation_count` calculation in the room metrics SQL query to only count cycle participations when a corresponding cycle_log entry exists
- Changed from `COUNT(rcs.cycle_id)` to `COUNT(CASE WHEN cl.id IS NOT NULL THEN rcs.cycle_id END)`

## Implementation Details
The previous implementation was counting all room_cycle_state records regardless of whether they had an associated cycle_log entry. This could lead to inflated participation counts when left joins were used. The fix ensures that only cycles with valid cycle_log records are counted toward a room's participation metrics, providing more accurate reporting of actual room participation in heating/cooling cycles.

https://claude.ai/code/session_01PwfrbZ4x5osqBeZDYUEcHq