### PR TITLE
Fix HA WebSocket disconnect causing UI to hang/become unresponsive

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -244,7 +244,7 @@ class CycleEngine:
                         )
                         self._last_setpoint_sent = ambient_f
                     except Exception as exc:
-                        log.error("Failed to reset setpoint to ambient: %s", exc)
+                        log.error("Failed to reset setpoint to ambient: %s: %r", exc, exc)
                 await self._maybe_reconcile(conn)
                 await self._maybe_broadcast()
                 return
@@ -1045,7 +1045,7 @@ class CycleEngine:
                                 },
                             )
                     except Exception as exc:
-                        log.error("Abort: failed to reset setpoint to ambient: %s", exc)
+                        log.error("Abort: failed to reset setpoint to ambient: %s: %r", exc, exc)
 
         self._state = CycleState.IDLE
         self._cycle_mode = None

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -309,18 +309,28 @@ class HAClient:
             self._ha_url.replace("http://", "ws://").replace("https://", "wss://")
         ) + "/api/websocket"
         log.info("Connecting to %s", ws_url)
-        async with self._session.ws_connect(ws_url) as ws:
-            self._ws = ws
-            await self._handshake()
-            # Populate state cache before signalling ready
-            try:
-                await self.fetch_states()
-            except Exception as exc:
-                log.warning("Could not pre-fetch states: %s", exc)
-            await self._subscribe_state_changed()
-            self._connected.set()
-            log.info("HA WebSocket connected and subscribed")
-            await self._read_loop()
+        try:
+            async with self._session.ws_connect(ws_url) as ws:
+                self._ws = ws
+                await self._handshake()
+                # Populate state cache before signalling ready
+                try:
+                    await self.fetch_states()
+                except Exception as exc:
+                    log.warning("Could not pre-fetch states: %s", exc)
+                await self._subscribe_state_changed()
+                self._connected.set()
+                log.info("HA WebSocket connected and subscribed")
+                await self._read_loop()
+        finally:
+            # Always clean up so stale _ws is never used and in-flight callers
+            # fail immediately instead of waiting for their per-call timeout.
+            self._ws = None
+            self._connected.clear()
+            for fut in list(self._pending.values()):
+                if not fut.done():
+                    fut.set_exception(RuntimeError("HA WebSocket disconnected"))
+            self._pending.clear()
 
     async def _handshake(self) -> None:
         assert self._ws is not None
@@ -382,12 +392,21 @@ class HAClient:
                     asyncio.create_task(cb(entity_id, new_state))
 
     async def _send(self, payload: dict) -> dict:
+        if not self._connected.is_set():
+            raise RuntimeError("HA not connected")
         assert self._ws is not None
         self._msg_id += 1
-        payload["id"] = self._msg_id
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
-        self._pending[self._msg_id] = fut
-        await self._ws.send_json(payload)
+        msg_id = self._msg_id
+        payload["id"] = msg_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[msg_id] = fut
+        try:
+            await asyncio.wait_for(self._ws.send_json(payload), timeout=5.0)
+        except Exception:
+            self._pending.pop(msg_id, None)
+            if not fut.done():
+                fut.cancel()
+            raise
         return await asyncio.wait_for(fut, timeout=10.0)
 
 

--- a/smart_vent/backend/tests/test_ha_client.py
+++ b/smart_vent/backend/tests/test_ha_client.py
@@ -311,6 +311,7 @@ def _make_auto_resolving_client() -> HAClient:
     mock_ws = AsyncMock()
     mock_ws.send_json.side_effect = fake_send_json
     client._ws = mock_ws
+    client._connected.set()
     return client
 
 

--- a/smart_vent/backend/tests/test_ha_client_internals.py
+++ b/smart_vent/backend/tests/test_ha_client_internals.py
@@ -6,6 +6,7 @@ only exercised by the real WebSocket lifecycle.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -219,11 +220,16 @@ class TestStart:
 class TestConnect:
     async def test_connect_success_path(self):
         client = HAClient("ws://ha.local", "tok")
+        connected_during_read: list[bool] = []
 
         client._handshake = AsyncMock()
         client._subscribe_state_changed = AsyncMock()
-        client._read_loop = AsyncMock()
         client.fetch_states = AsyncMock(return_value=[])
+
+        async def capturing_read_loop():
+            connected_during_read.append(client._connected.is_set())
+
+        client._read_loop = capturing_read_loop
 
         mock_ws = AsyncMock()
         mock_ctx = AsyncMock()
@@ -238,16 +244,23 @@ class TestConnect:
 
         client._handshake.assert_called_once()
         client._subscribe_state_changed.assert_called_once()
-        client._read_loop.assert_called_once()
-        assert client._connected.is_set()
+        # _connected must have been set while the read loop ran
+        assert connected_during_read == [True]
+        # _connected must be cleared after _connect() returns (finally block)
+        assert not client._connected.is_set()
 
     async def test_connect_fetch_states_failure_is_swallowed(self):
         client = HAClient("ws://ha.local", "tok")
+        connected_during_read: list[bool] = []
 
         client._handshake = AsyncMock()
         client._subscribe_state_changed = AsyncMock()
-        client._read_loop = AsyncMock()
         client.fetch_states = AsyncMock(side_effect=RuntimeError("http error"))
+
+        async def capturing_read_loop():
+            connected_during_read.append(client._connected.is_set())
+
+        client._read_loop = capturing_read_loop
 
         mock_ws = AsyncMock()
         mock_ctx = AsyncMock()
@@ -260,7 +273,9 @@ class TestConnect:
 
         await client._connect()  # must not raise
 
-        assert client._connected.is_set()
+        # fetch_states failure is swallowed; connection still proceeds
+        assert connected_during_read == [True]
+        assert not client._connected.is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -323,3 +338,69 @@ class TestGetTemperatureUnit:
         client._session = mock_session
         await client.get_temperature_unit()
         assert captured_urls[0].startswith("https://")
+
+
+# ---------------------------------------------------------------------------
+# _send() disconnect fast-fail and pending cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestSend:
+    async def test_send_raises_when_not_connected(self):
+        client = HAClient("ws://ha.local", "tok")
+        # _connected is not set — should raise immediately
+        with pytest.raises(RuntimeError, match="HA not connected"):
+            await client._send({"type": "call_service"})
+
+    async def test_send_cancels_pending_on_send_json_failure(self):
+        client = HAClient("ws://ha.local", "tok")
+        client._connected.set()
+
+        mock_ws = AsyncMock()
+        mock_ws.send_json.side_effect = RuntimeError("send failed")
+        client._ws = mock_ws
+
+        with pytest.raises(RuntimeError, match="send failed"):
+            await client._send({"type": "call_service"})
+
+        # Pending future must have been cleaned up
+        assert client._pending == {}
+
+    async def test_connect_cleanup_cancels_pending_futures(self):
+        """Pending futures are resolved with an error when _connect exits."""
+        client = HAClient("ws://ha.local", "tok")
+
+        async def slow_read_loop():
+            # While connected, register a pending future then let the loop exit
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()
+            client._pending[99] = fut
+            await asyncio.sleep(0)  # yield so finally runs when we exit
+
+        client._handshake = AsyncMock()
+        client._subscribe_state_changed = AsyncMock()
+        client.fetch_states = AsyncMock(return_value=[])
+        client._read_loop = slow_read_loop
+
+        mock_ws = AsyncMock()
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.ws_connect = MagicMock(return_value=mock_ctx)
+        client._session = mock_session
+
+        # Manually plant a pending future before calling _connect
+        loop = asyncio.get_running_loop()
+        orphan_fut = loop.create_future()
+        client._pending[42] = orphan_fut
+
+        await client._connect()
+
+        # After _connect exits, all pending futures must be resolved and cleared
+        assert client._pending == {}
+        assert orphan_fut.done()
+        exc = orphan_fut.exception()
+        assert exc is not None
+        assert "disconnected" in str(exc).lower()

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",


### PR DESCRIPTION
Three bugs caused the UI to stop responding when HA became unavailable
mid-operation (e.g. while clearing presence holdovers):

1. `_send` had no timeout on `ws.send_json()` — a frozen TCP connection
   (half-open state after a network partition) would block indefinitely,
   holding the engine lock for every in-flight service call.

2. `self._ws` was never set to None after the WebSocket context manager
   exited, so the `assert self._ws is not None` guard in `_send` passed
   even after the connection dropped, then `send_json` would hang.

3. Pending futures in `self._pending` were never cancelled when the
   connection dropped.  Each in-flight call had to wait the full 10 s
   `asyncio.wait_for` timeout, causing a pile-up of tasks each holding
   the engine lock for 10 s.  With rapid presence events this created a
   waterfall that saturated the event loop.

Fixes:
- `_connect` now has a `try/finally` that always: sets `self._ws = None`,
  clears `self._connected`, and resolves every pending future with a
  "HA WebSocket disconnected" error so callers fail in milliseconds.
- `_send` checks `_connected.is_set()` first and raises immediately when
  the client is not connected.
- `_send` wraps `ws.send_json()` in `asyncio.wait_for(..., timeout=5.0)`
  so a frozen TCP connection can't block indefinitely.
- `_send` cleans up its own pending entry if `send_json` fails (before
  a response is expected).
- Use `asyncio.get_running_loop()` instead of deprecated `get_event_loop()`.
- Improve error logging in cycle_engine to include `%r` so exception type
  is visible even when `str(exc)` is empty (e.g. `asyncio.TimeoutError`
  in Python 3.11+ has no string representation).

https://claude.ai/code/session_011mtjufAtDrj1XvtHAKhDsy