### PR TITLE
ci: release process maturity — versioning, healthz, smoke test, runbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  # GitHub Actions
+  # GitHub Actions — group all minor/patch bumps into one PR per week
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -45,8 +45,16 @@ updates:
       day: wednesday
       time: "16:00"
       timezone: America/New_York
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(ci)"
     labels:
       - dependencies
       - ci
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,19 +134,32 @@ jobs:
         working-directory: smart_vent
       - name: Run Container Smoke Test
         run: |
-          # Start container in detached mode
-          docker run -d --name smoke-test -e CI=true plenum:test
-          
-          # Wait for the container to finish (our run.sh exits after 10s in CI mode)
-          echo "Waiting for container to finish smoke test..."
-          timeout 30s docker wait smoke-test || (docker logs smoke-test && exit 1)
-          
-          # Check exit code
-          EXIT_CODE=$(docker inspect smoke-test --format='{{.State.ExitCode}}')
+          # Start container with port exposed. HA_URL/HA_TOKEN are dummies — the HTTP
+          # server binds before the HA client connects, so healthz is reachable even
+          # without a real HA instance.
+          docker run -d --name smoke-test \
+            -p 8099:8099 \
+            -e HA_URL=http://localhost:8123 \
+            -e HA_TOKEN=dummy \
+            plenum:test
+
+          # Poll /api/healthz until HTTP 200 or 30s timeout
+          echo "Waiting for /api/healthz to respond..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8099/api/healthz || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ /api/healthz returned 200 after ${i}s"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "❌ /api/healthz did not respond within 30s"
+              docker logs smoke-test
+              docker stop smoke-test
+              exit 1
+            fi
+            sleep 1
+          done
+
           docker logs smoke-test
-          
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "Container exited with non-zero code $EXIT_CODE"
-            exit 1
-          fi
+          docker stop smoke-test
           echo "Smoke test passed!"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -78,6 +78,11 @@ jobs:
             fi
 
             PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+
+            # Skip release-automation PRs — they are housekeeping, not user-facing changes
+            if echo "$PR_TITLE" | grep -qE '^Release v[0-9]'; then
+              continue
+            fi
             PR_URL=$(echo "$PR_JSON" | jq -r '.url')
             PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
 
@@ -156,12 +161,13 @@ jobs:
 
           mv /tmp/CHANGELOG_new.md smart_vent/CHANGELOG.md
 
-      - name: Bump version in config.yaml and pyproject.toml
+      - name: Bump version in config.yaml, pyproject.toml, and package.json
         env:
           VERSION: ${{ steps.versions.outputs.version }}
         run: |
           sed -i "s/^version: \".*\"/version: \"${VERSION}\"/" smart_vent/config.yaml
           sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" smart_vent/pyproject.toml
+          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" smart_vent/frontend/package.json
 
       - name: Create release branch, commit, and push
         env:
@@ -173,7 +179,7 @@ jobs:
 
           BRANCH="release/${TAG}"
           git checkout -b "$BRANCH"
-          git add smart_vent/CHANGELOG.md smart_vent/config.yaml smart_vent/pyproject.toml
+          git add smart_vent/CHANGELOG.md smart_vent/config.yaml smart_vent/pyproject.toml smart_vent/frontend/package.json
           git commit -m "chore: release ${TAG} — bump version and update changelog"
           git push origin "$BRANCH" --force
 
@@ -206,3 +212,15 @@ jobs:
             --body-file /tmp/pr_body.md \
             --head "$BRANCH" \
             --base main
+
+      - name: Populate GitHub Release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.versions.outputs.tag }}
+          VERSION: ${{ steps.versions.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release edit "${TAG}" \
+            --repo "$REPO" \
+            --title "Plenum ${TAG}" \
+            --notes-file /tmp/pr_body.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -156,11 +156,12 @@ jobs:
 
           mv /tmp/CHANGELOG_new.md smart_vent/CHANGELOG.md
 
-      - name: Bump version in config.yaml
+      - name: Bump version in config.yaml and pyproject.toml
         env:
           VERSION: ${{ steps.versions.outputs.version }}
         run: |
           sed -i "s/^version: \".*\"/version: \"${VERSION}\"/" smart_vent/config.yaml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" smart_vent/pyproject.toml
 
       - name: Create release branch, commit, and push
         env:
@@ -172,7 +173,7 @@ jobs:
 
           BRANCH="release/${TAG}"
           git checkout -b "$BRANCH"
-          git add smart_vent/CHANGELOG.md smart_vent/config.yaml
+          git add smart_vent/CHANGELOG.md smart_vent/config.yaml smart_vent/pyproject.toml
           git commit -m "chore: release ${TAG} — bump version and update changelog"
           git push origin "$BRANCH" --force
 

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,109 @@
+name: Validate Release
+
+# Dry-run release validation — builds the Docker image, runs the full test
+# suite, and smoke-tests the container against /api/healthz.
+# Nothing is pushed. Run this before tagging to confirm a commit is releasable.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or commit SHA to validate (defaults to current branch)"
+        required: false
+        default: ""
+
+jobs:
+  validate:
+    name: Release Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: smart_vent/frontend/package-lock.json
+
+      - name: Install Python dependencies
+        run: pip install ".[dev]"
+        working-directory: smart_vent
+
+      - name: Python lint
+        run: |
+          ruff check backend/
+          ruff format --check backend/
+        working-directory: smart_vent
+
+      - name: Python tests
+        run: python -m pytest backend/tests/ -v
+        working-directory: smart_vent
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: smart_vent/frontend
+
+      - name: Frontend lint
+        run: |
+          npm run lint
+          npm run format:check
+        working-directory: smart_vent/frontend
+
+      - name: Frontend tests
+        run: npm run test:coverage
+        working-directory: smart_vent/frontend
+
+      - name: Build Docker image
+        run: docker build -t plenum:validate .
+        working-directory: smart_vent
+
+      - name: Container smoke test
+        run: |
+          docker run -d --name validate-smoke \
+            -p 8099:8099 \
+            -e HA_URL=http://localhost:8123 \
+            -e HA_TOKEN=dummy \
+            plenum:validate
+
+          echo "Polling /api/healthz..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8099/api/healthz || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ /api/healthz returned 200 after ${i}s"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "❌ /api/healthz did not respond within 30s"
+              docker logs validate-smoke
+              docker stop validate-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+
+          docker logs validate-smoke
+          docker stop validate-smoke
+
+      - name: Report versions
+        run: |
+          echo "## Release Validation Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Version |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| config.yaml | $(grep '^version:' smart_vent/config.yaml | sed 's/version:[[:space:]]*//' | tr -d '\"') |" >> $GITHUB_STEP_SUMMARY
+          echo "| pyproject.toml | $(grep '^version = ' smart_vent/pyproject.toml | sed 's/version = //' | tr -d '\"') |" >> $GITHUB_STEP_SUMMARY
+          echo "| package.json | $(node -p "require('./smart_vent/frontend/package.json').version") |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ All checks passed — this commit is releasable." >> $GITHUB_STEP_SUMMARY

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,87 @@
+# Plenum Release Runbook
+
+## Before you release
+
+Run the dry-run validation workflow to confirm the commit is releasable:
+
+1. Go to **Actions → Validate Release → Run workflow**
+2. Leave `ref` blank to validate the current branch, or enter a specific SHA
+3. All jobs must pass — lint, tests (backend + frontend), Docker build, and healthz smoke test
+4. The summary shows whether all three version files agree (`config.yaml`, `pyproject.toml`, `package.json`)
+
+Only proceed once the validation workflow is green.
+
+## Cutting a release
+
+```bash
+# 1. Make sure your local main is up to date
+git checkout main && git pull origin main
+
+# 2. Tag the release — semver, no skipping patch versions
+git tag v0.X.Y
+
+# 3. Push the tag — this triggers the release-pr.yml workflow
+git push origin v0.X.Y
+```
+
+The workflow will:
+- Bump the version in `config.yaml`, `pyproject.toml`, and `frontend/package.json`
+- Prepend a section to `CHANGELOG.md` (filtered to real feature PRs, not housekeeping)
+- Open a Release PR titled "Release vX.Y.Z"
+- Populate the GitHub Release page with the same notes
+
+## Merging the release PR
+
+1. Confirm the `Build & Push release image` CI job passed (this is the required check)
+2. Confirm the Trivy scan shows no CRITICAL vulnerabilities
+3. Merge the PR — the Docker image was already pushed during the PR; no second build runs
+4. The GitHub Release is already published with the correct notes
+
+## Policy
+
+- **One release per day maximum** under normal circumstances
+- **All changes must come through a PR** — no direct pushes to `main`, even for hotfixes
+- **A patch release is fine** on short notice but still requires a PR and green CI
+- **Version numbers are semver**: bug fixes → patch, new features → minor, breaking changes → major
+
+## Hotfix procedure
+
+If something is broken in production:
+
+```bash
+# 1. Branch from main (NOT from a feature branch)
+git checkout main && git pull origin main
+git checkout -b fix/describe-the-problem
+
+# 2. Make the fix, write a test that reproduces the issue
+# 3. Open a PR against main — CI must pass
+# 4. Once merged, immediately cut a patch release:
+git checkout main && git pull origin main
+git tag v0.X.Y+1
+git push origin v0.X.Y+1
+```
+
+Never push directly to `main`, even under pressure. It bypasses CI and creates the exact reactive cycle we've had before.
+
+## If the Docker build fails during a release PR
+
+1. **Do not merge the release PR** — the broken image has already been pushed to GHCR
+2. Fix the issue in a new feature PR against `main`
+3. After the fix merges, delete the failed release tag and create a new one:
+   ```bash
+   git push origin :v0.X.Y          # delete remote tag
+   git tag -d v0.X.Y                # delete local tag
+   git tag v0.X.Y+1                 # new patch version for the fix
+   git push origin v0.X.Y+1
+   ```
+4. The old broken image tag will remain in GHCR but `latest` will not point to it once the new release pushes
+
+## What triggers what
+
+| Action | Workflow | Result |
+|--------|----------|--------|
+| Push `v*.*.*` tag | `release-pr.yml` | Creates release branch, opens PR, populates GitHub Release notes |
+| Open PR → main (non-release) | `docker.yml` → `build-pr` | Docker build only, no push |
+| Open release PR | `docker.yml` → `build-release` | Docker build + push `:version` and `:latest` |
+| `workflow_dispatch` | `validate-release.yml` | Full dry-run validation, nothing pushed |
+| Any PR or push to main | `lint.yml` | Lint, tests, security scan, Docker smoke test |

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -101,6 +101,18 @@ def _from_f(value: float | None, unit: str) -> float | str:
 
 
 # ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+@docs(tags=["system"], summary="Health check")
+@response_schema(schemas.SuccessSchema)
+@routes.get("/api/healthz")
+async def healthz(request: web.Request) -> web.Response:
+    return json_response({"ok": True})
+
+
+# ---------------------------------------------------------------------------
 # Rooms
 # ---------------------------------------------------------------------------
 

--- a/smart_vent/frontend/package.json
+++ b/smart_vent/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plenum-ui",
-  "version": "0.1.0",
+  "version": "0.9.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/smart_vent/pyproject.toml
+++ b/smart_vent/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=70"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "flair-replacement"
+name = "plenum"
 version = "0.1.0"
-description = "HVAC cycle manager — Flair vent replacement for Home Assistant"
+description = "HVAC cycle manager add-on for Home Assistant"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.9",

--- a/smart_vent/pyproject.toml
+++ b/smart_vent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plenum"
-version = "0.1.0"
+version = "0.9.12"
 description = "HVAC cycle manager add-on for Home Assistant"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Closes all actionable items from issue #141 (release process maturity). The work falls into four areas: version consistency across all three project files, release pipeline improvements, a stronger Docker smoke test, and governance/documentation.

### Version sync (all three files now stay in lockstep)
- Rename `pyproject.toml` package from `flair-replacement` → `plenum` — the wheel was building as `flair_replacement-*.whl` in CI
- Bump `pyproject.toml` version `0.1.0` → `0.9.12` to match `config.yaml`
- Bump `frontend/package.json` version `0.1.0` → `0.9.12`
- `release-pr.yml` now bumps all three files (`config.yaml`, `pyproject.toml`, `package.json`) on every release tag — no more drift

> Note: `flair.db` references in `main.py`, `run.sh`, and migration tests are intentional — they refer to actual filenames on users' disks from the previous version and must stay as-is.

### Release pipeline
- **Changelog contamination fixed** — release PR titles (`Release vX.Y.Z`) are now filtered out of the next release's changelog so housekeeping commits don't appear as features
- **GitHub Release notes** — `release-pr.yml` now runs `gh release edit` after opening the release PR, populating the GitHub Releases page with the same changelog content (previously the Releases tab had no notes)
- **New `validate-release.yml`** — `workflow_dispatch` dry-run workflow that runs lint, both test suites, Docker build, and the healthz smoke test without pushing anything; run this before tagging to confirm a commit is releasable

### Docker smoke test
- Added `GET /api/healthz → {"ok": true}` to `routes.py` with `@docs`/`@response_schema` decorators (passes the OpenAPI enforcement test)
- Smoke test in `lint.yml` now exposes port 8099, polls `/api/healthz` until HTTP 200 (up to 30s), and fails explicitly if no response — catches import errors and startup failures that the old 10-second wait missed

### Governance & documentation
- `dependabot.yml` — added `groups` block to batch all GitHub Actions minor/patch bumps into one weekly PR instead of one per action
- `RELEASE.md` — new runbook at repo root documenting the normal release flow, hotfix procedure, what to do if a Docker build fails mid-release, and the one-release-per-day policy

## What's not in this PR
- **Branch protection on `main`** — must be enabled manually in GitHub Settings → Branches (require PRs, require CI to pass, disallow direct push)
- **Pinning Docker base image to a digest** — deferred post-launch; requires pulling the image to get the current digest

## Test plan
- [ ] `ruff check` and `ruff format --check` pass on `backend/`
- [ ] `pytest` passes with ≥90% coverage
- [ ] Frontend lint, format, and test:coverage pass
- [ ] OpenAPI enforcement test (`test_api_spec_enforcement.py`) passes — confirms `GET /api/healthz` has correct decorators
- [ ] Docker build succeeds and smoke test reaches HTTP 200 on `/api/healthz`
