### PR TITLE
fix(#151): prevent chart grid overflow on mobile viewports

### DIFF
--- a/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
@@ -761,7 +761,7 @@ export function ChartGrid({
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(380px, 1fr))",
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(380px, 100%), 1fr))",
         gap: "1rem",
       }}
     >


### PR DESCRIPTION
## Summary

- Fixes graph charts on the Metrics page extending to the right edge of the screen on mobile devices
- Root cause: `minmax(380px, 1fr)` in the `ChartGrid` forced a 380 px minimum column width, wider than most phone screens (~320–430 px minus 1 rem padding on each side)
- Fix: replace `380px` with `min(380px, 100%)` so the column minimum caps at the container's available width on narrow viewports

## What changed

`smart_vent/frontend/src/components/charts/MetricsCharts.tsx` — one-line change in `ChartGrid`:

```diff
- gridTemplateColumns: "repeat(auto-fit, minmax(380px, 1fr))",
+ gridTemplateColumns: "repeat(auto-fit, minmax(min(380px, 100%), 1fr))",
```

On desktop the behaviour is identical (container is always wider than 380 px). On mobile the column shrinks to fit the container, matching the padding of every other page element.

## Test plan

- [ ] Run `npx vitest run` — all 120 frontend tests pass
- [ ] Open the Metrics page on a mobile device or browser DevTools mobile emulator (e.g. iPhone 12 Pro, 390 px wide)
- [ ] Verify all charts ("Cycles per day", "Average cycle duration", "Heating & cooling hours per day", etc.) stay within the page padding and do not extend to the right edge
- [ ] Verify the two-column chart layout still appears on desktop (≥ ~800 px wide)

https://claude.ai/code/session_01ETxxXJR5wacQS4PuDqua8H

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETxxXJR5wacQS4PuDqua8H)_