### PR TITLE
🛡️ Sentinel: Fix middleware RuntimeError and harden security headers

### DIFF
--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -54,10 +54,11 @@ def _migrate_db_filename(data_dir: str) -> None:
                 os.rename(old_side, os.path.join(data_dir, f"app.db{suffix}"))
 
 
-def _apply_security_headers(headers: Any) -> None:
+def _apply_security_headers(headers: Any, request: web.Request) -> None:
     """Apply standard defense-in-depth security headers to a response header dict."""
     headers["X-Content-Type-Options"] = "nosniff"
     headers["X-Frame-Options"] = "SAMEORIGIN"
+    headers["X-XSS-Protection"] = "1; mode=block"
     headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
     # CSP: Allow 'self' for everything. 'unsafe-inline' is needed for standard React/Vite
@@ -68,8 +69,16 @@ def _apply_security_headers(headers: Any) -> None:
         "script-src 'self' 'unsafe-inline'; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data:; "
-        "connect-src 'self';"
+        "connect-src 'self'; "
+        "frame-ancestors 'self';"
     )
+
+    # HSTS: Only if request is secure (SSL/TLS)
+    if request.secure:
+        headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+
+    # Suppress Server header
+    headers["Server"] = ""
 
 
 @web.middleware
@@ -79,7 +88,9 @@ async def security_headers_middleware(request: web.Request, handler: Any) -> web
         response = await handler(request)
     except web.HTTPException as ex:
         # Re-apply headers even to error responses (404, 403, etc.)
-        _apply_security_headers(ex.headers)
+        # Check prepared to avoid RuntimeError on some aiohttp versions/response types
+        if not ex.prepared:
+            _apply_security_headers(ex.headers, request)
         raise
     except Exception:
         # For unexpected errors that aren't HTTPErrors, aiohttp would return a
@@ -87,10 +98,12 @@ async def security_headers_middleware(request: web.Request, handler: Any) -> web
         # headers are still present by returning a custom 500 response.
         log.exception("Unhandled exception in request handler")
         error_resp = web.Response(status=500, text="Internal Server Error")
-        _apply_security_headers(error_resp.headers)
+        _apply_security_headers(error_resp.headers, request)
         return error_resp
 
-    _apply_security_headers(response.headers)
+    # Don't modify headers if response is already prepared (e.g. WebSocket)
+    if not response.prepared:
+        _apply_security_headers(response.headers, request)
     return response
 
 

--- a/smart_vent/backend/tests/integration/test_security.py
+++ b/smart_vent/backend/tests/integration/test_security.py
@@ -19,6 +19,20 @@ async def test_security_headers_present(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_websocket_headers_no_runtime_error(client) -> None:
+    """Verify that connecting to WebSocket doesn't trigger a RuntimeError in middleware.
+
+    WebSockets are 'prepared' inside the handler, and modifying headers of a
+    prepared response normally raises RuntimeError.
+    """
+    async with client.ws_connect("/ws") as ws:
+        # If we get here, it means the handshake succeeded and no 500 was returned
+        # due to a RuntimeError in the middleware.
+        assert not ws.closed
+        await ws.close()
+
+
+@pytest.mark.asyncio
 async def test_security_headers_on_spa_route(client) -> None:
     """Verify security headers are also present on non-API routes (SPA)."""
     # Even if frontend_dist is None in tests, the route is still registered

--- a/smart_vent/backend/tests/integration/test_security.py
+++ b/smart_vent/backend/tests/integration/test_security.py
@@ -55,3 +55,14 @@ async def test_500_security_headers(client) -> None:
 
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"
     assert resp.headers.get("X-Frame-Options") == "SAMEORIGIN"
+
+
+@pytest.mark.asyncio
+async def test_hardened_headers_present(client) -> None:
+    """Verify the additional hardened headers added by Sentinel are present."""
+    resp = await client.get("/api/rooms")
+    assert resp.status == 200
+
+    assert resp.headers.get("X-XSS-Protection") == "1; mode=block"
+    assert resp.headers.get("Server") == ""
+    assert "frame-ancestors 'self'" in resp.headers.get("Content-Security-Policy", "")

--- a/smart_vent/backend/tests/test_main_coverage.py
+++ b/smart_vent/backend/tests/test_main_coverage.py
@@ -60,8 +60,12 @@ class TestMigrateDbFilename:
 
 class TestApplySecurityHeaders:
     def test_sets_expected_headers(self):
+        from unittest.mock import MagicMock
+
         headers: dict = {}
-        _apply_security_headers(headers)
+        request = MagicMock()
+        request.secure = False
+        _apply_security_headers(headers, request)
         assert "X-Content-Type-Options" in headers
         assert "X-Frame-Options" in headers
         assert "Content-Security-Policy" in headers

--- a/smart_vent/backend/tests/test_main_coverage.py
+++ b/smart_vent/backend/tests/test_main_coverage.py
@@ -72,6 +72,44 @@ class TestApplySecurityHeaders:
         assert "Referrer-Policy" in headers
         assert "Permissions-Policy" in headers
 
+    def test_xss_protection_and_server_suppression(self):
+        from unittest.mock import MagicMock
+
+        headers: dict = {}
+        request = MagicMock()
+        request.secure = False
+        _apply_security_headers(headers, request)
+        assert headers.get("X-XSS-Protection") == "1; mode=block"
+        assert headers.get("Server") == ""
+
+    def test_hsts_set_for_secure_requests(self):
+        from unittest.mock import MagicMock
+
+        headers: dict = {}
+        request = MagicMock()
+        request.secure = True
+        _apply_security_headers(headers, request)
+        hsts = headers.get("Strict-Transport-Security", "")
+        assert "max-age=31536000" in hsts
+
+    def test_hsts_not_set_for_insecure_requests(self):
+        from unittest.mock import MagicMock
+
+        headers: dict = {}
+        request = MagicMock()
+        request.secure = False
+        _apply_security_headers(headers, request)
+        assert "Strict-Transport-Security" not in headers
+
+    def test_frame_ancestors_in_csp(self):
+        from unittest.mock import MagicMock
+
+        headers: dict = {}
+        request = MagicMock()
+        request.secure = False
+        _apply_security_headers(headers, request)
+        assert "frame-ancestors 'self'" in headers.get("Content-Security-Policy", "")
+
 
 # ---------------------------------------------------------------------------
 # build_app — frontend_dist warning path


### PR DESCRIPTION
🛡️ Sentinel: Fix middleware RuntimeError and harden security headers

### Severity: HIGH (Potential DoS via middleware crash)

### Vulnerability
The `security_headers_middleware` in `smart_vent/backend/main.py` would attempt to modify headers of a response even if it was already "prepared" (sent to the client), which raises a `RuntimeError` in `aiohttp`. This is particularly problematic for WebSockets and streaming responses. Additionally, several standard security headers were missing or could be strengthened.

### Impact
- **Denial of Service**: Any request that prepares its response (like a WebSocket handshake) would trigger a 500 error because the middleware would crash while trying to set headers.
- **Information Leakage**: The `Server` header was being sent by default, exposing the underlying server technology.
- **Weak Defense-in-Depth**: Missing HSTS and XSS protection headers.

### Fix
- Updated `security_headers_middleware` to check `response.prepared` (and `ex.prepared` for HTTPExceptions) before modifying headers.
- Enhanced `_apply_security_headers` to:
  - Add `X-XSS-Protection: 1; mode=block`.
  - Add `frame-ancestors 'self'` to the `Content-Security-Policy`.
  - Apply `Strict-Transport-Security` when the request is secure.
  - Suppress the `Server` header.
- Added a regression test in `smart_vent/backend/tests/integration/test_security.py` to ensure WebSocket connections do not trigger the crash.

### Verification
- Ran `python3 -m pytest backend/tests/integration/test_security.py` - all passed.
- Ran the full integration test suite - all 67 tests passed.
- Verified code formatting and linting with `ruff`.

---
*PR created automatically by Jules for task [17437122252264725046](https://jules.google.com/task/17437122252264725046) started by @dhruvb14*