### PR TITLE
ci: add automated dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     directory: /smart_vent
     schedule:
       interval: weekly
-      day: monday
-      time: "09:00"
+      day: wednesday
+      time: "16:00"
       timezone: America/New_York
     open-pull-requests-limit: 5
     commit-message:
@@ -24,8 +24,8 @@ updates:
     directory: /smart_vent/frontend
     schedule:
       interval: weekly
-      day: monday
-      time: "09:00"
+      day: wednesday
+      time: "16:00"
       timezone: America/New_York
     open-pull-requests-limit: 5
     commit-message:
@@ -42,8 +42,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
-      time: "09:00"
+      day: wednesday
+      time: "16:00"
       timezone: America/New_York
     commit-message:
       prefix: "chore(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  # Python backend — pyproject.toml
+  - package-ecosystem: pip
+    directory: /smart_vent
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - python
+    ignore:
+      # Major version bumps require manual review
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Frontend — package.json
+  - package-ecosystem: npm
+    directory: /smart_vent/frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - javascript
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies
+      - ci


### PR DESCRIPTION
Implemented issue #16 by adding .github/dependabot.yml to configure automated dependency updates for the Python backend (pip), React frontend (npm), and GitHub Actions. Major version updates are excluded to allow for manual review.

---
*PR created automatically by Jules for task [17125190184622776026](https://jules.google.com/task/17125190184622776026) started by @dhruvb14*