### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   python-lint:
     name: Python (ruff)


### PR DESCRIPTION
Potential fix for [https://github.com/dhruvb14/smart-thermostat-with-vents/security/code-scanning/6](https://github.com/dhruvb14/smart-thermostat-with-vents/security/code-scanning/6)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/lint.yml` (after `on:` is typical) to set a secure baseline for all jobs. The minimal safe baseline for this lint/test workflow is:

- `contents: read`

This preserves existing behavior for checkout and read operations while preventing unnecessary write-capable token use. If any specific job later requires write access (for example, uploading PR comments or security findings), that job should define its own `permissions` block with only the required additional scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
