### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Input Validation Bounds

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-05 - [MEDIUM] Input Validation Bounds for Normalized Temperature Units
+**Vulnerability:** Missing input validation on temperature setpoints allowed extreme values (e.g., 150°F or 150°C) which could lead to illogical system states or physical safety concerns if passed through to hardware.
+**Learning:** In a multi-unit system where inputs are normalized internally (e.g., Celsius to Fahrenheit), validation bounds MUST be applied to the normalized internal value. Applying bounds to the raw input before conversion is insufficient if the units are not known or varied.
+**Prevention:** Always perform unit conversion to the internal standard (Fahrenheit) first, then apply strict range limits (40°F–90°F) before persisting or using the value in logic. Update existing tests that use "placeholder" extreme values to stay within the new safe boundaries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Workflow conventions
 
 - **After every push to a PR**: always update the PR body with a description of what changed, why, and a test plan. Do this every time without being asked.
+- **When reviewing a PR and pushing fixes**: push directly to the PR's own branch (not to a separate review branch), so the fixes appear in the PR diff.
 
 ## What this repo is
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -151,6 +151,8 @@ async def create_room(request: web.Request) -> web.Response:
         return error("presence_holdover_hours must be between 0 and 8760")
 
     if sys_temp is not None:
+        if not isinstance(sys_temp, (int, float)):
+            return error("system_wide_temp must be numeric")
         sys_temp_f = _to_f(sys_temp, unit)
         if not (40 <= sys_temp_f <= 90):
             return _temp_range_error("system_wide_temp", 40, 90, unit)
@@ -222,6 +224,8 @@ async def update_room(request: web.Request) -> web.Response:
     if "system_wide_temp" in body:
         val = body["system_wide_temp"]
         if val is not None:
+            if not isinstance(val, (int, float)):
+                return error("system_wide_temp must be numeric")
             val_f = _to_f(val, unit)
             if not (40 <= val_f <= 90):
                 return _temp_range_error("system_wide_temp", 40, 90, unit)
@@ -591,7 +595,10 @@ async def update_schedule(request: web.Request) -> web.Response:
     if "end_time" in body:
         schedule.end_time = time.fromisoformat(body["end_time"])
     if "target_temp" in body:
-        target_temp_f = _to_f(float(body["target_temp"]), unit)
+        try:
+            target_temp_f = _to_f(float(body["target_temp"]), unit)
+        except (ValueError, TypeError):
+            return error("target_temp must be numeric")
         if not (40 <= target_temp_f <= 90):
             return _temp_range_error("target_temp", 40, 90, unit)
         schedule.target_temp = target_temp_f
@@ -800,11 +807,17 @@ async def set_override(request: web.Request) -> web.Response:
 
     # Security: input validation
     unit = request.app["scheduler"].get_temperature_unit()
-    target_temp_f = _to_f(float(body["target_temp"]), unit)
+    try:
+        target_temp_f = _to_f(float(body["target_temp"]), unit)
+    except (ValueError, TypeError):
+        return error("target_temp must be numeric")
     if not (40 <= target_temp_f <= 90):
         return _temp_range_error("target_temp", 40, 90, unit)
 
-    duration_hours = float(body.get("duration_hours", 2.0))
+    try:
+        duration_hours = float(body.get("duration_hours", 2.0))
+    except (ValueError, TypeError):
+        return error("duration_hours must be numeric")
     if not (0 <= duration_hours <= 8760):
         return error("duration_hours must be between 0 and 8760")
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -101,6 +101,13 @@ def _from_f(value: float | None, unit: str) -> float | str:
     return round(float(value), 1)
 
 
+def _temp_range_error(field: str, low_f: float, high_f: float, unit: str) -> web.Response:
+    """Generate a unit-aware temperature range error response."""
+    low = _from_f(low_f, unit)
+    high = _from_f(high_f, unit)
+    return error(f"{field} must be between {low} and {high}°{unit}")
+
+
 # ---------------------------------------------------------------------------
 # Health
 # ---------------------------------------------------------------------------
@@ -146,7 +153,7 @@ async def create_room(request: web.Request) -> web.Response:
     if sys_temp is not None:
         sys_temp_f = _to_f(sys_temp, unit)
         if not (40 <= sys_temp_f <= 90):
-            return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
+            return _temp_range_error("system_wide_temp", 40, 90, unit)
 
     temp_offset_in = body.get("temp_offset", 0.0)
     if not isinstance(temp_offset_in, (int, float)):
@@ -217,7 +224,7 @@ async def update_room(request: web.Request) -> web.Response:
         if val is not None:
             val_f = _to_f(val, unit)
             if not (40 <= val_f <= 90):
-                return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
+                return _temp_range_error("system_wide_temp", 40, 90, unit)
     if "temp_offset" in body:
         val = body["temp_offset"]
         if not isinstance(val, (int, float)):
@@ -539,7 +546,7 @@ async def create_schedule(request: web.Request) -> web.Response:
     try:
         target_temp_f = _to_f(float(body["target_temp"]), unit)
         if not (40 <= target_temp_f <= 90):
-            return error("target_temp must be between 40 and 90°F (or equivalent)")
+            return _temp_range_error("target_temp", 40, 90, unit)
 
         s = Schedule.create(
             room_id=request.match_info["room_id"],
@@ -586,7 +593,7 @@ async def update_schedule(request: web.Request) -> web.Response:
     if "target_temp" in body:
         target_temp_f = _to_f(float(body["target_temp"]), unit)
         if not (40 <= target_temp_f <= 90):
-            return error("target_temp must be between 40 and 90°F (or equivalent)")
+            return _temp_range_error("target_temp", 40, 90, unit)
         schedule.target_temp = target_temp_f
     # Check for overlapping schedules (excluding self)
     for e in schedules:
@@ -653,14 +660,14 @@ async def create_thermostat(request: web.Request) -> web.Response:
     if default_temp is not None:
         default_temp_f = _to_f(default_temp, unit)
         if not (40 <= default_temp_f <= 90):
-            return error("default_temp must be between 40 and 90°F (or equivalent)")
+            return _temp_range_error("default_temp", 40, 90, unit)
 
     # Use existing (F) values as default if not in body
     min_f = _to_f(min_val, unit) if min_val is not None else tc.min_setpoint
     max_f = _to_f(max_val, unit) if max_val is not None else tc.max_setpoint
 
     if not (40 <= min_f <= 100) or not (40 <= max_f <= 100):
-        return error("Setpoints must be between 40 and 100°F (or equivalent)")
+        return _temp_range_error("Setpoints", 40, 100, unit)
     if min_f >= max_f:
         return error("min_setpoint must be less than max_setpoint")
     for field in (
@@ -719,14 +726,14 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
     if default_temp is not None:
         default_temp_f = _to_f(default_temp, unit)
         if not (40 <= default_temp_f <= 90):
-            return error("default_temp must be between 40 and 90°F (or equivalent)")
+            return _temp_range_error("default_temp", 40, 90, unit)
 
     # Use existing (F) values as default if not in body
     min_f = _to_f(min_val, unit) if min_val is not None else tc.min_setpoint
     max_f = _to_f(max_val, unit) if max_val is not None else tc.max_setpoint
 
     if not (40 <= min_f <= 100) or not (40 <= max_f <= 100):
-        return error("Setpoints must be between 40 and 100°F (or equivalent)")
+        return _temp_range_error("Setpoints", 40, 100, unit)
     if min_f >= max_f:
         return error("min_setpoint must be less than max_setpoint")
     for field in (
@@ -795,7 +802,7 @@ async def set_override(request: web.Request) -> web.Response:
     unit = request.app["scheduler"].get_temperature_unit()
     target_temp_f = _to_f(float(body["target_temp"]), unit)
     if not (40 <= target_temp_f <= 90):
-        return error("target_temp must be between 40 and 90°F (or equivalent)")
+        return _temp_range_error("target_temp", 40, 90, unit)
 
     duration_hours = float(body.get("duration_hours", 2.0))
     if not (0 <= duration_hours <= 8760):

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -140,8 +140,13 @@ async def create_room(request: web.Request) -> web.Response:
 
     # Security: input validation
     holdover = body.get("presence_holdover_hours", 2.0)
-    if not isinstance(holdover, (int, float)) or holdover < 0:
-        return error("presence_holdover_hours must be a non-negative number")
+    if not isinstance(holdover, (int, float)) or not (0 <= holdover <= 8760):
+        return error("presence_holdover_hours must be between 0 and 8760")
+
+    if sys_temp is not None:
+        sys_temp_f = _to_f(sys_temp, unit)
+        if not (40 <= sys_temp_f <= 90):
+            return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
 
     temp_offset_in = body.get("temp_offset", 0.0)
     if not isinstance(temp_offset_in, (int, float)):
@@ -205,8 +210,14 @@ async def update_room(request: web.Request) -> web.Response:
     # Security: input validation
     if "presence_holdover_hours" in body:
         val = body["presence_holdover_hours"]
-        if not isinstance(val, (int, float)) or val < 0:
-            return error("presence_holdover_hours must be a non-negative number")
+        if not isinstance(val, (int, float)) or not (0 <= val <= 8760):
+            return error("presence_holdover_hours must be between 0 and 8760")
+    if "system_wide_temp" in body:
+        val = body["system_wide_temp"]
+        if val is not None:
+            val_f = _to_f(val, unit)
+            if not (40 <= val_f <= 90):
+                return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
     if "temp_offset" in body:
         val = body["temp_offset"]
         if not isinstance(val, (int, float)):
@@ -526,12 +537,16 @@ async def create_schedule(request: web.Request) -> web.Response:
         return error(f"Required fields: {required}")
     unit = request.app["scheduler"].get_temperature_unit()
     try:
+        target_temp_f = _to_f(float(body["target_temp"]), unit)
+        if not (40 <= target_temp_f <= 90):
+            return error("target_temp must be between 40 and 90°F (or equivalent)")
+
         s = Schedule.create(
             room_id=request.match_info["room_id"],
             days_of_week=body["days_of_week"],
             start_time=time.fromisoformat(body["start_time"]),
             end_time=time.fromisoformat(body["end_time"]),
-            target_temp=_to_f(float(body["target_temp"]), unit),
+            target_temp=target_temp_f,
         )
     except (ValueError, TypeError):
         return error("Invalid schedule payload")
@@ -569,7 +584,10 @@ async def update_schedule(request: web.Request) -> web.Response:
     if "end_time" in body:
         schedule.end_time = time.fromisoformat(body["end_time"])
     if "target_temp" in body:
-        schedule.target_temp = _to_f(float(body["target_temp"]), unit)
+        target_temp_f = _to_f(float(body["target_temp"]), unit)
+        if not (40 <= target_temp_f <= 90):
+            return error("target_temp must be between 40 and 90°F (or equivalent)")
+        schedule.target_temp = target_temp_f
     # Check for overlapping schedules (excluding self)
     for e in schedules:
         if e.id == schedule.id:
@@ -624,10 +642,18 @@ async def create_thermostat(request: web.Request) -> web.Response:
     # Security: input validation
     min_val = body.get("min_setpoint")
     max_val = body.get("max_setpoint")
-    if (min_val is not None and not isinstance(min_val, (int, float))) or (
-        max_val is not None and not isinstance(max_val, (int, float))
+    default_temp = body.get("default_temp")
+    if (
+        (min_val is not None and not isinstance(min_val, (int, float)))
+        or (max_val is not None and not isinstance(max_val, (int, float)))
+        or (default_temp is not None and not isinstance(default_temp, (int, float)))
     ):
-        return error("Setpoints must be numeric")
+        return error("Temperatures must be numeric")
+
+    if default_temp is not None:
+        default_temp_f = _to_f(default_temp, unit)
+        if not (40 <= default_temp_f <= 90):
+            return error("default_temp must be between 40 and 90°F (or equivalent)")
 
     # Use existing (F) values as default if not in body
     min_f = _to_f(min_val, unit) if min_val is not None else tc.min_setpoint
@@ -682,10 +708,18 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
     # Security: input validation
     min_val = body.get("min_setpoint")
     max_val = body.get("max_setpoint")
-    if (min_val is not None and not isinstance(min_val, (int, float))) or (
-        max_val is not None and not isinstance(max_val, (int, float))
+    default_temp = body.get("default_temp")
+    if (
+        (min_val is not None and not isinstance(min_val, (int, float)))
+        or (max_val is not None and not isinstance(max_val, (int, float)))
+        or (default_temp is not None and not isinstance(default_temp, (int, float)))
     ):
-        return error("Setpoints must be numeric")
+        return error("Temperatures must be numeric")
+
+    if default_temp is not None:
+        default_temp_f = _to_f(default_temp, unit)
+        if not (40 <= default_temp_f <= 90):
+            return error("default_temp must be between 40 and 90°F (or equivalent)")
 
     # Use existing (F) values as default if not in body
     min_f = _to_f(min_val, unit) if min_val is not None else tc.min_setpoint
@@ -756,11 +790,20 @@ async def set_override(request: web.Request) -> web.Response:
     body = await request.json()
     if "target_temp" not in body:
         return error("target_temp required")
-    duration_hours = float(body.get("duration_hours", 2.0))
+
+    # Security: input validation
     unit = request.app["scheduler"].get_temperature_unit()
+    target_temp_f = _to_f(float(body["target_temp"]), unit)
+    if not (40 <= target_temp_f <= 90):
+        return error("target_temp must be between 40 and 90°F (or equivalent)")
+
+    duration_hours = float(body.get("duration_hours", 2.0))
+    if not (0 <= duration_hours <= 8760):
+        return error("duration_hours must be between 0 and 8760")
+
     override = RoomOverride(
         room_id=request.match_info["room_id"],
-        target_temp=_to_f(float(body["target_temp"]), unit),
+        target_temp=target_temp_f,
         expires_at=datetime.now(UTC) + timedelta(hours=duration_hours),
     )
     conn = await get_conn(request)

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -964,7 +964,7 @@ class TestScheduleTempConversion:
                 "days_of_week": [0],
                 "start_time": "08:00",
                 "end_time": "18:00",
-                "target_temp": 70.0,
+                "target_temp": 21.0,
             },
         )
         sched_id = (await r2.json())["id"]

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -1,0 +1,114 @@
+"""Reproduction tests for missing input validations."""
+
+import pytest
+
+
+async def _create_room(client, name="Living Room", thermostat="climate.test"):
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": name, "thermostat_entity_id": thermostat},
+    )
+    assert resp.status == 201
+    return await resp.json()
+
+
+@pytest.mark.asyncio
+async def test_create_room_system_wide_temp_bounds(client):
+    # Too high
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": 150},
+    )
+    assert resp.status == 400
+    # Too low
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": 10},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_update_room_system_wide_temp_bounds(client):
+    room = await _create_room(client)
+    resp = await client.put(f"/api/rooms/{room['id']}", json={"system_wide_temp": 150})
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_room_presence_holdover_cap(client):
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "presence_holdover_hours": 9000},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_target_temp_bounds(client):
+    room = await _create_room(client)
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/schedules",
+        json={
+            "days_of_week": [0],
+            "start_time": "08:00",
+            "end_time": "09:00",
+            "target_temp": 150.0,
+        },
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_target_temp_bounds(client):
+    room = await _create_room(client)
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/schedules",
+        json={
+            "days_of_week": [0],
+            "start_time": "08:00",
+            "end_time": "09:00",
+            "target_temp": 70.0,
+        },
+    )
+    sched = await resp.json()
+    resp = await client.put(
+        f"/api/rooms/{room['id']}/schedules/{sched['id']}",
+        json={"target_temp": 150.0},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_create_thermostat_default_temp_bounds(client):
+    resp = await client.post(
+        "/api/thermostats",
+        json={"thermostat_entity_id": "climate.t1", "default_temp": 150.0},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_upsert_thermostat_default_temp_bounds(client):
+    resp = await client.put(
+        "/api/thermostats/climate.t1",
+        json={"default_temp": 150.0},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_set_override_bounds(client):
+    room = await _create_room(client)
+    # Target temp too high
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": 150.0},
+    )
+    assert resp.status == 400
+    # Duration too long
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": 70.0, "duration_hours": 9000},
+    )
+    assert resp.status == 400

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -59,15 +59,42 @@ async def test_create_room_system_wide_temp_bounds_celsius(celsius_client):
 @pytest.mark.asyncio
 async def test_update_room_system_wide_temp_bounds(client):
     room = await _create_room(client)
+    # Too high
     resp = await client.put(f"/api/rooms/{room['id']}", json={"system_wide_temp": 150})
+    assert resp.status == 400
+    # Too low
+    resp = await client.put(f"/api/rooms/{room['id']}", json={"system_wide_temp": 30})
     assert resp.status == 400
 
 
 @pytest.mark.asyncio
+async def test_room_system_wide_temp_non_numeric(client):
+    # Non-numeric in create should return 400, not 500
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": "hot"},
+    )
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "system_wide_temp must be numeric"
+
+    room = await _create_room(client, name="Other", thermostat="climate.y")
+    resp = await client.put(f"/api/rooms/{room['id']}", json={"system_wide_temp": "warm"})
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "system_wide_temp must be numeric"
+
+
+@pytest.mark.asyncio
 async def test_room_presence_holdover_cap(client):
+    # Too high
     resp = await client.post(
         "/api/rooms",
         json={"name": "Room", "thermostat_entity_id": "climate.x", "presence_holdover_hours": 9000},
+    )
+    assert resp.status == 400
+    # Negative
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "presence_holdover_hours": -1},
     )
     assert resp.status == 400
 
@@ -75,6 +102,7 @@ async def test_room_presence_holdover_cap(client):
 @pytest.mark.asyncio
 async def test_create_schedule_target_temp_bounds(client):
     room = await _create_room(client)
+    # Too high
     resp = await client.post(
         f"/api/rooms/{room['id']}/schedules",
         json={
@@ -82,6 +110,17 @@ async def test_create_schedule_target_temp_bounds(client):
             "start_time": "08:00",
             "end_time": "09:00",
             "target_temp": 150.0,
+        },
+    )
+    assert resp.status == 400
+    # Too low
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/schedules",
+        json={
+            "days_of_week": [0],
+            "start_time": "08:00",
+            "end_time": "09:00",
+            "target_temp": 30.0,
         },
     )
     assert resp.status == 400
@@ -100,27 +139,64 @@ async def test_update_schedule_target_temp_bounds(client):
         },
     )
     sched = await resp.json()
+    # Too high
     resp = await client.put(
         f"/api/rooms/{room['id']}/schedules/{sched['id']}",
         json={"target_temp": 150.0},
     )
     assert resp.status == 400
+    # Too low
+    resp = await client.put(
+        f"/api/rooms/{room['id']}/schedules/{sched['id']}",
+        json={"target_temp": 30.0},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_target_temp_non_numeric(client):
+    room = await _create_room(client)
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/schedules",
+        json={"days_of_week": [0], "start_time": "08:00", "end_time": "09:00", "target_temp": 70.0},
+    )
+    sched = await resp.json()
+    resp = await client.put(
+        f"/api/rooms/{room['id']}/schedules/{sched['id']}",
+        json={"target_temp": "hot"},
+    )
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "target_temp must be numeric"
 
 
 @pytest.mark.asyncio
 async def test_create_thermostat_default_temp_bounds(client):
+    # Too high
     resp = await client.post(
         "/api/thermostats",
         json={"thermostat_entity_id": "climate.t1", "default_temp": 150.0},
+    )
+    assert resp.status == 400
+    # Too low
+    resp = await client.post(
+        "/api/thermostats",
+        json={"thermostat_entity_id": "climate.t2", "default_temp": 30.0},
     )
     assert resp.status == 400
 
 
 @pytest.mark.asyncio
 async def test_upsert_thermostat_default_temp_bounds(client):
+    # Too high
     resp = await client.put(
         "/api/thermostats/climate.t1",
         json={"default_temp": 150.0},
+    )
+    assert resp.status == 400
+    # Too low
+    resp = await client.put(
+        "/api/thermostats/climate.t1",
+        json={"default_temp": 30.0},
     )
     assert resp.status == 400
 
@@ -134,9 +210,40 @@ async def test_set_override_bounds(client):
         json={"target_temp": 150.0},
     )
     assert resp.status == 400
+    # Target temp too low
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": 30.0},
+    )
+    assert resp.status == 400
     # Duration too long
     resp = await client.post(
         f"/api/rooms/{room['id']}/override",
         json={"target_temp": 70.0, "duration_hours": 9000},
     )
     assert resp.status == 400
+    # Negative duration
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": 70.0, "duration_hours": -1},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_set_override_non_numeric(client):
+    room = await _create_room(client)
+    # Non-numeric target_temp
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": "warm"},
+    )
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "target_temp must be numeric"
+    # Non-numeric duration_hours
+    resp = await client.post(
+        f"/api/rooms/{room['id']}/override",
+        json={"target_temp": 70.0, "duration_hours": "forever"},
+    )
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "duration_hours must be numeric"

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -3,6 +3,21 @@
 import pytest
 
 
+@pytest.fixture
+async def celsius_client(fake_ha, db_path):
+    """Client where the active temperature unit has been set to Celsius."""
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from backend.main import build_app
+
+    app = build_app(fake_ha, db_path, frontend_dist=None, start_ha=False)
+    server = TestServer(app)
+    async with TestClient(server) as c:
+        await c.start_server()
+        c.app["scheduler"]._active_unit = "C"
+        yield c
+
+
 async def _create_room(client, name="Living Room", thermostat="climate.test"):
     resp = await client.post(
         "/api/rooms",
@@ -20,12 +35,25 @@ async def test_create_room_system_wide_temp_bounds(client):
         json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": 150},
     )
     assert resp.status == 400
+    assert (await resp.json())["error"] == "system_wide_temp must be between 40.0 and 90.0°F"
     # Too low
     resp = await client.post(
         "/api/rooms",
         json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": 10},
     )
     assert resp.status == 400
+    assert (await resp.json())["error"] == "system_wide_temp must be between 40.0 and 90.0°F"
+
+
+@pytest.mark.asyncio
+async def test_create_room_system_wide_temp_bounds_celsius(celsius_client):
+    # Too high: 40°C = 104°F > 90°F
+    resp = await celsius_client.post(
+        "/api/rooms",
+        json={"name": "Room", "thermostat_entity_id": "climate.x", "system_wide_temp": 40},
+    )
+    assert resp.status == 400
+    assert (await resp.json())["error"] == "system_wide_temp must be between 4.4 and 32.2°C"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability: Missing Input Validation Bounds
The API endpoints for creating and updating rooms, schedules, thermostats, and overrides lacked strict range validation for temperature setpoints and duration parameters. This allowed a user (or a malicious actor) to set extremely high or low temperatures (e.g., 150°F or 150°C) and excessively long durations.

### 🎯 Impact
Extreme temperature setpoints could lead to illogical system states, potential software crashes (e.g., OverflowError in duration calculations), or even physical safety concerns and equipment wear if these values were passed through to the thermostat hardware.

### 🔧 Fix
- Added bounds checking (40°F to 90°F) for all user-provided temperature setpoints.
- Crucially, validation is performed *after* normalization to Fahrenheit, ensuring correct behavior regardless of whether the user provides Celsius or Fahrenheit.
- Added a cap of 8760 hours (one year) for durations.
- Integrated validations into `create_room`, `update_room`, `create_schedule`, `update_schedule`, `create_thermostat`, `upsert_thermostat`, and `set_override`.

### 🩹 Follow-up fixes (latest commit)
Four additional edge cases were identified and closed after initial review:

1. **`create_room` / `update_room` — non-numeric `system_wide_temp` caused 500**: `_to_f()` was called before the type was checked. A non-numeric value (e.g. `"hot"`) raised an unhandled `ValueError` and returned HTTP 500 instead of 400. Fixed by adding `isinstance(val, (int, float))` guards matching the existing pattern for `holdover` and `temp_offset`.

2. **`update_schedule` — non-numeric `target_temp` caused 500**: The `float()` cast was outside a try/except, unlike `create_schedule` which was already protected. Wrapped in `try/except (ValueError, TypeError)`.

3. **`set_override` — non-numeric `target_temp` / `duration_hours` caused 500**: Same issue — both `float()` casts now wrapped in try/except.

4. **Lower-bound and negative-value paths were untested**: The original test suite only exercised the upper bound (150°F). Added lower-bound cases (30°F), negative `duration_hours`, and non-numeric string tests across all affected endpoints.

### ✅ Verification
- Created `smart_vent/backend/tests/integration/test_sentinel_validation.py` with 12 targeted tests covering both upper and lower bounds, negative durations, Celsius mode, and non-numeric inputs.
- Ran the full integration test suite and confirmed no regressions: **515 tests passing**.
- Verified code style with `ruff`.

### 🧪 Test plan
- `POST /api/rooms` with `system_wide_temp: 150` → 400
- `POST /api/rooms` with `system_wide_temp: 30` → 400
- `POST /api/rooms` with `system_wide_temp: "hot"` → 400 (not 500)
- `PUT /api/rooms/:id` with `system_wide_temp: "warm"` → 400 (not 500)
- `POST /api/rooms` with `presence_holdover_hours: 9000` → 400
- `POST /api/rooms` with `presence_holdover_hours: -1` → 400
- `POST /api/rooms/:id/schedules` with `target_temp: 150` → 400
- `POST /api/rooms/:id/schedules` with `target_temp: 30` → 400
- `PUT /api/rooms/:id/schedules/:id` with `target_temp: "hot"` → 400 (not 500)
- `POST /api/thermostats` with `default_temp: 150` or `30` → 400
- `POST /api/rooms/:id/override` with `target_temp: "warm"` → 400 (not 500)
- `POST /api/rooms/:id/override` with `duration_hours: "forever"` → 400 (not 500)
- `POST /api/rooms/:id/override` with `duration_hours: -1` → 400
- All of the above with Celsius mode active: error messages show converted bounds (e.g. `"4.4 and 32.2°C"`)

---
*PR created automatically by Jules for task [9859075946629546924](https://jules.google.com/task/9859075946629546924) started by @dhruvb14*