### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce File Size Limit on Database Restore

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -39,6 +39,9 @@ log = logging.getLogger(__name__)
 
 routes = web.RouteTableDef()
 
+# Security: Limit database restore uploads to 10MB to prevent DoS via disk exhaustion.
+MAX_RESTORE_SIZE = 10 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1735,12 +1738,18 @@ async def restore_db(request: web.Request) -> web.Response:
         return error("Multipart field 'file' required")
 
     # Write upload to a temp file first so we can validate before overwriting
+    size_acc = 0
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            size_acc += len(chunk)
+            if size_acc > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"Upload exceeds maximum allowed size of {MAX_RESTORE_SIZE} bytes")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+
 import pytest
 
 

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,22 @@
+"""Security tests for the restore endpoint."""
+
+from __future__ import annotations
+
+import io
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_restore_too_large_rejected(client):
+    """Verify that a restore upload exceeding 10MB is rejected."""
+    # 11MB of data
+    large_data = b"0" * (11 * 1024 * 1024)
+    data = io.BytesIO(large_data)
+
+    # We use a multipart request as expected by the handler
+    resp = await client.post("/api/restore", data={"file": data})
+
+    # This should return 400 Bad Request if the limit is enforced.
+    assert resp.status == 400
+    result = await resp.json()
+    assert "exceeds" in result["error"]


### PR DESCRIPTION
As Sentinel, I identified a potential Denial of Service (DoS) vulnerability in the database restore endpoint. The `/api/restore` endpoint accepted multipart file uploads without enforcing a size limit, which could lead to disk space exhaustion.

I have implemented a 10MB limit (`MAX_RESTORE_SIZE`) within the chunk-reading loop of the `restore_db` handler in `smart_vent/backend/api/routes.py`. If an upload exceeds this limit, the process is aborted, the temporary file is deleted, and a 400 Bad Request error is returned.

I also added a regression test in `smart_vent/backend/tests/integration/test_restore_security.py` to ensure this limit is correctly enforced. All backend tests passed successfully.

---
*PR created automatically by Jules for task [5216730877690272077](https://jules.google.com/task/5216730877690272077) started by @dhruvb14*