### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Input Validation Bounds for Database Restore

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1721,6 +1721,9 @@ async def backup_db(request: web.Request) -> web.Response:
         return error("Backup failed", 500)
 
 
+MAX_RESTORE_SIZE = 10 * 1024 * 1024  # 10MB
+
+
 @docs(tags=["system"], summary="Restore a database from backup")
 @response_schema(
     schemas.SuccessSchema
@@ -1737,10 +1740,16 @@ async def restore_db(request: web.Request) -> web.Response:
     # Write upload to a temp file first so we can validate before overwriting
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
+        size = 0
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            size += len(chunk)
+            if size > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"File too large (max {MAX_RESTORE_SIZE // 1024 // 1024}MB)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_restore_db_size_limit(client):
+    """Verify that uploading a large file to /api/restore is blocked."""
+    # 11MB dummy data (exceeds 10MB limit)
+    large_data = b"a" * (11 * 1024 * 1024)
+
+    data = aiohttp.FormData()
+    data.add_field("file", large_data, filename="large.db")
+
+    resp = await client.post("/api/restore", data=data)
+
+    assert resp.status == 400
+    body = await resp.json()
+    assert "too large" in body["error"]
+    assert "10MB" in body["error"]


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The /api/restore endpoint lacked file size limits on database uploads, posing a potential Denial of Service (DoS) risk via disk space exhaustion.
🎯 Impact: An attacker could upload a very large file to fill up the disk on the host system, potentially causing the application or the entire system to crash.
🔧 Fix: Implemented a 10MB limit (MAX_RESTORE_SIZE) in the restore_db handler. The upload is checked chunk-by-chunk during the streaming process, and if the limit is exceeded, the temporary file is deleted and a 400 Bad Request error is returned.
✅ Verification: Added a new integration test 'smart_vent/backend/tests/integration/test_restore_security.py' that attempts to upload an 11MB file and verifies it is rejected with the correct error message.

---
*PR created automatically by Jules for task [901265853702186286](https://jules.google.com/task/901265853702186286) started by @dhruvb14*