### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS via Database Restore Size Limit

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -39,6 +39,8 @@ log = logging.getLogger(__name__)
 
 routes = web.RouteTableDef()
 
+MAX_RESTORE_SIZE = 10 * 1024 * 1024  # 10MB (Issue #154)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1735,12 +1737,18 @@ async def restore_db(request: web.Request) -> web.Response:
         return error("Multipart field 'file' required")
 
     # Write upload to a temp file first so we can validate before overwriting
+    total_size = 0
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            total_size += len(chunk)
+            if total_size > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"Upload exceeds maximum allowed size ({MAX_RESTORE_SIZE} bytes)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -3,6 +3,7 @@
 import pytest
 from aiohttp import FormData
 
+
 @pytest.mark.asyncio
 async def test_restore_too_large_rejected(client):
     """Verify that a database restore exceeding 10MB is rejected (DoS prevention)."""

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -11,15 +11,13 @@ async def test_restore_too_large_rejected(client):
     large_data = b"a" * (10 * 1024 * 1024 + 1)
 
     data = FormData()
-    data.add_field('file',
-                   large_data,
-                   filename='app.db',
-                   content_type='application/octet-stream')
+    data.add_field("file", large_data, filename="app.db", content_type="application/octet-stream")
 
     resp = await client.post("/api/restore", data=data)
     assert resp.status == 400
     result = await resp.json()
     assert "exceeds" in result["error"].lower() or "too large" in result["error"].lower()
+
 
 @pytest.mark.asyncio
 async def test_restore_normal_size_accepted(client):
@@ -30,10 +28,7 @@ async def test_restore_normal_size_accepted(client):
     db_bytes = await backup_resp.read()
 
     data = FormData()
-    data.add_field('file',
-                   db_bytes,
-                   filename='app.db',
-                   content_type='application/octet-stream')
+    data.add_field("file", db_bytes, filename="app.db", content_type="application/octet-stream")
 
     resp = await client.post("/api/restore", data=data)
     assert resp.status == 200

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,40 @@
+"""Security tests for the database restore endpoint."""
+
+import pytest
+from aiohttp import FormData
+
+@pytest.mark.asyncio
+async def test_restore_too_large_rejected(client):
+    """Verify that a database restore exceeding 10MB is rejected (DoS prevention)."""
+    # 10MB + 1 byte
+    large_data = b"a" * (10 * 1024 * 1024 + 1)
+
+    data = FormData()
+    data.add_field('file',
+                   large_data,
+                   filename='app.db',
+                   content_type='application/octet-stream')
+
+    resp = await client.post("/api/restore", data=data)
+    assert resp.status == 400
+    result = await resp.json()
+    assert "exceeds" in result["error"].lower() or "too large" in result["error"].lower()
+
+@pytest.mark.asyncio
+async def test_restore_normal_size_accepted(client):
+    """Verify that a normal-sized valid database restore still works."""
+    # First take a backup to get a valid small DB
+    backup_resp = await client.get("/api/backup")
+    assert backup_resp.status == 200
+    db_bytes = await backup_resp.read()
+
+    data = FormData()
+    data.add_field('file',
+                   db_bytes,
+                   filename='app.db',
+                   content_type='application/octet-stream')
+
+    resp = await client.post("/api/restore", data=data)
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["restored"] is True


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing file size limit on the database restore endpoint.
🎯 Impact: An attacker could exhaust disk space by uploading an excessively large file, causing a Denial of Service.
🔧 Fix: Implemented a 10MB limit (MAX_RESTORE_SIZE) enforced during the streaming upload of the database backup. Added cleanup to delete the partial file if the limit is exceeded.
✅ Verification: Added an integration test `smart_vent/backend/tests/integration/test_restore_security.py` that verifies rejection of files exceeding 10MB with a 400 error and ensures valid small restores still work.

---
*PR created automatically by Jules for task [11270022005231140497](https://jules.google.com/task/11270022005231140497) started by @dhruvb14*