### PR TITLE
Move system/dev toggles and API docs to settings gear dropdown with confirmation dialogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Plenum — Developer Notes for Claude
 
+## Workflow conventions
+
+- **After every push to a PR**: always update the PR body with a description of what changed, why, and a test plan. Do this every time without being asked.
+
 ## What this repo is
 
 A Home Assistant add-on that replaces the Flair cloud app. It controls HA `cover` entities (vents) while reading temperature from HA `sensor` entities and commanding HA `climate` entities (thermostats). The UI is a React SPA served via HA ingress.

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.1.0",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.1.0",
+      "version": "0.9.13",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -35,7 +35,7 @@ describe("App Root", () => {
     expect(await screen.findByText(/Rooms/i, { selector: ".page-title" })).toBeInTheDocument();
   });
 
-  it("toggles system status", async () => {
+  it("toggles system status via dropdown and confirmation", async () => {
     vi.mocked(api.setSystemEnabled).mockResolvedValue({ enabled: false });
     render(
       <MemoryRouter>
@@ -43,16 +43,44 @@ describe("App Root", () => {
       </MemoryRouter>
     );
 
-    const toggleBtn = await screen.findByText(/System On/i);
-    fireEvent.click(toggleBtn);
+    // Open settings dropdown
+    const gearBtn = await screen.findByLabelText(/Settings/i);
+    fireEvent.click(gearBtn);
+
+    // Click the system item in the dropdown
+    const systemItem = await screen.findByText(/System On/i);
+    fireEvent.click(systemItem);
+
+    // Confirmation dialog appears
+    expect(await screen.findByText(/Turn off system\?/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
 
     await waitFor(() => {
       expect(api.setSystemEnabled).toHaveBeenCalledWith(false);
     });
+
+    // Re-open dropdown to confirm state updated
+    fireEvent.click(gearBtn);
     expect(await screen.findByText(/System Off/i)).toBeInTheDocument();
   });
 
-  it("toggles dev mode", async () => {
+  it("cancels system toggle when cancel is clicked", async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const gearBtn = await screen.findByLabelText(/Settings/i);
+    fireEvent.click(gearBtn);
+    fireEvent.click(await screen.findByText(/System On/i));
+    expect(await screen.findByText(/Turn off system\?/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+
+    expect(api.setSystemEnabled).not.toHaveBeenCalled();
+  });
+
+  it("toggles dev mode via dropdown and confirmation", async () => {
     vi.mocked(api.setDevModeApi).mockResolvedValue({ dev_mode: true });
     render(
       <MemoryRouter>
@@ -60,12 +88,40 @@ describe("App Root", () => {
       </MemoryRouter>
     );
 
-    const devBtn = await screen.findByText(/Dev Off/i);
-    fireEvent.click(devBtn);
+    // Open settings dropdown
+    const gearBtn = await screen.findByLabelText(/Settings/i);
+    fireEvent.click(gearBtn);
+
+    // Click the dev mode item in the dropdown
+    const devItem = await screen.findByText(/Dev Off/i);
+    fireEvent.click(devItem);
+
+    // Confirmation dialog appears
+    expect(await screen.findByText(/Developer Mode/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
 
     await waitFor(() => {
       expect(api.setDevModeApi).toHaveBeenCalledWith(true);
     });
+
+    // Re-open dropdown to confirm state updated
+    fireEvent.click(gearBtn);
     expect(await screen.findByText(/Dev On/i)).toBeInTheDocument();
+  });
+
+  it("cancels dev mode toggle when cancel is clicked", async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const gearBtn = await screen.findByLabelText(/Settings/i);
+    fireEvent.click(gearBtn);
+    fireEvent.click(await screen.findByText(/Dev Off/i));
+    expect(await screen.findByText(/Developer Mode/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+
+    expect(api.setDevModeApi).not.toHaveBeenCalled();
   });
 });

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useState } from "react";
+import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { Route, Routes, NavLink } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Rooms from "./pages/Rooms";
@@ -91,53 +91,129 @@ function AppRoot({ children }: { children: React.ReactNode }) {
 }
 
 // ---------------------------------------------------------------------------
-// Nav + SystemToggle
+// Nav + SettingsDropdown
 // ---------------------------------------------------------------------------
 
-function SystemToggle() {
+type ConfirmKind = "system" | "devmode";
+
+function SettingsDropdown() {
   const { enabled, toggle } = useSystem();
-  return (
-    <button
-      className={`system-toggle ${enabled ? "enabled" : "disabled"}`}
-      onClick={toggle}
-      title={enabled ? "System enabled — click to disable" : "System disabled — click to enable"}
-    >
-      <span className="system-toggle-dot" />
-      {enabled ? "System On" : "System Off"}
-    </button>
-  );
-}
-
-function DevModeToggle() {
   const { devMode, toggleDevMode } = useDevMode();
-  return (
-    <button
-      className={`dev-mode-toggle ${devMode ? "active" : ""}`}
-      onClick={toggleDevMode}
-      title={
-        devMode
-          ? "Developer mode ON — engine runs but no HA changes. Click to disable."
-          : "Click to enable developer mode"
-      }
-    >
-      🛠 {devMode ? "Dev On" : "Dev Off"}
-    </button>
-  );
-}
+  const [open, setOpen] = useState(false);
+  const [confirm, setConfirm] = useState<ConfirmKind | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
-function DocsButton() {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const handleSystemClick = () => {
+    setOpen(false);
+    setConfirm("system");
+  };
+
+  const handleDevModeClick = () => {
+    setOpen(false);
+    setConfirm("devmode");
+  };
+
+  const handleConfirm = () => {
+    if (confirm === "system") toggle();
+    else if (confirm === "devmode") toggleDevMode();
+    setConfirm(null);
+  };
+
+  const handleCancel = () => setConfirm(null);
+
   return (
-    <a
-      href="api/docs/"
-      className="docs-button"
-      title="Open API Documentation (Swagger UI)"
-      onClick={(e) => {
-        e.preventDefault();
-        window.location.href = "api/docs/";
-      }}
-    >
-      📖 API Docs
-    </a>
+    <div className="settings-dropdown" ref={ref}>
+      <button className="settings-gear-btn" onClick={() => setOpen((o) => !o)} aria-label="Settings">
+        ⚙️
+      </button>
+
+      {open && (
+        <div className="settings-menu">
+          <button className="settings-menu-item" onClick={handleSystemClick}>
+            <span
+              className="system-toggle-dot"
+              style={{ background: enabled ? "var(--green)" : "var(--red)" }}
+            />
+            {enabled ? "System On" : "System Off"}
+          </button>
+          <button className="settings-menu-item" onClick={handleDevModeClick}>
+            🛠 {devMode ? "Dev On" : "Dev Off"}
+          </button>
+          <a
+            className="settings-menu-item"
+            href="api/docs/"
+            onClick={(e) => {
+              e.preventDefault();
+              setOpen(false);
+              window.location.href = "api/docs/";
+            }}
+          >
+            📖 API Docs
+          </a>
+        </div>
+      )}
+
+      {confirm === "system" && (
+        <div
+          className="modal-backdrop"
+          onClick={(e) => e.target === e.currentTarget && handleCancel()}
+        >
+          <div className="modal">
+            <div className="modal-title">
+              {enabled ? "Turn off system?" : "Turn on system?"}
+            </div>
+            <p>
+              {enabled
+                ? "When system is disabled, all active cycles are terminated and all vents open."
+                : "When system is enabled, control will resume and cycles will restart based on current settings."}
+            </p>
+            <div className="modal-footer">
+              <button className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button className="btn btn-primary" onClick={handleConfirm}>
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirm === "devmode" && (
+        <div
+          className="modal-backdrop"
+          onClick={(e) => e.target === e.currentTarget && handleCancel()}
+        >
+          <div className="modal">
+            <div className="modal-title">Developer Mode</div>
+            <p>
+              {devMode
+                ? "When disabled, the system will resume normal operation and control thermostats and vents directly."
+                : "When enabled, the system runs but logs all actions instead of actually controlling thermostats and vents. No Home Assistant changes will be made. This is useful for testing and simulation."}
+            </p>
+            <div className="modal-footer">
+              <button className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button className="btn btn-primary" onClick={handleConfirm}>
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -193,9 +269,7 @@ function Nav() {
       </div>
 
       <div className="nav-right">
-        <DocsButton />
-        <DevModeToggle />
-        <SystemToggle />
+        <SettingsDropdown />
         {/* Hamburger — mobile only */}
         <button
           className="nav-hamburger"

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -134,7 +134,11 @@ function SettingsDropdown() {
 
   return (
     <div className="settings-dropdown" ref={ref}>
-      <button className="settings-gear-btn" onClick={() => setOpen((o) => !o)} aria-label="Settings">
+      <button
+        className="settings-gear-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Settings"
+      >
         ⚙️
       </button>
 
@@ -170,9 +174,7 @@ function SettingsDropdown() {
           onClick={(e) => e.target === e.currentTarget && handleCancel()}
         >
           <div className="modal">
-            <div className="modal-title">
-              {enabled ? "Turn off system?" : "Turn on system?"}
-            </div>
+            <div className="modal-title">{enabled ? "Turn off system?" : "Turn on system?"}</div>
             <p>
               {enabled
                 ? "When system is disabled, all active cycles are terminated and all vents open."

--- a/smart_vent/frontend/src/styles.css
+++ b/smart_vent/frontend/src/styles.css
@@ -286,7 +286,9 @@
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
   padding: 0;
 }
 .settings-gear-btn:hover {
@@ -321,7 +323,9 @@
   font-weight: 500;
   cursor: pointer;
   text-decoration: none;
-  transition: background 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
   white-space: nowrap;
 }
 .settings-menu-item:hover {

--- a/smart_vent/frontend/src/styles.css
+++ b/smart_vent/frontend/src/styles.css
@@ -271,6 +271,64 @@
   color: #b45309 !important;
 }
 
+/* ── Settings gear dropdown ── */
+.settings-dropdown {
+  position: relative;
+}
+.settings-gear-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: none;
+  border: 1.5px solid var(--gray-200);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.15s, border-color 0.15s;
+  padding: 0;
+}
+.settings-gear-btn:hover {
+  background: var(--gray-100);
+  border-color: var(--gray-400);
+}
+.settings-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: #fff;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  min-width: 170px;
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  padding: 0.35rem;
+  gap: 0.15rem;
+}
+.settings-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 6px;
+  border: none;
+  background: none;
+  color: var(--gray-700);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+.settings-menu-item:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+}
+
 /* ── Dev mode page ── */
 .dev-layout {
   display: grid;


### PR DESCRIPTION
## Summary

- Replaces the three inline nav buttons (System Toggle, Dev Mode Toggle, API Docs) with a single ⚙️ gear icon dropdown in the nav bar
- Adds confirmation dialogs before any toggle action to prevent accidental activation, especially on mobile
- API Docs link in the dropdown opens directly without a confirmation step
- Adds a workflow convention to `CLAUDE.md`: update PR description after every push

## Changes

**`App.tsx`**
- Removed `SystemToggle`, `DevModeToggle`, and `DocsButton` inline components
- Added `SettingsDropdown` component with a gear button, a positioned dropdown menu, and modal confirmation dialogs for both toggles
- Click-outside handler closes the dropdown automatically

**`styles.css`**
- Added `.settings-gear-btn`, `.settings-dropdown`, `.settings-menu`, and `.settings-menu-item` styles
- Dropdown uses `z-index: 150` to sit above the sticky nav

**`App.test.tsx`**
- Updated existing toggle tests to go through the new dropdown → confirmation → confirm flow
- Added cancel tests for both system and dev mode toggles

**`CLAUDE.md`**
- Added workflow convention: always update the PR body after every push

## Test plan

- [x] All 120 frontend tests pass (`npx vitest run`)
- [x] ESLint and Prettier checks pass
- [ ] Dropdown appears/disappears on gear icon click
- [ ] Clicking outside the dropdown closes it
- [ ] System toggle confirmation shows correct message for on→off and off→on
- [ ] Dev mode toggle confirmation shows correct message for enabling and disabling
- [ ] Cancel closes the dialog without changing state
- [ ] Confirm closes the dialog and applies the change
- [ ] API Docs link navigates correctly
- [ ] Behavior works on mobile viewport

Closes #149

https://claude.ai/code/session_01DW8JhG3PeUAHKMu3xc8AaL