### PR TITLE
fix(#150): replace OutsideTempPanel dropdown with EntityPicker search

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "statusMessage": "Running lint + tests before commit…",
+            "timeout": 180,
+            "command": "npm --prefix /home/user/smart-thermostat-with-vents/smart_vent/frontend run lint && npm --prefix /home/user/smart-thermostat-with-vents/smart_vent/frontend run test:coverage && (cd /home/user/smart-thermostat-with-vents/smart_vent && ruff check backend/ && ruff format --check backend/)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/smart_vent/frontend/eslint.config.js
+++ b/smart_vent/frontend/eslint.config.js
@@ -21,5 +21,22 @@ export default tseslint.config(
       "no-console": ["warn", { allow: ["warn", "error"] }],
     },
   },
+  // Enforce EntityPicker usage: ban direct getHAEntities imports outside the component itself.
+  // Tests use `vi.mocked(api.getHAEntities)` via namespace import, so they are unaffected.
+  {
+    files: ["**/*.{ts,tsx}"],
+    ignores: ["**/EntityPicker.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ImportSpecifier[imported.name='getHAEntities']",
+          message:
+            "Use the EntityPicker component instead of calling getHAEntities directly. " +
+            "See src/components/EntityPicker.tsx.",
+        },
+      ],
+    },
+  },
   prettierConfig,
 );

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/smart_vent/frontend/src/components/EntityPicker.tsx
+++ b/smart_vent/frontend/src/components/EntityPicker.tsx
@@ -48,8 +48,7 @@ export default function EntityPicker({
       <input
         className="form-control"
         placeholder={
-          placeholder ??
-          `Search ${Array.isArray(domain) ? domain.join(" / ") : domain} entities…`
+          placeholder ?? `Search ${Array.isArray(domain) ? domain.join(" / ") : domain} entities…`
         }
         value={query}
         onChange={(e) => {

--- a/smart_vent/frontend/src/components/EntityPicker.tsx
+++ b/smart_vent/frontend/src/components/EntityPicker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { getHAEntities, type HAEntity } from "../api";
 
 interface Props {
-  domain: string;
+  domain: string | string[];
   placeholder?: string;
   hasAttribute?: string;
   excludeIcon?: string;
@@ -47,7 +47,10 @@ export default function EntityPicker({
     <div className="entity-picker" ref={ref}>
       <input
         className="form-control"
-        placeholder={placeholder ?? `Search ${domain} entities…`}
+        placeholder={
+          placeholder ??
+          `Search ${Array.isArray(domain) ? domain.join(" / ") : domain} entities…`
+        }
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -134,9 +134,12 @@ describe("Metrics Page", () => {
   it("handles outside temp entity change", async () => {
     render(<Metrics />);
 
-    // Find the select by its default option or label context
-    const select = await screen.findByDisplayValue(/Outside Temp/i);
-    fireEvent.change(select, { target: { value: "sensor.outside_temp" } });
+    const searchInput = await screen.findByPlaceholderText(/Search sensor \/ weather entities/i);
+    fireEvent.focus(searchInput);
+    fireEvent.change(searchInput, { target: { value: "outside" } });
+
+    const option = await screen.findByText("Outside Temp");
+    fireEvent.mouseDown(option);
 
     await waitFor(() => {
       expect(api.setOutsideTempEntity).toHaveBeenCalledWith("sensor.outside_temp");

--- a/smart_vent/frontend/src/pages/Metrics.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   downloadMetricsCsv,
-  getHAEntities,
   getMetricsHomeSummary,
   getMetricsThermostatSummary,
   getOutsideTempEntity,
   getThermostats,
   setOutsideTempEntity,
-  type HAEntity,
   type MetricsRange,
   type MetricsSummary,
   type ThermostatConfig,
 } from "../api";
+import EntityPicker from "../components/EntityPicker";
 import { ChartGrid } from "../components/charts/MetricsCharts";
 import { useUnit } from "../contexts";
 
@@ -50,7 +49,6 @@ function formatSeconds(s: number): string {
 
 function OutsideTempPanel({ onChange }: { onChange?: (entityId: string | null) => void }) {
   const { fmtTemp } = useUnit();
-  const [entities, setEntities] = useState<HAEntity[]>([]);
   const [current, setCurrent] = useState<{
     entity_id: string | null;
     current_value: number | null;
@@ -60,11 +58,7 @@ function OutsideTempPanel({ onChange }: { onChange?: (entityId: string | null) =
 
   const refresh = async () => {
     try {
-      const [list, cur] = await Promise.all([
-        getHAEntities(["sensor", "weather"]),
-        getOutsideTempEntity(),
-      ]);
-      setEntities(list);
+      const cur = await getOutsideTempEntity();
       setCurrent(cur);
       onChange?.(cur.entity_id);
     } catch (e) {
@@ -107,25 +101,31 @@ function OutsideTempPanel({ onChange }: { onChange?: (entityId: string | null) =
       )}
 
       <div style={{ display: "flex", gap: ".75rem", alignItems: "center", flexWrap: "wrap" }}>
-        <select
-          className="form-control"
-          style={{ flex: "1 1 320px", minWidth: 200 }}
-          value={current?.entity_id ?? ""}
-          onChange={(e) => onSelect(e.target.value || null)}
-          disabled={saving}
-        >
-          <option value="">— None (don't track outside temperature) —</option>
-          {entities.map((e) => (
-            <option key={e.entity_id} value={e.entity_id}>
-              {e.friendly_name} ({e.entity_id})
-            </option>
-          ))}
-        </select>
+        <div style={{ flex: "1 1 320px", minWidth: 200 }}>
+          <EntityPicker
+            domain={["sensor", "weather"]}
+            placeholder="Search sensor / weather entities…"
+            onSelect={(id) => void onSelect(id)}
+          />
+        </div>
 
-        {current?.entity_id && (
-          <span className="badge badge-blue">
-            Current value: {current.current_value !== null ? fmtTemp(current.current_value) : "n/a"}
-          </span>
+        {current?.entity_id ? (
+          <>
+            <span className="badge badge-blue">
+              {current.entity_id}
+              {current.current_value !== null && ` · ${fmtTemp(current.current_value)}`}
+            </span>
+            <button
+              className="btn btn-secondary"
+              onClick={() => void onSelect(null)}
+              disabled={saving}
+              type="button"
+            >
+              Clear
+            </button>
+          </>
+        ) : (
+          <span className="text-sm text-muted">— None (don&apos;t track outside temperature) —</span>
         )}
       </div>
     </div>

--- a/smart_vent/frontend/src/pages/Metrics.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.tsx
@@ -125,7 +125,9 @@ function OutsideTempPanel({ onChange }: { onChange?: (entityId: string | null) =
             </button>
           </>
         ) : (
-          <span className="text-sm text-muted">— None (don&apos;t track outside temperature) —</span>
+          <span className="text-sm text-muted">
+            — None (don&apos;t track outside temperature) —
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes #150. The "outside temperature source" selector on the Metrics page was a plain `<select>` that loaded every `sensor` and `weather` entity into a static list — unusable on real HA installations with hundreds of entities.

### Changes

- **`EntityPicker.tsx`** — widened the `domain` prop from `string` to `string | string[]` (`api.ts` already accepted this; the default placeholder now joins arrays with ` / ` for readability)
- **`Metrics.tsx`** — replaced the `<select>` in `OutsideTempPanel` with `EntityPicker` scoped to `["sensor", "weather"]`; the currently-selected entity is now shown as a badge with a **Clear** button; the redundant `getHAEntities` fetch inside the panel was removed (EntityPicker manages its own list internally)
- **`Metrics.test.tsx`** — updated the outside-temp test to interact with the EntityPicker search input + `mouseDown` instead of the old `<select>` `change` event
- **`eslint.config.js`** — added a `no-restricted-syntax` rule that **errors** if any file other than `EntityPicker.tsx` imports `getHAEntities` by name. This makes it a CI-enforced invariant that entity selection goes through `EntityPicker`, not a hand-rolled dropdown.
- **Prettier formatting** — fixed `format:check` failures in the two changed files (caught by CI)

### ESLint enforcement detail

```
error  Use the EntityPicker component instead of calling getHAEntities directly.
       See src/components/EntityPicker.tsx  no-restricted-syntax
```

Tests use `vi.mocked(api.getHAEntities)` via namespace import (`import * as api`) so they are unaffected. Only named imports of `getHAEntities` in non-`EntityPicker.tsx` files are blocked.

## Test plan

- [ ] All 120 frontend unit tests pass (`npm run test:coverage`) with all coverage thresholds met
- [ ] `npm run lint` passes — no false positives from the new rule
- [ ] `npm run format:check` passes
- [ ] Adding `import { getHAEntities } from "../api"` to any page/component triggers the ESLint error
- [ ] On a real HA instance with many sensor/weather entities, typing in the "Outside temperature source" input filters results client-side and caps the list at 30 — no more full-page dropdown
- [ ] Selecting an entity from the picker saves it and shows the entity ID + current value badge
- [ ] Clicking **Clear** removes the entity (sets to `null`) and the "— None —" hint reappears
- [ ] No regression: the `EntityPicker` in the Rooms page (single `string` domain) still works correctly

https://claude.ai/code/session_01XcbH12cGnFwFoczXMUcHqo