### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Input Validation Bounds

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -139,6 +139,13 @@ async def create_room(request: web.Request) -> web.Response:
     sys_temp = body.get("system_wide_temp")
 
     # Security: input validation
+    if sys_temp is not None:
+        if not isinstance(sys_temp, (int, float)):
+            return error("system_wide_temp must be numeric")
+        sys_temp_f = _to_f(sys_temp, unit)
+        if not (40 <= sys_temp_f <= 90):
+            return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
+
     holdover = body.get("presence_holdover_hours", 2.0)
     if not isinstance(holdover, (int, float)) or holdover < 0:
         return error("presence_holdover_hours must be a non-negative number")
@@ -225,7 +232,15 @@ async def update_room(request: web.Request) -> web.Response:
             setattr(room, field, body[field])
     if "system_wide_temp" in body:
         val = body["system_wide_temp"]
-        room.system_wide_temp = _to_f(val, unit) if val is not None else None
+        if val is not None:
+            if not isinstance(val, (int, float)):
+                return error("system_wide_temp must be numeric")
+            val_f = _to_f(val, unit)
+            if not (40 <= val_f <= 90):
+                return error("system_wide_temp must be between 40 and 90°F (or equivalent)")
+            room.system_wide_temp = val_f
+        else:
+            room.system_wide_temp = None
     if "temp_offset" in body:
         room.temp_offset = _delta_to_f(body["temp_offset"], unit)
     await db.upsert_room(conn, room)
@@ -526,12 +541,17 @@ async def create_schedule(request: web.Request) -> web.Response:
         return error(f"Required fields: {required}")
     unit = request.app["scheduler"].get_temperature_unit()
     try:
+        target_temp = float(body["target_temp"])
+        target_temp_f = _to_f(target_temp, unit)
+        if not (40 <= target_temp_f <= 90):
+            return error("target_temp must be between 40 and 90°F (or equivalent)")
+
         s = Schedule.create(
             room_id=request.match_info["room_id"],
             days_of_week=body["days_of_week"],
             start_time=time.fromisoformat(body["start_time"]),
             end_time=time.fromisoformat(body["end_time"]),
-            target_temp=_to_f(float(body["target_temp"]), unit),
+            target_temp=target_temp_f,
         )
     except (ValueError, TypeError):
         return error("Invalid schedule payload")
@@ -569,7 +589,14 @@ async def update_schedule(request: web.Request) -> web.Response:
     if "end_time" in body:
         schedule.end_time = time.fromisoformat(body["end_time"])
     if "target_temp" in body:
-        schedule.target_temp = _to_f(float(body["target_temp"]), unit)
+        try:
+            target_temp = float(body["target_temp"])
+            target_temp_f = _to_f(target_temp, unit)
+            if not (40 <= target_temp_f <= 90):
+                return error("target_temp must be between 40 and 90°F (or equivalent)")
+            schedule.target_temp = target_temp_f
+        except (ValueError, TypeError):
+            return error("target_temp must be numeric")
     # Check for overlapping schedules (excluding self)
     for e in schedules:
         if e.id == schedule.id:
@@ -756,11 +783,26 @@ async def set_override(request: web.Request) -> web.Response:
     body = await request.json()
     if "target_temp" not in body:
         return error("target_temp required")
-    duration_hours = float(body.get("duration_hours", 2.0))
+
+    try:
+        duration_hours = float(body.get("duration_hours", 2.0))
+        if not (0 <= duration_hours <= 8760):
+            return error("duration_hours must be between 0 and 8760 (1 year)")
+    except (ValueError, TypeError):
+        return error("duration_hours must be numeric")
+
     unit = request.app["scheduler"].get_temperature_unit()
+    try:
+        target_temp = float(body["target_temp"])
+        target_temp_f = _to_f(target_temp, unit)
+        if not (40 <= target_temp_f <= 90):
+            return error("target_temp must be between 40 and 90°F (or equivalent)")
+    except (ValueError, TypeError):
+        return error("target_temp must be numeric")
+
     override = RoomOverride(
         room_id=request.match_info["room_id"],
-        target_temp=_to_f(float(body["target_temp"]), unit),
+        target_temp=target_temp_f,
         expires_at=datetime.now(UTC) + timedelta(hours=duration_hours),
     )
     conn = await get_conn(request)

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -964,9 +964,10 @@ class TestScheduleTempConversion:
                 "days_of_week": [0],
                 "start_time": "08:00",
                 "end_time": "18:00",
-                "target_temp": 70.0,
+                "target_temp": 21.0,
             },
         )
+        assert r2.status == 201
         sched_id = (await r2.json())["id"]
         resp = await celsius_client.put(
             f"/api/rooms/{room_id}/schedules/{sched_id}",

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -4,7 +4,9 @@ Verify that all API endpoints enforce safe bounds for temperatures and durations
 """
 
 from __future__ import annotations
+
 import pytest
+
 
 @pytest.mark.asyncio
 async def test_room_system_wide_temp_bounds(client) -> None:

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -1,0 +1,70 @@
+"""
+🛡️ Sentinel: Input validation bounds tests.
+Verify that all API endpoints enforce safe bounds for temperatures and durations.
+"""
+
+from __future__ import annotations
+import pytest
+
+@pytest.mark.asyncio
+async def test_room_system_wide_temp_bounds(client) -> None:
+    """Verify system_wide_temp is restricted to [40, 90]°F."""
+    # Too low (30°F)
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Cold Room",
+            "thermostat_entity_id": "climate.test",
+            "system_wide_temp": 30
+        }
+    )
+    assert resp.status == 400
+    assert "between 40 and 90" in (await resp.json())["error"]
+
+    # Too high (100°F)
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Hot Room",
+            "thermostat_entity_id": "climate.test",
+            "system_wide_temp": 100
+        }
+    )
+    assert resp.status == 400
+    assert "between 40 and 90" in (await resp.json())["error"]
+
+@pytest.mark.asyncio
+async def test_override_bounds(client) -> None:
+    """Verify set_override validates target_temp and duration_hours."""
+    # Create a room first
+    resp = await client.post("/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"})
+    room_id = (await resp.json())["id"]
+
+    # Invalid temp
+    resp = await client.post(f"/api/rooms/{room_id}/override", json={"target_temp": 110})
+    assert resp.status == 400
+
+    # Negative duration
+    resp = await client.post(f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": -1})
+    assert resp.status == 400
+
+    # Excessive duration
+    resp = await client.post(f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": 99999})
+    assert resp.status == 400
+
+@pytest.mark.asyncio
+async def test_schedule_temp_bounds(client) -> None:
+    """Verify schedule target_temp is restricted to [40, 90]°F."""
+    resp = await client.post("/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"})
+    room_id = (await resp.json())["id"]
+
+    resp = await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": [0],
+            "start_time": "08:00",
+            "end_time": "09:00",
+            "target_temp": 120
+        }
+    )
+    assert resp.status == 400

--- a/smart_vent/backend/tests/integration/test_sentinel_validation.py
+++ b/smart_vent/backend/tests/integration/test_sentinel_validation.py
@@ -14,11 +14,7 @@ async def test_room_system_wide_temp_bounds(client) -> None:
     # Too low (30°F)
     resp = await client.post(
         "/api/rooms",
-        json={
-            "name": "Cold Room",
-            "thermostat_entity_id": "climate.test",
-            "system_wide_temp": 30
-        }
+        json={"name": "Cold Room", "thermostat_entity_id": "climate.test", "system_wide_temp": 30},
     )
     assert resp.status == 400
     assert "between 40 and 90" in (await resp.json())["error"]
@@ -26,20 +22,19 @@ async def test_room_system_wide_temp_bounds(client) -> None:
     # Too high (100°F)
     resp = await client.post(
         "/api/rooms",
-        json={
-            "name": "Hot Room",
-            "thermostat_entity_id": "climate.test",
-            "system_wide_temp": 100
-        }
+        json={"name": "Hot Room", "thermostat_entity_id": "climate.test", "system_wide_temp": 100},
     )
     assert resp.status == 400
     assert "between 40 and 90" in (await resp.json())["error"]
+
 
 @pytest.mark.asyncio
 async def test_override_bounds(client) -> None:
     """Verify set_override validates target_temp and duration_hours."""
     # Create a room first
-    resp = await client.post("/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"})
+    resp = await client.post(
+        "/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"}
+    )
     room_id = (await resp.json())["id"]
 
     # Invalid temp
@@ -47,26 +42,28 @@ async def test_override_bounds(client) -> None:
     assert resp.status == 400
 
     # Negative duration
-    resp = await client.post(f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": -1})
+    resp = await client.post(
+        f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": -1}
+    )
     assert resp.status == 400
 
     # Excessive duration
-    resp = await client.post(f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": 99999})
+    resp = await client.post(
+        f"/api/rooms/{room_id}/override", json={"target_temp": 70, "duration_hours": 99999}
+    )
     assert resp.status == 400
+
 
 @pytest.mark.asyncio
 async def test_schedule_temp_bounds(client) -> None:
     """Verify schedule target_temp is restricted to [40, 90]°F."""
-    resp = await client.post("/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"})
+    resp = await client.post(
+        "/api/rooms", json={"name": "Test", "thermostat_entity_id": "climate.test"}
+    )
     room_id = (await resp.json())["id"]
 
     resp = await client.post(
         f"/api/rooms/{room_id}/schedules",
-        json={
-            "days_of_week": [0],
-            "start_time": "08:00",
-            "end_time": "09:00",
-            "target_temp": 120
-        }
+        json={"days_of_week": [0], "start_time": "08:00", "end_time": "09:00", "target_temp": 120},
     )
     assert resp.status == 400


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing input validation for temperature setpoints and override durations in the REST API.
🎯 **Impact:** Without bounds checking, malicious or accidental input could command HVAC equipment to extreme temperatures (e.g., 0°F or 500°F). This could lead to physical damage to the HVAC system, burst pipes, or extreme energy waste. Additionally, non-validated override durations could cause logic errors in expiration calculations.
🔧 **Fix:** Implemented strict input validation in `smart_vent/backend/api/routes.py` for `create_room`, `update_room`, `create_schedule`, `update_schedule`, and `set_override`. 
   - Temperatures are clamped to a safe range of **40°F to 90°F** (normalized after unit conversion).
   - Override durations are clamped to **0 to 8760 hours** (1 year).
   - Non-numeric inputs for these fields now return a 400 Bad Request error.
✅ **Verification:** 
   - Added a new integration test suite: `smart_vent/backend/tests/integration/test_sentinel_validation.py`.
   - Ran the full backend test suite (`python3 -m pytest smart_vent/backend/tests/`). All **506 tests passed**.
   - Verified that Celsius-to-Fahrenheit conversion still works correctly under the new bounds.

---
*PR created automatically by Jules for task [17411626990209404881](https://jules.google.com/task/17411626990209404881) started by @dhruvb14*