### PR TITLE
feat: vacation mode — suspend schedules and hold thermostats within safety band

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1346,7 +1346,9 @@ async def enable_vacation_mode(request: web.Request) -> web.Response:
     if return_at <= datetime.now(UTC):
         return error("return_at must be in the future")
     await request.app["scheduler"].set_vacation_mode(True, return_at)
-    await emit(request, "info", "api", "Vacation mode enabled", {"return_at": return_at.isoformat()})
+    await emit(
+        request, "info", "api", "Vacation mode enabled", {"return_at": return_at.isoformat()}
+    )
     return json_response({"enabled": True, "return_at": return_at.isoformat()})
 
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -705,12 +705,17 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "overshoot_delta",
         "cycle_timeout_hours",
         "reconciliation_interval_min",
+        "vacation_hvac_mode",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):
                 setattr(tc, field, _to_f(body[field], unit))
             elif field in ("deadband", "overshoot_delta"):
                 setattr(tc, field, _delta_to_f(body[field], unit))
+            elif field == "vacation_hvac_mode":
+                if body[field] not in ("range", "single"):
+                    return error("vacation_hvac_mode must be 'range' or 'single'")
+                setattr(tc, field, body[field])
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -771,12 +776,17 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "overshoot_delta",
         "cycle_timeout_hours",
         "reconciliation_interval_min",
+        "vacation_hvac_mode",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):
                 setattr(tc, field, _to_f(body[field], unit))
             elif field in ("deadband", "overshoot_delta"):
                 setattr(tc, field, _delta_to_f(body[field], unit))
+            elif field == "vacation_hvac_mode":
+                if body[field] not in ("range", "single"):
+                    return error("vacation_hvac_mode must be 'range' or 'single'")
+                setattr(tc, field, body[field])
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -1272,10 +1282,19 @@ async def get_settings(request: web.Request) -> web.Response:
     unit_change_ack_required = (
         await db.get_system_setting(conn, "unit_change_ack_required", "0") == "1"
     )
+    scheduler = request.app["scheduler"]
     return json_response(
         {
             "temperature_unit": temperature_unit,
             "unit_change_ack_required": unit_change_ack_required,
+            "vacation_mode": {
+                "enabled": scheduler.get_vacation_mode(),
+                "return_at": (
+                    scheduler.get_vacation_return_at().isoformat()
+                    if scheduler.get_vacation_return_at()
+                    else None
+                ),
+            },
         }
     )
 
@@ -1287,6 +1306,86 @@ async def ack_unit_change(request: web.Request) -> web.Response:
     """Dismiss the unit-change banner by clearing the ack flag."""
     await request.app["scheduler"].ack_unit_change()
     return json_response({"unit_change_ack_required": False})
+
+
+# ---------------------------------------------------------------------------
+# Vacation mode
+# ---------------------------------------------------------------------------
+
+
+@docs(tags=["settings"], summary="Get vacation mode state")
+@response_schema(schemas.VacationModeSchema)
+@routes.get("/api/settings/vacation-mode")
+async def get_vacation_mode(request: web.Request) -> web.Response:
+    """Return current vacation mode state."""
+    scheduler = request.app["scheduler"]
+    return_at = scheduler.get_vacation_return_at()
+    return json_response(
+        {
+            "enabled": scheduler.get_vacation_mode(),
+            "return_at": return_at.isoformat() if return_at else None,
+        }
+    )
+
+
+@docs(tags=["settings"], summary="Enable vacation mode")
+@response_schema(schemas.VacationModeSchema, code=200)
+@routes.post("/api/settings/vacation-mode")
+async def enable_vacation_mode(request: web.Request) -> web.Response:
+    """Enable vacation mode. Body: {return_at: ISO-8601 UTC string}."""
+    body = await request.json()
+    return_at_str = body.get("return_at")
+    if not return_at_str:
+        return error("return_at (ISO-8601 UTC datetime) is required")
+    try:
+        return_at = datetime.fromisoformat(return_at_str)
+        if return_at.tzinfo is None:
+            return_at = return_at.replace(tzinfo=UTC)
+    except ValueError:
+        return error("return_at must be a valid ISO-8601 datetime")
+    if return_at <= datetime.now(UTC):
+        return error("return_at must be in the future")
+    await request.app["scheduler"].set_vacation_mode(True, return_at)
+    await emit(request, "info", "api", "Vacation mode enabled", {"return_at": return_at.isoformat()})
+    return json_response({"enabled": True, "return_at": return_at.isoformat()})
+
+
+@docs(tags=["settings"], summary="Disable vacation mode")
+@response_schema(schemas.VacationModeSchema)
+@routes.delete("/api/settings/vacation-mode")
+async def disable_vacation_mode(request: web.Request) -> web.Response:
+    """Disable vacation mode immediately and resume normal scheduling."""
+    await request.app["scheduler"].set_vacation_mode(False)
+    await emit(request, "info", "api", "Vacation mode disabled", {})
+    return json_response({"enabled": False, "return_at": None})
+
+
+@docs(tags=["thermostats"], summary="Test vacation range mode on thermostat")
+@response_schema(schemas.VacationTestSchema)
+@routes.post("/api/thermostats/{entity_id:.+}/test-vacation")
+async def test_vacation_mode(request: web.Request) -> web.Response:
+    """Temporarily send the vacation range command to a thermostat so the user
+    can verify it responded correctly in HA. Caller is responsible for
+    reverting (the engine will correct state on the next tick if vacation mode
+    is not active, or keep the range if vacation mode is enabled)."""
+    entity_id = request.match_info["entity_id"]
+    conn = await get_conn(request)
+    tc = await db.get_thermostat_config(conn, entity_id)
+    ha = request.app["ha"]
+    try:
+        await ha.set_thermostat_temperature_range(entity_id, tc.min_setpoint, tc.max_setpoint)
+    except Exception as exc:
+        return error(f"Failed to send range command: {exc}", status=502)
+    # Return current HA state so the UI can surface it to the user.
+    state = ha.get_state(entity_id)
+    return json_response(
+        {
+            "ok": True,
+            "min_setpoint": tc.min_setpoint,
+            "max_setpoint": tc.max_setpoint,
+            "thermostat_state": state,
+        }
+    )
 
 
 @docs(tags=["system"], summary="Restart the application")

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -186,6 +186,18 @@ class OutsideTempEntitySettingSchema(Schema):
     current_value = fields.Float(allow_none=True)
 
 
+class VacationModeSchema(Schema):
+    enabled = fields.Bool()
+    return_at = fields.Str(allow_none=True)
+
+
+class VacationTestSchema(Schema):
+    ok = fields.Bool()
+    min_setpoint = fields.Float(allow_none=True)
+    max_setpoint = fields.Float(allow_none=True)
+    thermostat_state = fields.Dict()
+
+
 class AppSettingsSchema(Schema):
     temperature_unit = fields.Str()
     unit_change_ack_required = fields.Bool()

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -301,6 +301,8 @@ _MIGRATIONS = [
     # Outside-temperature capture (Issue #85 Phase 1c)
     "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_start REAL",
     "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_end REAL",
+    # Vacation mode thermostat hold strategy
+    "ALTER TABLE thermostat_configs ADD COLUMN vacation_hvac_mode TEXT NOT NULL DEFAULT 'single'",
 ]
 
 
@@ -586,6 +588,7 @@ async def get_all_thermostat_configs(
 
 
 def _row_to_tc(row) -> ThermostatConfig:
+    keys = row.keys() if hasattr(row, "keys") else []
     return ThermostatConfig(
         thermostat_entity_id=row["thermostat_entity_id"],
         name=row["name"] if row["name"] is not None else "",
@@ -598,6 +601,7 @@ def _row_to_tc(row) -> ThermostatConfig:
         overshoot_delta=row["overshoot_delta"],
         cycle_timeout_hours=row["cycle_timeout_hours"],
         reconciliation_interval_min=int(row["reconciliation_interval_min"] or 0),
+        vacation_hvac_mode=row["vacation_hvac_mode"] if "vacation_hvac_mode" in keys else "single",
     )
 
 
@@ -606,8 +610,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
         """INSERT INTO thermostat_configs
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
             max_vent_closed_min,min_open_vents,overshoot_delta,cycle_timeout_hours,
-            reconciliation_interval_min)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            reconciliation_interval_min,vacation_hvac_mode)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -618,7 +622,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              min_open_vents=excluded.min_open_vents,
              overshoot_delta=excluded.overshoot_delta,
              cycle_timeout_hours=excluded.cycle_timeout_hours,
-             reconciliation_interval_min=excluded.reconciliation_interval_min
+             reconciliation_interval_min=excluded.reconciliation_interval_min,
+             vacation_hvac_mode=excluded.vacation_hvac_mode
         """,
         (
             tc.thermostat_entity_id,
@@ -632,6 +637,7 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             tc.overshoot_delta,
             tc.cycle_timeout_hours,
             tc.reconciliation_interval_min,
+            tc.vacation_hvac_mode,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -59,6 +59,7 @@ class CycleEngine:
         broadcast: BroadcastFn | None = None,
         event_logger: EventLogger | None = None,
         get_enabled: Callable[[], bool] | None = None,
+        get_vacation_mode: Callable[[], bool] | None = None,
     ) -> None:
         self.thermostat_entity_id = thermostat_entity_id
         self._ha = ha
@@ -66,6 +67,7 @@ class CycleEngine:
         self._broadcast = broadcast
         self._logger = event_logger
         self._get_enabled = get_enabled
+        self._get_vacation_mode = get_vacation_mode
 
         self._state = CycleState.IDLE
         self._cycle_log: CycleLog | None = None
@@ -165,24 +167,8 @@ class CycleEngine:
         await expire_holdovers(conn)
         await db.clear_expired_overrides(conn)
 
-        # Determine which rooms should be active now
-        new_active = await get_active_rooms(conn, self.thermostat_entity_id)
-        new_active_map = {ar.room.id: ar for ar in new_active}
-
-        if not new_active_map:
-            if self._state != CycleState.IDLE:
-                await self._abort_cycle(conn, reason="no active rooms")
-            # IDLE reconciliation: ensure all zone vents are open even when no
-            # rooms are scheduled. Only runs when system is enabled.
-            if self._get_enabled is None or self._get_enabled():
-                await self._maybe_reconcile(conn)
-            return
-
-        # Check thermostat availability (safety check always runs, even when disabled).
-        # Transient outages (HA restarts, network blips) are tolerated — skip the tick
-        # and keep the cycle alive. Drift correction re-asserts the setpoint on recovery
-        # since _last_reconciled_at is not updated during skipped ticks. Cycle timeout
-        # is the outer bound for genuinely extended outages.
+        # Thermostat availability check — always runs, even when system is
+        # disabled or vacation mode is active. Transient outages are tolerated.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
             log.warning(
@@ -205,6 +191,29 @@ class CycleEngine:
                 await self._abort_cycle(conn, reason="system disabled")
             else:
                 log.debug("System disabled — skipping tick for %s", self.thermostat_entity_id)
+            return
+
+        # Vacation mode guard — abort any running cycle, then apply the
+        # configured hold strategy (range or single-setpoint) each tick.
+        # Checked before active-room evaluation so it fires even when no
+        # rooms have schedules (e.g. empty house during vacation).
+        if self._get_vacation_mode is not None and self._get_vacation_mode():
+            if self._state != CycleState.IDLE:
+                await self._abort_cycle(conn, reason="vacation mode")
+            await self._apply_vacation_hold(conn, thermo_state)
+            return
+
+        # Determine which rooms should be active now
+        new_active = await get_active_rooms(conn, self.thermostat_entity_id)
+        new_active_map = {ar.room.id: ar for ar in new_active}
+
+        if not new_active_map:
+            if self._state != CycleState.IDLE:
+                await self._abort_cycle(conn, reason="no active rooms")
+            # IDLE reconciliation: ensure all zone vents are open even when no
+            # rooms are scheduled. Only runs when system is enabled.
+            if self._get_enabled is None or self._get_enabled():
+                await self._maybe_reconcile(conn)
             return
 
         # Detect HVAC mode
@@ -2021,6 +2030,89 @@ class CycleEngine:
                     "rooms_skipped": skipped,
                 },
             )
+
+    async def _apply_vacation_hold(
+        self, conn: aiosqlite.Connection, thermo_state: dict | None
+    ) -> None:
+        """Apply the configured vacation hold strategy for this thermostat.
+
+        Called on every tick while vacation mode is active (after any running
+        cycle has been aborted). ``thermo_state`` is the already-fetched HA
+        state dict (may be None / unavailable — we bail out in that case).
+        """
+        if thermo_state is None or thermo_state.get("state") == "unavailable":
+            return
+
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+
+        if tc.vacation_hvac_mode == "range":
+            # Set thermostat to heat_cool/auto with low=min_setpoint, high=max_setpoint.
+            # Re-assert every tick so external changes are corrected.
+            try:
+                await self._ha.set_thermostat_temperature_range(
+                    self.thermostat_entity_id, tc.min_setpoint, tc.max_setpoint
+                )
+            except Exception as exc:
+                log.error(
+                    "Vacation hold: failed to set range for %s: %s",
+                    self.thermostat_entity_id,
+                    exc,
+                )
+            return
+
+        # Single-setpoint mode: turn off unless a bound is breached.
+        current_temp = thermo_state.get("attributes", {}).get("current_temperature")
+        current_hvac_mode = thermo_state.get("state", "off")
+
+        if current_temp is None:
+            if current_hvac_mode != "off":
+                try:
+                    await self._ha.set_thermostat_hvac_mode(self.thermostat_entity_id, "off")
+                except Exception as exc:
+                    log.error(
+                        "Vacation hold: failed to turn off %s: %s",
+                        self.thermostat_entity_id,
+                        exc,
+                    )
+            return
+
+        current_temp_f = float(current_temp)
+
+        if current_temp_f < tc.min_setpoint:
+            # Too cold — heat to the minimum bound.
+            try:
+                await self._ha.set_thermostat_temperature(
+                    self.thermostat_entity_id, tc.min_setpoint, hvac_mode="heat"
+                )
+            except Exception as exc:
+                log.error(
+                    "Vacation hold: failed to heat %s to min_setpoint: %s",
+                    self.thermostat_entity_id,
+                    exc,
+                )
+        elif current_temp_f > tc.max_setpoint:
+            # Too hot — cool to the maximum bound.
+            try:
+                await self._ha.set_thermostat_temperature(
+                    self.thermostat_entity_id, tc.max_setpoint, hvac_mode="cool"
+                )
+            except Exception as exc:
+                log.error(
+                    "Vacation hold: failed to cool %s to max_setpoint: %s",
+                    self.thermostat_entity_id,
+                    exc,
+                )
+        else:
+            # Temperature is within the safe band — ensure HVAC is off.
+            if current_hvac_mode != "off":
+                try:
+                    await self._ha.set_thermostat_hvac_mode(self.thermostat_entity_id, "off")
+                except Exception as exc:
+                    log.error(
+                        "Vacation hold: failed to turn off %s: %s",
+                        self.thermostat_entity_id,
+                        exc,
+                    )
 
     async def _maybe_broadcast(self) -> None:
         if self._broadcast:

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -206,6 +206,52 @@ class HAClient:
         )
         await self.call_service("climate", "set_temperature", service_data)
 
+    async def set_thermostat_hvac_mode(self, entity_id: str, mode: str) -> None:
+        if self.dev_mode:
+            log.info("[DEV] Would set %s hvac_mode → %s", entity_id, mode)
+            if self._dev_logger:
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
+                    f"Would set thermostat {entity_id} hvac_mode → {mode}",
+                    {"entity_id": entity_id, "hvac_mode": mode, "action": "set_hvac_mode"},
+                )
+            return
+        log.info("Setting %s hvac_mode → %s", entity_id, mode)
+        await self.call_service(
+            "climate", "set_hvac_mode", {"entity_id": entity_id, "hvac_mode": mode}
+        )
+
+    async def set_thermostat_temperature_range(
+        self, entity_id: str, low: float, high: float
+    ) -> None:
+        if self.dev_mode:
+            log.info("[DEV] Would set %s range → %.1f–%.1f°F", entity_id, low, high)
+            if self._dev_logger:
+                await self._dev_logger.log(
+                    "info",
+                    "dev",
+                    f"Would set thermostat {entity_id} range → {low:.1f}–{high:.1f}°F",
+                    {
+                        "entity_id": entity_id,
+                        "target_temp_low": low,
+                        "target_temp_high": high,
+                        "action": "set_temperature_range",
+                    },
+                )
+            return
+        log.info("Setting %s range → %.1f–%.1f°F", entity_id, low, high)
+        await self.call_service(
+            "climate",
+            "set_temperature",
+            {
+                "entity_id": entity_id,
+                "hvac_mode": "heat_cool",
+                "target_temp_low": low,
+                "target_temp_high": high,
+            },
+        )
+
     async def open_cover(self, entity_id: str) -> None:
         if self.dev_mode:
             msg = f"[DEV] Would open vent {entity_id}"

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -138,6 +138,10 @@ class ThermostatConfig:
     # intended state and corrects external changes (e.g. Flair app, manual HA overrides).
     # 0 = disabled. Should not exceed cycle_timeout_hours * 60.
     reconciliation_interval_min: int = 0
+    # How to hold the thermostat during vacation mode:
+    # "range"   → set heat_cool/auto mode with low=min_setpoint, high=max_setpoint
+    # "single"  → turn off; re-engage heat/cool when a bound is breached
+    vacation_hvac_mode: str = "single"
 
 
 @dataclass

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -265,7 +265,9 @@ class Scheduler:
                 "system",
                 f"Vacation mode {'enabled until ' + return_at.isoformat() if enabled and return_at else 'disabled'}",
             )
-        await self._reset_and_reevaluate(reason=f"vacation mode {'enabled' if enabled else 'disabled'}")
+        await self._reset_and_reevaluate(
+            reason=f"vacation mode {'enabled' if enabled else 'disabled'}"
+        )
         if self._broadcast:
             await self._broadcast(
                 "vacation_mode_changed",

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Callable, Coroutine
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -49,6 +49,8 @@ class Scheduler:
         self._dev_mode: bool = False
         self._active_unit: str = "F"
         self._unit_override: str = ""  # non-empty when locked by env var / config
+        self._vacation_mode: bool = False
+        self._vacation_return_at: datetime | None = None
 
     # ------------------------------------------------------------------
     # Startup / shutdown
@@ -64,6 +66,10 @@ class Scheduler:
         self._system_enabled = val == "1"
         dev_val = await db.get_system_setting(self._db_conn, "developer_mode", "0")
         self._dev_mode = dev_val == "1"
+        vac_val = await db.get_system_setting(self._db_conn, "vacation_mode_enabled", "0")
+        self._vacation_mode = vac_val == "1"
+        vac_return = await db.get_system_setting(self._db_conn, "vacation_mode_return_at", "")
+        self._vacation_return_at = datetime.fromisoformat(vac_return) if vac_return else None
 
         # Temperature unit: env var / add-on config wins; otherwise restore last-known
         self._unit_override = os.environ.get("TEMPERATURE_UNIT", "").upper()
@@ -162,6 +168,10 @@ class Scheduler:
         self._system_enabled = val == "1"
         dev_val = await db.get_system_setting(self._db_conn, "developer_mode", "0")
         self._dev_mode = dev_val == "1"
+        vac_val = await db.get_system_setting(self._db_conn, "vacation_mode_enabled", "0")
+        self._vacation_mode = vac_val == "1"
+        vac_return = await db.get_system_setting(self._db_conn, "vacation_mode_return_at", "")
+        self._vacation_return_at = datetime.fromisoformat(vac_return) if vac_return else None
         if self._unit_override not in ("F", "C"):
             self._active_unit = await db.get_system_setting(self._db_conn, "temperature_unit", "F")
         self._ha.dev_mode = self._dev_mode
@@ -228,6 +238,49 @@ class Scheduler:
     async def ack_unit_change(self) -> None:
         """Clear the unit-change acknowledgement flag."""
         await db.set_system_setting(self._db_conn, "unit_change_ack_required", "0")
+
+    # ------------------------------------------------------------------
+    # Vacation mode
+    # ------------------------------------------------------------------
+
+    def get_vacation_mode(self) -> bool:
+        return self._vacation_mode
+
+    def get_vacation_return_at(self) -> datetime | None:
+        return self._vacation_return_at
+
+    async def set_vacation_mode(self, enabled: bool, return_at: datetime | None = None) -> None:
+        self._vacation_mode = enabled
+        self._vacation_return_at = return_at if enabled else None
+        await db.set_system_setting(self._db_conn, "vacation_mode_enabled", "1" if enabled else "0")
+        await db.set_system_setting(
+            self._db_conn,
+            "vacation_mode_return_at",
+            return_at.isoformat() if (enabled and return_at) else "",
+        )
+        log.info("Vacation mode %s", "enabled" if enabled else "disabled")
+        if self._event_logger:
+            await self._event_logger.log(
+                "info",
+                "system",
+                f"Vacation mode {'enabled until ' + return_at.isoformat() if enabled and return_at else 'disabled'}",
+            )
+        await self._reset_and_reevaluate(reason=f"vacation mode {'enabled' if enabled else 'disabled'}")
+        if self._broadcast:
+            await self._broadcast(
+                "vacation_mode_changed",
+                {
+                    "enabled": enabled,
+                    "return_at": return_at.isoformat() if (enabled and return_at) else None,
+                },
+            )
+
+    async def _check_vacation_expiry(self) -> None:
+        if not self._vacation_mode:
+            return
+        if self._vacation_return_at and datetime.now(UTC) >= self._vacation_return_at:
+            log.info("Vacation mode expired — resuming normal scheduling")
+            await self.set_vacation_mode(False)
 
     async def _startup_resolve_unit(self) -> None:
         """Background task: wait for HA to connect, then persist the detected unit."""
@@ -326,6 +379,7 @@ class Scheduler:
                     event_logger=self._event_logger,
                     # Engine runs when system is enabled OR dev mode is on
                     get_enabled=lambda: self._system_enabled or self._dev_mode,
+                    get_vacation_mode=lambda: self._vacation_mode,
                 )
                 self._engines[tid] = engine
                 log.info("CycleEngine created for %s", tid)
@@ -419,6 +473,7 @@ class Scheduler:
     # ------------------------------------------------------------------
 
     async def _tick_all(self) -> None:
+        await self._check_vacation_expiry()
         await self._check_unit_change()
         await self._sync_engines()
         tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]

--- a/smart_vent/backend/tests/integration/fake_ha.py
+++ b/smart_vent/backend/tests/integration/fake_ha.py
@@ -161,6 +161,49 @@ class FakeHomeAssistant:
             "attributes": attrs,
         }
 
+    async def set_thermostat_hvac_mode(self, entity_id: str, mode: str) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would set thermostat {entity_id} hvac_mode → {mode}",
+                {"entity_id": entity_id, "hvac_mode": mode, "action": "set_hvac_mode"},
+            )
+            return
+        self.calls.append(
+            ServiceCall(domain="climate", service="set_hvac_mode", data={"entity_id": entity_id, "hvac_mode": mode})
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": mode,
+            "attributes": dict(cur.get("attributes") or {}),
+        }
+
+    async def set_thermostat_temperature_range(
+        self, entity_id: str, low: float, high: float
+    ) -> None:
+        if self.dev_mode:
+            await self._dev_log(
+                f"Would set thermostat {entity_id} range → {low:.1f}–{high:.1f}°F",
+                {"entity_id": entity_id, "target_temp_low": low, "target_temp_high": high, "action": "set_temperature_range"},
+            )
+            return
+        self.calls.append(
+            ServiceCall(
+                domain="climate",
+                service="set_temperature",
+                data={"entity_id": entity_id, "hvac_mode": "heat_cool", "target_temp_low": low, "target_temp_high": high},
+            )
+        )
+        cur = self._state.get(entity_id, {"attributes": {}})
+        attrs = dict(cur.get("attributes") or {})
+        attrs["target_temp_low"] = low
+        attrs["target_temp_high"] = high
+        self._state[entity_id] = {
+            "entity_id": entity_id,
+            "state": "heat_cool",
+            "attributes": attrs,
+        }
+
     async def open_cover(self, entity_id: str) -> None:
         if self.dev_mode:
             await self._dev_log(

--- a/smart_vent/backend/tests/integration/fake_ha.py
+++ b/smart_vent/backend/tests/integration/fake_ha.py
@@ -169,7 +169,11 @@ class FakeHomeAssistant:
             )
             return
         self.calls.append(
-            ServiceCall(domain="climate", service="set_hvac_mode", data={"entity_id": entity_id, "hvac_mode": mode})
+            ServiceCall(
+                domain="climate",
+                service="set_hvac_mode",
+                data={"entity_id": entity_id, "hvac_mode": mode},
+            )
         )
         cur = self._state.get(entity_id, {"attributes": {}})
         self._state[entity_id] = {
@@ -184,14 +188,24 @@ class FakeHomeAssistant:
         if self.dev_mode:
             await self._dev_log(
                 f"Would set thermostat {entity_id} range → {low:.1f}–{high:.1f}°F",
-                {"entity_id": entity_id, "target_temp_low": low, "target_temp_high": high, "action": "set_temperature_range"},
+                {
+                    "entity_id": entity_id,
+                    "target_temp_low": low,
+                    "target_temp_high": high,
+                    "action": "set_temperature_range",
+                },
             )
             return
         self.calls.append(
             ServiceCall(
                 domain="climate",
                 service="set_temperature",
-                data={"entity_id": entity_id, "hvac_mode": "heat_cool", "target_temp_low": low, "target_temp_high": high},
+                data={
+                    "entity_id": entity_id,
+                    "hvac_mode": "heat_cool",
+                    "target_temp_low": low,
+                    "target_temp_high": high,
+                },
             )
         )
         cur = self._state.get(entity_id, {"attributes": {}})

--- a/smart_vent/backend/tests/integration/test_vacation_mode_api.py
+++ b/smart_vent/backend/tests/integration/test_vacation_mode_api.py
@@ -1,0 +1,196 @@
+"""
+Integration tests for vacation mode API endpoints.
+
+POST   /api/settings/vacation-mode  → enable
+DELETE /api/settings/vacation-mode  → disable
+GET    /api/settings/vacation-mode  → status
+GET    /api/settings               → includes vacation_mode key
+PUT    /api/thermostats/{id}        → persists vacation_hvac_mode
+POST   /api/thermostats/{id}/test-vacation → sends range command
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from aiohttp.test_utils import TestClient
+
+from backend import db
+from backend.models import Room, ThermostatConfig
+
+from .fake_ha import FakeHomeAssistant
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+THERMO = "climate.upstairs"
+
+
+async def _seed_thermo(client: TestClient) -> None:
+    conn = client.app["scheduler"]._db_conn
+    tc = ThermostatConfig(
+        thermostat_entity_id=THERMO,
+        name="Upstairs",
+        min_setpoint=62.0,
+        max_setpoint=80.0,
+    )
+    await db.upsert_thermostat_config(conn, tc)
+    room = Room(id="r1", name="Living Room", thermostat_entity_id=THERMO)
+    await db.upsert_room(conn, room)
+    await client.app["scheduler"].refresh_engines()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings includes vacation_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_settings_includes_vacation_mode(client: TestClient):
+    resp = await client.get("/api/settings")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "vacation_mode" in data
+    assert data["vacation_mode"]["enabled"] is False
+    assert data["vacation_mode"]["return_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/settings/vacation-mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_vacation_mode_default_off(client: TestClient):
+    resp = await client.get("/api/settings/vacation-mode")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["enabled"] is False
+    assert data["return_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings/vacation-mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_vacation_mode(client: TestClient):
+    return_at = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    resp = await client.post(
+        "/api/settings/vacation-mode",
+        json={"return_at": return_at},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["enabled"] is True
+    assert data["return_at"] is not None
+
+    # Confirm scheduler reflects it
+    assert client.app["scheduler"].get_vacation_mode() is True
+
+
+@pytest.mark.asyncio
+async def test_enable_vacation_mode_missing_return_at(client: TestClient):
+    resp = await client.post("/api/settings/vacation-mode", json={})
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_enable_vacation_mode_past_return_at(client: TestClient):
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    resp = await client.post("/api/settings/vacation-mode", json={"return_at": past})
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_enable_vacation_mode_invalid_return_at(client: TestClient):
+    resp = await client.post("/api/settings/vacation-mode", json={"return_at": "not-a-date"})
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/settings/vacation-mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disable_vacation_mode(client: TestClient):
+    # First enable it
+    return_at = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    await client.post("/api/settings/vacation-mode", json={"return_at": return_at})
+    assert client.app["scheduler"].get_vacation_mode() is True
+
+    # Then disable
+    resp = await client.delete("/api/settings/vacation-mode")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["enabled"] is False
+    assert data["return_at"] is None
+    assert client.app["scheduler"].get_vacation_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/thermostats — vacation_hvac_mode field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thermostat_put_vacation_hvac_mode_range(client: TestClient):
+    await _seed_thermo(client)
+    resp = await client.put(
+        f"/api/thermostats/{THERMO}",
+        json={"vacation_hvac_mode": "range"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["vacation_hvac_mode"] == "range"
+
+    # Confirm DB
+    conn = client.app["scheduler"]._db_conn
+    tc = await db.get_thermostat_config(conn, THERMO)
+    assert tc.vacation_hvac_mode == "range"
+
+
+@pytest.mark.asyncio
+async def test_thermostat_put_vacation_hvac_mode_invalid(client: TestClient):
+    await _seed_thermo(client)
+    resp = await client.put(
+        f"/api/thermostats/{THERMO}",
+        json={"vacation_hvac_mode": "banana"},
+    )
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/thermostats/{id}/test-vacation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_vacation_sends_range_command(client: TestClient, fake_ha: FakeHomeAssistant):
+    await _seed_thermo(client)
+    fake_ha.seed_state(
+        THERMO,
+        "heat",
+        {"current_temperature": 72.0, "temperature": 72.0, "hvac_action": "idle"},
+    )
+
+    resp = await client.post(f"/api/thermostats/{THERMO}/test-vacation")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["ok"] is True
+    assert data["min_setpoint"] == 62.0
+    assert data["max_setpoint"] == 80.0
+
+    # FakeHA should have received the range call
+    range_calls = [
+        c for c in fake_ha.calls
+        if c.domain == "climate" and c.service == "set_temperature" and "target_temp_low" in c.data
+    ]
+    assert len(range_calls) == 1
+    assert range_calls[0].data["target_temp_low"] == 62.0
+    assert range_calls[0].data["target_temp_high"] == 80.0

--- a/smart_vent/backend/tests/integration/test_vacation_mode_api.py
+++ b/smart_vent/backend/tests/integration/test_vacation_mode_api.py
@@ -21,7 +21,6 @@ from backend.models import Room, ThermostatConfig
 
 from .fake_ha import FakeHomeAssistant
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -188,7 +187,8 @@ async def test_test_vacation_sends_range_command(client: TestClient, fake_ha: Fa
 
     # FakeHA should have received the range call
     range_calls = [
-        c for c in fake_ha.calls
+        c
+        for c in fake_ha.calls
         if c.domain == "climate" and c.service == "set_temperature" and "target_temp_low" in c.data
     ]
     assert len(range_calls) == 1

--- a/smart_vent/backend/tests/test_vacation_mode.py
+++ b/smart_vent/backend/tests/test_vacation_mode.py
@@ -10,7 +10,6 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -18,10 +17,9 @@ import aiosqlite
 import pytest
 
 from backend import db
-from backend.engine.cycle_engine import CycleEngine, CycleState
+from backend.engine.cycle_engine import CycleEngine
 from backend.models import Room, ThermostatConfig
 from backend.scheduler import Scheduler
-
 
 # ---------------------------------------------------------------------------
 # Helpers (shared with test_scheduler.py pattern)
@@ -342,7 +340,9 @@ async def test_engine_vacation_mode_already_off_no_redundant_call():
 @pytest.mark.asyncio
 async def test_engine_vacation_mode_celsius_single_below_min():
     """Vacation hold always uses stored °F values regardless of unit."""
-    ha = _make_ha(hvac_mode="off", current_temp=12.0)  # 12°C raw from HA (already converted to °F by ha_client)
+    ha = _make_ha(
+        hvac_mode="off", current_temp=12.0
+    )  # 12°C raw from HA (already converted to °F by ha_client)
     # Simulate: current_temperature is returned by HA in °F after normalisation
     ha.get_state.return_value = {
         "state": "off",

--- a/smart_vent/backend/tests/test_vacation_mode.py
+++ b/smart_vent/backend/tests/test_vacation_mode.py
@@ -1,0 +1,370 @@
+"""
+Tests for vacation mode.
+
+Covers:
+  - Scheduler: load/persist vacation mode, auto-expiry on tick
+  - Cycle engine: vacation mode guard (abort + hold), range vs single-setpoint
+  - API endpoints: GET/POST/DELETE /api/settings/vacation-mode
+  - Thermostat PUT: vacation_hvac_mode field persisted
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.engine.cycle_engine import CycleEngine, CycleState
+from backend.models import Room, ThermostatConfig
+from backend.scheduler import Scheduler
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with test_scheduler.py pattern)
+# ---------------------------------------------------------------------------
+
+THERMO_A = "climate.thermo_a"
+
+
+def _make_ha(hvac_mode: str = "heat", current_temp: float = 72.0) -> MagicMock:
+    ha = MagicMock()
+    ha.subscribe_all = MagicMock()
+    ha.get_state.return_value = {
+        "state": hvac_mode,
+        "attributes": {
+            "current_temperature": current_temp,
+            "temperature": 72.0,
+            "hvac_action": "idle",
+        },
+    }
+    ha.get_numeric_state.return_value = None
+    ha.set_thermostat_temperature = AsyncMock()
+    ha.set_thermostat_hvac_mode = AsyncMock()
+    ha.set_thermostat_temperature_range = AsyncMock()
+    ha.open_cover = AsyncMock()
+    ha.close_cover = AsyncMock()
+    ha.dev_mode = False
+    ha._dev_logger = None
+    return ha
+
+
+async def _setup_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _insert_room(conn: aiosqlite.Connection, room_id: str, thermo: str) -> Room:
+    room = Room(id=room_id, name="Room", thermostat_entity_id=thermo)
+    await db.upsert_room(conn, room)
+    return room
+
+
+# ---------------------------------------------------------------------------
+# DB migration: vacation_hvac_mode column
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thermostat_config_vacation_hvac_mode_default():
+    conn = await _setup_db()
+    try:
+        tc = ThermostatConfig(thermostat_entity_id=THERMO_A)
+        await db.upsert_thermostat_config(conn, tc)
+        loaded = await db.get_thermostat_config(conn, THERMO_A)
+        assert loaded.vacation_hvac_mode == "single"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_thermostat_config_vacation_hvac_mode_range():
+    conn = await _setup_db()
+    try:
+        tc = ThermostatConfig(thermostat_entity_id=THERMO_A, vacation_hvac_mode="range")
+        await db.upsert_thermostat_config(conn, tc)
+        loaded = await db.get_thermostat_config(conn, THERMO_A)
+        assert loaded.vacation_hvac_mode == "range"
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Scheduler: vacation mode persistence and auto-expiry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_vacation_mode_set_and_get():
+    ha = _make_ha()
+    sched = Scheduler(ha=ha, db_path=":memory:")
+    sched._db_conn = await _setup_db()
+    sched._broadcast = None
+    sched._event_logger = None
+
+    assert not sched.get_vacation_mode()
+    return_at = datetime.now(UTC) + timedelta(days=7)
+    await sched.set_vacation_mode(True, return_at)
+    assert sched.get_vacation_mode()
+    assert sched.get_vacation_return_at() == return_at
+
+    # Persisted: reload from DB
+    val = await db.get_system_setting(sched._db_conn, "vacation_mode_enabled", "0")
+    assert val == "1"
+
+    await sched._db_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_vacation_mode_disable():
+    ha = _make_ha()
+    sched = Scheduler(ha=ha, db_path=":memory:")
+    sched._db_conn = await _setup_db()
+    sched._broadcast = None
+    sched._event_logger = None
+
+    return_at = datetime.now(UTC) + timedelta(days=7)
+    await sched.set_vacation_mode(True, return_at)
+    await sched.set_vacation_mode(False)
+
+    assert not sched.get_vacation_mode()
+    assert sched.get_vacation_return_at() is None
+    val = await db.get_system_setting(sched._db_conn, "vacation_mode_enabled", "0")
+    assert val == "0"
+
+    await sched._db_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_vacation_mode_auto_expiry():
+    """Expiry in the past → _check_vacation_expiry clears vacation mode."""
+    ha = _make_ha()
+    sched = Scheduler(ha=ha, db_path=":memory:")
+    sched._db_conn = await _setup_db()
+    sched._broadcast = None
+    sched._event_logger = None
+    sched._engines = {}
+
+    # Set a return_at in the past
+    past = datetime.now(UTC) - timedelta(seconds=1)
+    sched._vacation_mode = True
+    sched._vacation_return_at = past
+    await db.set_system_setting(sched._db_conn, "vacation_mode_enabled", "1")
+    await db.set_system_setting(sched._db_conn, "vacation_mode_return_at", past.isoformat())
+
+    await sched._check_vacation_expiry()
+
+    assert not sched.get_vacation_mode()
+    assert sched.get_vacation_return_at() is None
+
+    await sched._db_conn.close()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_vacation_mode_not_expired_yet():
+    """Future return_at → expiry check does NOT disable vacation mode."""
+    ha = _make_ha()
+    sched = Scheduler(ha=ha, db_path=":memory:")
+    sched._db_conn = await _setup_db()
+    sched._broadcast = None
+    sched._event_logger = None
+    sched._engines = {}
+
+    future = datetime.now(UTC) + timedelta(hours=48)
+    sched._vacation_mode = True
+    sched._vacation_return_at = future
+
+    await sched._check_vacation_expiry()
+    assert sched.get_vacation_mode()
+
+    await sched._db_conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cycle engine: vacation mode guard
+# ---------------------------------------------------------------------------
+
+
+def _make_engine(
+    ha: MagicMock,
+    vacation_mode: bool = False,
+    system_enabled: bool = True,
+) -> CycleEngine:
+    vent_ctrl = MagicMock()
+    vent_ctrl.open_all = AsyncMock()
+    vent_ctrl.get_vent_states = MagicMock(return_value={})
+    return CycleEngine(
+        thermostat_entity_id=THERMO_A,
+        ha=ha,
+        vent_ctrl=vent_ctrl,
+        get_enabled=lambda: system_enabled,
+        get_vacation_mode=lambda: vacation_mode,
+    )
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_range_sets_heat_cool():
+    """Range mode: set_thermostat_temperature_range called with min/max."""
+    ha = _make_ha(hvac_mode="heat", current_temp=72.0)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="range",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_temperature_range.assert_called_once_with(THERMO_A, 62.0, 80.0)
+        ha.set_thermostat_hvac_mode.assert_not_called()
+        ha.set_thermostat_temperature.assert_not_called()
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_single_within_range_turns_off():
+    """Single mode, temp within bounds: HVAC turned off."""
+    ha = _make_ha(hvac_mode="heat", current_temp=72.0)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_hvac_mode.assert_called_once_with(THERMO_A, "off")
+        ha.set_thermostat_temperature.assert_not_called()
+        ha.set_thermostat_temperature_range.assert_not_called()
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_single_below_min_heats():
+    """Single mode, temp below min_setpoint: heat to min_setpoint."""
+    ha = _make_ha(hvac_mode="off", current_temp=58.0)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_temperature.assert_called_once_with(THERMO_A, 62.0, hvac_mode="heat")
+        ha.set_thermostat_hvac_mode.assert_not_called()
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_single_above_max_cools():
+    """Single mode, temp above max_setpoint: cool to max_setpoint."""
+    ha = _make_ha(hvac_mode="off", current_temp=85.0)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_temperature.assert_called_once_with(THERMO_A, 80.0, hvac_mode="cool")
+        ha.set_thermostat_hvac_mode.assert_not_called()
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_already_off_no_redundant_call():
+    """Single mode, temp within range and HVAC already off: no call made."""
+    ha = _make_ha(hvac_mode="off", current_temp=72.0)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_hvac_mode.assert_not_called()
+        ha.set_thermostat_temperature.assert_not_called()
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Celsius mode: setback temps stored in °F, displayed correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_celsius_single_below_min():
+    """Vacation hold always uses stored °F values regardless of unit."""
+    ha = _make_ha(hvac_mode="off", current_temp=12.0)  # 12°C raw from HA (already converted to °F by ha_client)
+    # Simulate: current_temperature is returned by HA in °F after normalisation
+    ha.get_state.return_value = {
+        "state": "off",
+        "attributes": {"current_temperature": 53.6, "temperature": 53.6, "hvac_action": "idle"},
+    }
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        # min_setpoint stored in °F (62°F ≈ 16.7°C)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        # Should heat to 62°F (stored in °F regardless of unit)
+        ha.set_thermostat_temperature.assert_called_once_with(THERMO_A, 62.0, hvac_mode="heat")
+    finally:
+        await conn.close()

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -13,6 +13,7 @@ describe("App Root", () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "F",
       unit_change_ack_required: false,
+      vacation_mode: { enabled: false, return_at: null },
     });
     vi.mocked(api.connectWS).mockReturnValue(() => {});
     vi.mocked(api.getStatus).mockResolvedValue([]);

--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -18,6 +18,7 @@ describe("App Root", () => {
     vi.mocked(api.getStatus).mockResolvedValue([]);
     vi.mocked(api.getRooms).mockResolvedValue([]);
     vi.mocked(api.getThermostats).mockResolvedValue([]);
+    vi.mocked(api.getVacationMode).mockResolvedValue({ enabled: false, return_at: null });
   });
 
   it("renders the app and navigates", async () => {

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import {
   useDevMode,
 } from "./contexts";
 import UnitChangeBanner from "./components/UnitChangeBanner";
+import VacationModeBanner from "./components/VacationModeBanner";
 
 function AppRoot({ children }: { children: React.ReactNode }) {
   const [enabled, setEnabled] = useState<boolean>(true);
@@ -320,6 +321,7 @@ export default function App() {
     <AppRoot>
       <Nav />
       <UnitChangeBanner />
+      <VacationModeBanner />
       <main className="main">
         <Routes>
           <Route path="/" element={<Dashboard />} />

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -66,6 +66,15 @@ export interface ThermostatConfig {
   // 0 = disabled. How often (minutes) the engine re-checks vent/thermostat state
   // against actual HA state and corrects external changes.
   reconciliation_interval_min: number;
+  // How to hold the thermostat during vacation mode.
+  // "range"  → heat_cool/auto with low=min_setpoint, high=max_setpoint
+  // "single" → turn off; correct when a bound is breached
+  vacation_hvac_mode: "range" | "single";
+}
+
+export interface VacationMode {
+  enabled: boolean;
+  return_at: string | null; // ISO-8601 UTC string
 }
 
 export interface ZoneStatus {
@@ -686,12 +695,27 @@ export const triggerMonthlyRollup = (months_back?: number) =>
 export interface AppSettings {
   temperature_unit: "F" | "C";
   unit_change_ack_required: boolean;
+  vacation_mode: VacationMode;
 }
 
 export const getSettings = () => api<AppSettings>("/api/settings");
 
 export const ackUnitChange = () =>
   api<{ ok: true }>("/api/settings/ack-unit-change", { method: "POST" });
+
+export const getVacationMode = () => api<VacationMode>("/api/settings/vacation-mode");
+export const enableVacationMode = (return_at: string) =>
+  api<VacationMode>("/api/settings/vacation-mode", {
+    method: "POST",
+    body: JSON.stringify({ return_at }),
+  });
+export const disableVacationMode = () =>
+  api<VacationMode>("/api/settings/vacation-mode", { method: "DELETE" });
+export const testVacationMode = (entity_id: string) =>
+  api<{ ok: true; min_setpoint: number; max_setpoint: number; thermostat_state: unknown }>(
+    `/api/thermostats/${encodeURIComponent(entity_id)}/test-vacation`,
+    { method: "POST" }
+  );
 
 export const restartApp = () => api<{ restarting: true }>("/api/restart", { method: "POST" });
 

--- a/smart_vent/frontend/src/components/UnitChangeBanner.test.tsx
+++ b/smart_vent/frontend/src/components/UnitChangeBanner.test.tsx
@@ -14,6 +14,7 @@ describe("UnitChangeBanner", () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "F",
       unit_change_ack_required: false,
+      vacation_mode: { enabled: false, return_at: null },
     });
     const { container } = render(<UnitChangeBanner />);
     await waitFor(() => expect(api.getSettings).toHaveBeenCalled());
@@ -24,6 +25,7 @@ describe("UnitChangeBanner", () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "C",
       unit_change_ack_required: true,
+      vacation_mode: { enabled: false, return_at: null },
     });
     render(<UnitChangeBanner />);
     expect(await screen.findByText(/temperature unit changed to °C/i)).toBeInTheDocument();
@@ -36,6 +38,7 @@ describe("UnitChangeBanner", () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "C",
       unit_change_ack_required: true,
+      vacation_mode: { enabled: false, return_at: null },
     });
     vi.mocked(api.restartApp).mockResolvedValue({ restarting: true });
     render(<UnitChangeBanner />);
@@ -47,6 +50,7 @@ describe("UnitChangeBanner", () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "C",
       unit_change_ack_required: true,
+      vacation_mode: { enabled: false, return_at: null },
     });
     vi.mocked(api.ackUnitChange).mockResolvedValue({ ok: true });
     const { container } = render(<UnitChangeBanner />);

--- a/smart_vent/frontend/src/components/VacationModeBanner.test.tsx
+++ b/smart_vent/frontend/src/components/VacationModeBanner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VacationModeBanner from "./VacationModeBanner";
+import * as api from "../api";
+
+vi.mock("../api");
+
+describe("VacationModeBanner", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders nothing when vacation mode is off", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue({
+      temperature_unit: "F",
+      unit_change_ack_required: false,
+      vacation_mode: { enabled: false, return_at: null },
+    });
+    const { container } = render(<VacationModeBanner />);
+    await waitFor(() => expect(api.getSettings).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders banner when vacation mode is on", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue({
+      temperature_unit: "F",
+      unit_change_ack_required: false,
+      vacation_mode: { enabled: true, return_at: "2026-12-25T10:00:00.000Z" },
+    });
+    render(<VacationModeBanner />);
+    expect(await screen.findByText(/Vacation mode active/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manage/i)).toBeInTheDocument();
+  });
+
+  it("opens modal when banner is clicked", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue({
+      temperature_unit: "F",
+      unit_change_ack_required: false,
+      vacation_mode: { enabled: true, return_at: "2026-12-25T10:00:00.000Z" },
+    });
+    render(<VacationModeBanner />);
+    const banner = await screen.findByRole("alert");
+    fireEvent.click(banner);
+    expect(screen.getAllByText(/Vacation mode active/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/End vacation mode early/i)).toBeInTheDocument();
+  });
+
+  it("opens modal when Manage button is clicked", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue({
+      temperature_unit: "F",
+      unit_change_ack_required: false,
+      vacation_mode: { enabled: true, return_at: "2026-12-25T10:00:00.000Z" },
+    });
+    render(<VacationModeBanner />);
+    fireEvent.click(await screen.findByText(/Manage/i));
+    expect(screen.getAllByText(/Vacation mode active/i).length).toBeGreaterThan(0);
+  });
+});

--- a/smart_vent/frontend/src/components/VacationModeBanner.tsx
+++ b/smart_vent/frontend/src/components/VacationModeBanner.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { getSettings, type VacationMode } from "../api";
+import VacationModeModal from "./VacationModeModal";
+
+function formatReturnAt(isoStr: string | null): string {
+  if (!isoStr) return "";
+  try {
+    return new Date(isoStr).toLocaleString();
+  } catch {
+    return isoStr;
+  }
+}
+
+export default function VacationModeBanner() {
+  const [vacationMode, setVacationMode] = useState<VacationMode | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    getSettings()
+      .then((s) => setVacationMode(s.vacation_mode))
+      .catch(() => {});
+  }, []);
+
+  if (!vacationMode?.enabled) return null;
+
+  return (
+    <>
+      <div
+        className="vacation-mode-banner"
+        role="alert"
+        onClick={() => setShowModal(true)}
+        style={{ cursor: "pointer" }}
+      >
+        <div className="vacation-mode-banner-text">
+          <strong>Vacation mode active</strong> — schedules and presence triggers are paused.
+          Returning {formatReturnAt(vacationMode.return_at)}.
+        </div>
+        <div className="vacation-mode-banner-actions">
+          <button
+            className="btn-secondary"
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowModal(true);
+            }}
+          >
+            Manage
+          </button>
+        </div>
+      </div>
+
+      {showModal && (
+        <VacationModeModal
+          current={vacationMode}
+          onClose={() => setShowModal(false)}
+          onChanged={(updated) => {
+            setVacationMode(updated);
+            setShowModal(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/smart_vent/frontend/src/components/VacationModeModal.test.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import VacationModeModal from "./VacationModeModal";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const OFF: api.VacationMode = { enabled: false, return_at: null };
+const ON: api.VacationMode = { enabled: true, return_at: "2026-12-25T10:00:00.000Z" };
+
+describe("VacationModeModal — enable flow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows enable form when vacation mode is off", () => {
+    render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
+    expect(screen.getAllByText(/Enable vacation mode/i).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/Return date/i)).toBeInTheDocument();
+    expect(screen.getByText(/all room schedules/i)).toBeInTheDocument();
+  });
+
+  it("shows error when no date selected", async () => {
+    render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
+    const btn = screen.getAllByText(/Enable vacation mode/i).find(
+      (el) => el.tagName === "BUTTON"
+    )!;
+    fireEvent.click(btn);
+    expect(await screen.findByText(/choose a return date/i)).toBeInTheDocument();
+    expect(api.enableVacationMode).not.toHaveBeenCalled();
+  });
+
+  it("calls enableVacationMode and onChanged on valid submit", async () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString().slice(0, 16);
+    const updated: api.VacationMode = { enabled: true, return_at: new Date(future).toISOString() };
+    vi.mocked(api.enableVacationMode).mockResolvedValue(updated);
+
+    const onChanged = vi.fn();
+    const onClose = vi.fn();
+    render(<VacationModeModal current={OFF} onClose={onClose} onChanged={onChanged} />);
+
+    fireEvent.change(screen.getByLabelText(/Return date/i), { target: { value: future } });
+    const btn = screen.getAllByText(/Enable vacation mode/i).find(
+      (el) => el.tagName === "BUTTON"
+    )!;
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(api.enableVacationMode).toHaveBeenCalled());
+    expect(onChanged).toHaveBeenCalledWith(updated);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows error when past date selected", async () => {
+    render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
+    const past = new Date(Date.now() - 86_400_000).toISOString().slice(0, 16);
+    fireEvent.change(screen.getByLabelText(/Return date/i), { target: { value: past } });
+    const btn = screen.getAllByText(/Enable vacation mode/i).find(
+      (el) => el.tagName === "BUTTON"
+    )!;
+    fireEvent.click(btn);
+    expect(await screen.findByText(/in the future/i)).toBeInTheDocument();
+    expect(api.enableVacationMode).not.toHaveBeenCalled();
+  });
+});
+
+describe("VacationModeModal — dismiss flow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows active state info when vacation mode is on", () => {
+    render(<VacationModeModal current={ON} onClose={vi.fn()} onChanged={vi.fn()} />);
+    expect(screen.getByText(/Vacation mode active/i)).toBeInTheDocument();
+    expect(screen.getByText(/End vacation mode early/i)).toBeInTheDocument();
+  });
+
+  it("shows confirmation step before disabling", () => {
+    render(<VacationModeModal current={ON} onClose={vi.fn()} onChanged={vi.fn()} />);
+    fireEvent.click(screen.getByText(/End vacation mode early/i));
+    expect(screen.getByText(/End vacation mode\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/normal schedule control immediately/i)).toBeInTheDocument();
+    expect(screen.getByText(/Yes, end vacation mode/i)).toBeInTheDocument();
+    expect(screen.getByText(/Keep vacation mode/i)).toBeInTheDocument();
+  });
+
+  it("cancels back to info view on Keep vacation mode", () => {
+    render(<VacationModeModal current={ON} onClose={vi.fn()} onChanged={vi.fn()} />);
+    fireEvent.click(screen.getByText(/End vacation mode early/i));
+    fireEvent.click(screen.getByText(/Keep vacation mode/i));
+    expect(screen.getByText(/Vacation mode active/i)).toBeInTheDocument();
+  });
+
+  it("calls disableVacationMode and onChanged when confirmed", async () => {
+    const updated: api.VacationMode = { enabled: false, return_at: null };
+    vi.mocked(api.disableVacationMode).mockResolvedValue(updated);
+    const onChanged = vi.fn();
+    const onClose = vi.fn();
+
+    render(<VacationModeModal current={ON} onClose={onClose} onChanged={onChanged} />);
+    fireEvent.click(screen.getByText(/End vacation mode early/i));
+    fireEvent.click(screen.getByText(/Yes, end vacation mode/i));
+
+    await waitFor(() => expect(api.disableVacationMode).toHaveBeenCalled());
+    expect(onChanged).toHaveBeenCalledWith(updated);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/smart_vent/frontend/src/components/VacationModeModal.test.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.test.tsx
@@ -20,9 +20,7 @@ describe("VacationModeModal — enable flow", () => {
 
   it("shows error when no date selected", async () => {
     render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
-    const btn = screen.getAllByText(/Enable vacation mode/i).find(
-      (el) => el.tagName === "BUTTON"
-    )!;
+    const btn = screen.getAllByText(/Enable vacation mode/i).find((el) => el.tagName === "BUTTON")!;
     fireEvent.click(btn);
     expect(await screen.findByText(/choose a return date/i)).toBeInTheDocument();
     expect(api.enableVacationMode).not.toHaveBeenCalled();
@@ -38,9 +36,7 @@ describe("VacationModeModal — enable flow", () => {
     render(<VacationModeModal current={OFF} onClose={onClose} onChanged={onChanged} />);
 
     fireEvent.change(screen.getByLabelText(/Return date/i), { target: { value: future } });
-    const btn = screen.getAllByText(/Enable vacation mode/i).find(
-      (el) => el.tagName === "BUTTON"
-    )!;
+    const btn = screen.getAllByText(/Enable vacation mode/i).find((el) => el.tagName === "BUTTON")!;
     fireEvent.click(btn);
 
     await waitFor(() => expect(api.enableVacationMode).toHaveBeenCalled());
@@ -52,9 +48,7 @@ describe("VacationModeModal — enable flow", () => {
     render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
     const past = new Date(Date.now() - 86_400_000).toISOString().slice(0, 16);
     fireEvent.change(screen.getByLabelText(/Return date/i), { target: { value: past } });
-    const btn = screen.getAllByText(/Enable vacation mode/i).find(
-      (el) => el.tagName === "BUTTON"
-    )!;
+    const btn = screen.getAllByText(/Enable vacation mode/i).find((el) => el.tagName === "BUTTON")!;
     fireEvent.click(btn);
     expect(await screen.findByText(/in the future/i)).toBeInTheDocument();
     expect(api.enableVacationMode).not.toHaveBeenCalled();

--- a/smart_vent/frontend/src/components/VacationModeModal.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.tsx
@@ -127,8 +127,9 @@ export default function VacationModeModal({ current, onClose, onChanged }: Props
               <strong>normal scheduling resumes automatically</strong>.
             </p>
             <p style={{ marginBottom: "1.25rem", color: "var(--gray-600)", fontSize: ".9rem" }}>
-              Make sure each thermostat has a <em>Vacation HVAC mode</em> configured on the
-              Thermostats page so the system knows how to hold the temperature.
+              This applies to <strong>all thermostats</strong>. Each thermostat's hold strategy
+              (range or single setpoint) can be configured under{" "}
+              <em>Vacation mode hold strategy</em> on the Thermostats page.
             </p>
 
             <div className="form-group">

--- a/smart_vent/frontend/src/components/VacationModeModal.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.tsx
@@ -68,8 +68,8 @@ export default function VacationModeModal({ current, onClose, onChanged }: Props
             <>
               <div className="modal-title">End vacation mode?</div>
               <p style={{ marginBottom: "1rem" }}>
-                Your thermostats will return to <strong>normal schedule control immediately</strong>.
-                Any rooms with active schedules will resume within one minute.
+                Your thermostats will return to <strong>normal schedule control immediately</strong>
+                . Any rooms with active schedules will resume within one minute.
               </p>
               {error && (
                 <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
@@ -99,8 +99,8 @@ export default function VacationModeModal({ current, onClose, onChanged }: Props
                 configured safety limits.
               </p>
               <p style={{ marginBottom: "1rem", color: "var(--gray-600)", fontSize: ".9rem" }}>
-                Normal scheduling will resume automatically at your return date. You can also end
-                it early below.
+                Normal scheduling will resume automatically at your return date. You can also end it
+                early below.
               </p>
               <div className="modal-footer">
                 <button className="btn btn-secondary" onClick={onClose} disabled={busy}>

--- a/smart_vent/frontend/src/components/VacationModeModal.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { enableVacationMode, disableVacationMode, type VacationMode } from "../api";
+
+interface Props {
+  current: VacationMode;
+  onClose: () => void;
+  onChanged: (updated: VacationMode) => void;
+}
+
+function formatReturnAt(isoStr: string | null): string {
+  if (!isoStr) return "";
+  try {
+    return new Date(isoStr).toLocaleString();
+  } catch {
+    return isoStr;
+  }
+}
+
+export default function VacationModeModal({ current, onClose, onChanged }: Props) {
+  const [confirmDisable, setConfirmDisable] = useState(false);
+  const [returnAt, setReturnAt] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleEnable = async () => {
+    if (!returnAt) {
+      setError("Please choose a return date and time.");
+      return;
+    }
+    const dt = new Date(returnAt);
+    if (isNaN(dt.getTime()) || dt <= new Date()) {
+      setError("Return date must be in the future.");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      const updated = await enableVacationMode(dt.toISOString());
+      onChanged(updated);
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to enable vacation mode");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDisable = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      const updated = await disableVacationMode();
+      onChanged(updated);
+      onClose();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to disable vacation mode");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal">
+        {current.enabled ? (
+          /* ── Dismiss / cancel flow ── */
+          confirmDisable ? (
+            <>
+              <div className="modal-title">End vacation mode?</div>
+              <p style={{ marginBottom: "1rem" }}>
+                Your thermostats will return to <strong>normal schedule control immediately</strong>.
+                Any rooms with active schedules will resume within one minute.
+              </p>
+              {error && (
+                <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+                  {error}
+                </div>
+              )}
+              <div className="modal-footer">
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => setConfirmDisable(false)}
+                  disabled={busy}
+                >
+                  Keep vacation mode
+                </button>
+                <button className="btn btn-danger" onClick={handleDisable} disabled={busy}>
+                  {busy ? "Ending…" : "Yes, end vacation mode"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="modal-title">Vacation mode active</div>
+              <p style={{ marginBottom: "1rem" }}>
+                Vacation mode is <strong>active</strong> until{" "}
+                <strong>{formatReturnAt(current.return_at)}</strong>. All room schedules, presence
+                triggers, and overrides are paused. Each thermostat is being held within its
+                configured safety limits.
+              </p>
+              <p style={{ marginBottom: "1rem", color: "var(--gray-600)", fontSize: ".9rem" }}>
+                Normal scheduling will resume automatically at your return date. You can also end
+                it early below.
+              </p>
+              <div className="modal-footer">
+                <button className="btn btn-secondary" onClick={onClose} disabled={busy}>
+                  Close
+                </button>
+                <button
+                  className="btn btn-danger"
+                  onClick={() => setConfirmDisable(true)}
+                  disabled={busy}
+                >
+                  End vacation mode early
+                </button>
+              </div>
+            </>
+          )
+        ) : (
+          /* ── Enable flow ── */
+          <>
+            <div className="modal-title">Enable vacation mode</div>
+            <p style={{ marginBottom: "1rem" }}>
+              While vacation mode is active, <strong>all room schedules</strong>, presence triggers,
+              and temporary overrides are paused. Each thermostat will be held within its configured
+              minimum and maximum setpoint limits until the return date, then{" "}
+              <strong>normal scheduling resumes automatically</strong>.
+            </p>
+            <p style={{ marginBottom: "1.25rem", color: "var(--gray-600)", fontSize: ".9rem" }}>
+              Make sure each thermostat has a <em>Vacation HVAC mode</em> configured on the
+              Thermostats page so the system knows how to hold the temperature.
+            </p>
+
+            <div className="form-group">
+              <label className="form-label" htmlFor="vacation-return-at">
+                Return date &amp; time
+              </label>
+              <input
+                id="vacation-return-at"
+                className="form-control"
+                type="datetime-local"
+                value={returnAt}
+                onChange={(e) => setReturnAt(e.target.value)}
+                min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+              />
+              <div className="form-hint">
+                Vacation mode will end automatically at this local date and time and normal
+                scheduling will resume within one minute.
+              </div>
+            </div>
+
+            {error && (
+              <div className="badge badge-red" style={{ marginBottom: "1rem" }}>
+                {error}
+              </div>
+            )}
+
+            <div className="modal-footer">
+              <button className="btn btn-secondary" onClick={onClose} disabled={busy}>
+                Cancel
+              </button>
+              <button className="btn btn-primary" onClick={handleEnable} disabled={busy}>
+                {busy ? "Enabling…" : "Enable vacation mode"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -35,6 +35,7 @@ describe("Dashboard Page", () => {
     vi.clearAllMocks();
     vi.mocked(api.getStatus).mockResolvedValue(mockStatus);
     vi.mocked(api.connectWS).mockReturnValue(() => {});
+    vi.mocked(api.getVacationMode).mockResolvedValue({ enabled: false, return_at: null });
     vi.mocked(api.getRooms).mockResolvedValue([
       {
         id: "room-1",
@@ -60,6 +61,7 @@ describe("Dashboard Page", () => {
         overshoot_delta: 0.5,
         cycle_timeout_hours: 2,
         reconciliation_interval_min: 5,
+        vacation_hvac_mode: "single" as const,
       },
     ]);
   });
@@ -92,5 +94,23 @@ describe("Dashboard Page", () => {
     const refreshBtn = await screen.findByText(/Refresh/i);
     fireEvent.click(refreshBtn);
     expect(api.getStatus).toHaveBeenCalledTimes(2); // Initial + click
+  });
+
+  it("shows vacation mode active state and opens modal on button click", async () => {
+    vi.mocked(api.getVacationMode).mockResolvedValue({
+      enabled: true,
+      return_at: "2026-12-25T10:00:00.000Z",
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    expect(await screen.findByText(/Vacation mode active/i)).toBeInTheDocument();
+    expect(screen.getByText(/Schedules paused until/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Vacation mode active/i }));
+    expect(screen.getByText(/End vacation mode early/i)).toBeInTheDocument();
   });
 });

--- a/smart_vent/frontend/src/pages/Dashboard.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.tsx
@@ -3,12 +3,15 @@ import {
   getStatus,
   getRooms,
   getThermostats,
+  getVacationMode,
   connectWS,
   type ZoneStatus,
   type Room,
   type ThermostatConfig,
+  type VacationMode,
 } from "../api";
 import { useUnit } from "../contexts";
+import VacationModeModal from "../components/VacationModeModal";
 
 function modeColor(mode: string): string {
   if (mode === "cooling") return "blue";
@@ -159,12 +162,20 @@ export default function Dashboard() {
   const [thermostats, setThermostats] = useState<ThermostatConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+  const [vacationMode, setVacationMode] = useState<VacationMode>({ enabled: false, return_at: null });
+  const [showVacationModal, setShowVacationModal] = useState(false);
 
   const load = async () => {
-    const [z, r, tc] = await Promise.all([getStatus(), getRooms(), getThermostats()]);
+    const [z, r, tc, vm] = await Promise.all([
+      getStatus(),
+      getRooms(),
+      getThermostats(),
+      getVacationMode(),
+    ]);
     setZones(z);
     setRooms(r);
     setThermostats(tc);
+    setVacationMode(vm ?? { enabled: false, return_at: null });
     setLastUpdate(new Date());
     setLoading(false);
   };
@@ -205,6 +216,23 @@ export default function Dashboard() {
         </button>
       </div>
 
+      {/* Vacation mode button — sits above climate cards */}
+      <div style={{ marginBottom: "1rem" }}>
+        <button
+          className={`btn ${vacationMode.enabled ? "btn-warning" : "btn-secondary"}`}
+          onClick={() => setShowVacationModal(true)}
+          style={{ display: "flex", alignItems: "center", gap: ".5rem" }}
+        >
+          ✈ {vacationMode.enabled ? "Vacation mode active" : "Enable vacation mode"}
+        </button>
+        {vacationMode.enabled && vacationMode.return_at && (
+          <div className="form-hint" style={{ marginTop: ".4rem" }}>
+            Schedules paused until{" "}
+            {new Date(vacationMode.return_at).toLocaleString()}
+          </div>
+        )}
+      </div>
+
       {zones.length === 0 ? (
         <div className="card">
           <div className="empty-state">
@@ -225,6 +253,17 @@ export default function Dashboard() {
             />
           ))}
         </div>
+      )}
+
+      {showVacationModal && (
+        <VacationModeModal
+          current={vacationMode}
+          onClose={() => setShowVacationModal(false)}
+          onChanged={(updated) => {
+            setVacationMode(updated);
+            setShowVacationModal(false);
+          }}
+        />
       )}
     </div>
   );

--- a/smart_vent/frontend/src/pages/Dashboard.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.tsx
@@ -162,7 +162,10 @@ export default function Dashboard() {
   const [thermostats, setThermostats] = useState<ThermostatConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
-  const [vacationMode, setVacationMode] = useState<VacationMode>({ enabled: false, return_at: null });
+  const [vacationMode, setVacationMode] = useState<VacationMode>({
+    enabled: false,
+    return_at: null,
+  });
   const [showVacationModal, setShowVacationModal] = useState(false);
 
   const load = async () => {
@@ -227,8 +230,7 @@ export default function Dashboard() {
         </button>
         {vacationMode.enabled && vacationMode.return_at && (
           <div className="form-hint" style={{ marginTop: ".4rem" }}>
-            Schedules paused until{" "}
-            {new Date(vacationMode.return_at).toLocaleString()}
+            Schedules paused until {new Date(vacationMode.return_at).toLocaleString()}
           </div>
         )}
       </div>

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -39,6 +39,7 @@ describe("Metrics Page", () => {
         overshoot_delta: 0.5,
         cycle_timeout_hours: 2,
         reconciliation_interval_min: 5,
+        vacation_hvac_mode: "single" as const,
       },
     ]);
     vi.mocked(api.getMetricsHomeSummary).mockResolvedValue(mockSummary);

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -19,6 +19,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     overshoot_delta: 0.5,
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
+    vacation_hvac_mode: "single" as const,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Settings.test.tsx
+++ b/smart_vent/frontend/src/pages/Settings.test.tsx
@@ -19,6 +19,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     overshoot_delta: 0.5,
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
+    vacation_hvac_mode: "single" as const,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -19,6 +19,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     overshoot_delta: 0.5,
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
+    vacation_hvac_mode: "single" as const,
   },
 ];
 
@@ -143,6 +144,53 @@ describe("Thermostats Page", () => {
       expect(api.restoreBackup).toHaveBeenCalledWith(file);
     });
     expect(await screen.findByText(/Restore complete/i)).toBeInTheDocument();
+  });
+});
+
+describe("Thermostats Page — vacation mode selector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
+    vi.mocked(api.getHAEntities).mockResolvedValue([]);
+    vi.mocked(api.downloadBackup).mockReturnValue(undefined);
+  });
+
+  it("renders the Vacation HVAC mode selector", async () => {
+    render(<Thermostats />);
+    expect(await screen.findByLabelText(/Vacation HVAC mode/i)).toBeInTheDocument();
+  });
+
+  it("shows helper text for single setpoint mode", async () => {
+    render(<Thermostats />);
+    await screen.findByLabelText(/Vacation HVAC mode/i);
+    expect(screen.getByText(/turns the HVAC.*off/i)).toBeInTheDocument();
+  });
+
+  it("shows helper text and Test button for range mode", async () => {
+    vi.mocked(api.getThermostats).mockResolvedValue([
+      { ...mockThermostats[0], vacation_hvac_mode: "range" as const },
+    ]);
+    render(<Thermostats />);
+    await screen.findByLabelText(/Vacation HVAC mode/i);
+    expect(screen.getAllByText(/Test auto mode/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/heat_cool.*auto/i)).toBeInTheDocument();
+  });
+
+  it("Test button calls testVacationMode", async () => {
+    vi.mocked(api.getThermostats).mockResolvedValue([
+      { ...mockThermostats[0], vacation_hvac_mode: "range" as const },
+    ]);
+    vi.mocked(api.testVacationMode).mockResolvedValue({
+      ok: true,
+      min_setpoint: 60,
+      max_setpoint: 80,
+      thermostat_state: {},
+    });
+    render(<Thermostats />);
+    const testBtn = await screen.findByRole("button", { name: /Test auto mode/i });
+    fireEvent.click(testBtn);
+    await waitFor(() => expect(api.testVacationMode).toHaveBeenCalledWith("climate.test"));
+    expect(await screen.findByText(/Check your thermostat/i)).toBeInTheDocument();
   });
 });
 

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -423,8 +423,8 @@ function ThermostatCard({
           {form.vacation_hvac_mode === "range" ? (
             <>
               Requires your thermostat to support <strong>heat_cool</strong> or{" "}
-              <strong>auto</strong> mode in Home Assistant. During vacation mode the thermostat
-              will be set to <em>heat_cool</em> with a lower bound of{" "}
+              <strong>auto</strong> mode in Home Assistant. During vacation mode the thermostat will
+              be set to <em>heat_cool</em> with a lower bound of{" "}
               <strong>
                 {toDisplay(form.min_setpoint)}
                 {unitLabel}
@@ -439,8 +439,8 @@ function ThermostatCard({
           ) : (
             <>
               For thermostats that only support a single target temperature at a time. During
-              vacation mode the system turns the HVAC <strong>off</strong>. If the temperature
-              drops below{" "}
+              vacation mode the system turns the HVAC <strong>off</strong>. If the temperature drops
+              below{" "}
               <strong>
                 {toDisplay(form.min_setpoint)}
                 {unitLabel}
@@ -490,10 +490,10 @@ function ThermostatCard({
             )}
           </div>
           <div className="form-hint" style={{ marginTop: ".5rem" }}>
-            Clicking <em>Test auto mode</em> immediately sends the{" "}
-            <strong>heat_cool</strong> command with your current min/max setpoints to this
-            thermostat so you can verify it responded correctly in Home Assistant. After saving
-            or closing, the system reverts the thermostat within one minute.
+            Clicking <em>Test auto mode</em> immediately sends the <strong>heat_cool</strong>{" "}
+            command with your current min/max setpoints to this thermostat so you can verify it
+            responded correctly in Home Assistant. After saving or closing, the system reverts the
+            thermostat within one minute.
           </div>
         </div>
       )}

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -394,7 +394,12 @@ function ThermostatCard({
         className="text-sm"
         style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}
       >
-        Vacation mode
+        Vacation mode hold strategy
+      </div>
+      <div className="form-hint" style={{ marginBottom: ".75rem" }}>
+        Vacation mode is enabled system-wide from the Dashboard and applies to all thermostats.
+        Configure below how <em>this</em> thermostat should hold temperature while vacation mode is
+        active.
       </div>
 
       <div className="form-group" style={{ maxWidth: 400 }}>

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -6,6 +6,7 @@ import {
   deleteThermostat,
   downloadBackup,
   restoreBackup,
+  testVacationMode,
   type ThermostatConfig,
 } from "../api";
 import EntityPicker from "../components/EntityPicker";
@@ -187,6 +188,8 @@ function ThermostatCard({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
+  const [testingVacation, setTestingVacation] = useState(false);
+  const [vacationTestResult, setVacationTestResult] = useState<string | null>(null);
 
   const save = async () => {
     if (!form.name.trim()) {
@@ -383,6 +386,117 @@ function ThermostatCard({
           {Math.floor(form.cycle_timeout_hours * 60)} min).
         </div>
       </div>
+
+      <hr className="divider" />
+
+      {/* Vacation mode HVAC strategy */}
+      <div
+        className="text-sm"
+        style={{ fontWeight: 600, color: "var(--gray-700)", marginBottom: ".75rem" }}
+      >
+        Vacation mode
+      </div>
+
+      <div className="form-group" style={{ maxWidth: 400 }}>
+        <label
+          className="form-label"
+          htmlFor={`thermo-${config.thermostat_entity_id}-vacation-mode`}
+        >
+          Vacation HVAC mode
+        </label>
+        <select
+          id={`thermo-${config.thermostat_entity_id}-vacation-mode`}
+          className="form-control"
+          value={form.vacation_hvac_mode ?? "single"}
+          onChange={(e) =>
+            setForm((f) => ({
+              ...f,
+              vacation_hvac_mode: e.target.value as "range" | "single",
+              // Clear test result when switching mode
+            }))
+          }
+        >
+          <option value="single">Single setpoint (heat or cool)</option>
+          <option value="range">Range (heat_cool / auto)</option>
+        </select>
+        <div className="form-hint">
+          {form.vacation_hvac_mode === "range" ? (
+            <>
+              Requires your thermostat to support <strong>heat_cool</strong> or{" "}
+              <strong>auto</strong> mode in Home Assistant. During vacation mode the thermostat
+              will be set to <em>heat_cool</em> with a lower bound of{" "}
+              <strong>
+                {toDisplay(form.min_setpoint)}
+                {unitLabel}
+              </strong>{" "}
+              and an upper bound of{" "}
+              <strong>
+                {toDisplay(form.max_setpoint)}
+                {unitLabel}
+              </strong>
+              , letting it manage both heating and cooling natively.
+            </>
+          ) : (
+            <>
+              For thermostats that only support a single target temperature at a time. During
+              vacation mode the system turns the HVAC <strong>off</strong>. If the temperature
+              drops below{" "}
+              <strong>
+                {toDisplay(form.min_setpoint)}
+                {unitLabel}
+              </strong>{" "}
+              it switches to heat mode; if it rises above{" "}
+              <strong>
+                {toDisplay(form.max_setpoint)}
+                {unitLabel}
+              </strong>{" "}
+              it switches to cool mode. Once back in range, the HVAC turns off again.
+            </>
+          )}
+        </div>
+      </div>
+
+      {form.vacation_hvac_mode === "range" && (
+        <div className="form-group" style={{ maxWidth: 400 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: ".75rem", flexWrap: "wrap" }}>
+            <button
+              className="btn btn-secondary"
+              disabled={testingVacation}
+              onClick={async () => {
+                setTestingVacation(true);
+                setVacationTestResult(null);
+                try {
+                  await testVacationMode(config.thermostat_entity_id);
+                  setVacationTestResult(
+                    "Command sent. Check your thermostat in Home Assistant — it should now show heat_cool mode with your min/max bounds."
+                  );
+                } catch (e: unknown) {
+                  setVacationTestResult(
+                    "Error: " + (e instanceof Error ? e.message : "Test failed")
+                  );
+                } finally {
+                  setTestingVacation(false);
+                }
+              }}
+            >
+              {testingVacation ? "Testing…" : "Test auto mode"}
+            </button>
+            {vacationTestResult && (
+              <span
+                className={`badge ${vacationTestResult.startsWith("Error") ? "badge-red" : "badge-green"}`}
+              >
+                {vacationTestResult}
+              </span>
+            )}
+          </div>
+          <div className="form-hint" style={{ marginTop: ".5rem" }}>
+            Clicking <em>Test auto mode</em> immediately sends the{" "}
+            <strong>heat_cool</strong> command with your current min/max setpoints to this
+            thermostat so you can verify it responded correctly in Home Assistant. After saving
+            or closing, the system reverts the thermostat within one minute.
+          </div>
+        </div>
+      )}
 
       <div style={{ marginTop: "1.25rem", display: "flex", alignItems: "center", gap: ".75rem" }}>
         <button className="btn btn-primary" onClick={save} disabled={saving}>


### PR DESCRIPTION
Closes #189

## What this does

When vacation mode is enabled, all room schedules, presence triggers, and temporary overrides are suspended **system-wide** (applies to all thermostats). Each thermostat is held within its configured `min_setpoint`/`max_setpoint` safety band until a user-specified return date and time, after which normal scheduling resumes automatically within one tick (~60 s).

### Hold strategy (per-thermostat, user-configured)

The *hold strategy* is configured per thermostat because different thermostats support different HA modes — but vacation mode itself is a single on/off toggle affecting everything.

| Mode | Behavior |
|---|---|
| **Range** (`heat_cool`/auto) | Sends `climate.set_temperature` with `target_temp_low = min_setpoint`, `target_temp_high = max_setpoint`. Best for thermostats that support a dual setpoint mode. |
| **Single** (on/off) | Turns HVAC off. If temperature drifts below `min_setpoint` it heats to the minimum; if it rises above `max_setpoint` it cools to the maximum; otherwise stays off. |

Users select the strategy per thermostat on the Thermostats page under **"Vacation mode hold strategy"** (renamed from "Vacation mode" to avoid implying it's a per-thermostat toggle). A **Test** button for range mode sends the range command immediately so the user can verify HA responded — the engine reverts state on the next tick if vacation mode is not actually active.

---

## Changes

### Backend
- **`models.py`** — `vacation_hvac_mode: str = "single"` field on `ThermostatConfig`
- **`db.py`** — migration adds `vacation_hvac_mode` column; `upsert`/`get` updated
- **`scheduler.py`** — stores vacation state in `system_settings`; `_check_vacation_expiry()` runs first in every tick; new `get/set_vacation_mode()` helpers
- **`engine/cycle_engine.py`** — vacation guard moved **before** active-room evaluation so it fires even when rooms have no schedules; `_apply_vacation_hold()` implements range and single logic
- **`ha_client.py`** — `set_thermostat_hvac_mode()` and `set_thermostat_temperature_range()` (respects dev mode)
- **`api/routes.py`** — `GET/POST/DELETE /api/settings/vacation-mode`, `POST /api/thermostats/{id}/test-vacation`; all routes have `@docs` + `@response_schema`
- **`api/schemas.py`** — `VacationModeSchema`, `VacationTestSchema`

### Frontend
- **`VacationModeModal`** — enable flow (datetime picker + "applies to all thermostats" copy) and dismiss flow (two-step confirmation before ending early)
- **`VacationModeBanner`** — globally visible amber alert banner when vacation mode is active; clicking banner or "Manage" button opens the modal in dismiss flow
- **`App.tsx`** — renders `VacationModeBanner` alongside `UnitChangeBanner`
- **`Dashboard`** — single system-wide vacation mode button placed before the first climate card; shows "Schedules paused until …" hint when active
- **`Thermostats`** — per-thermostat **"Vacation mode hold strategy"** section with helper note explaining the system-wide vs. per-thermostat distinction; Test button for range mode
- **`api.ts`** — `VacationMode` type, `vacation_hvac_mode` on `ThermostatConfig`, `getVacationMode/enableVacationMode/disableVacationMode/testVacationMode`

### Tests
- 12 backend unit tests: scheduler state, auto-expiry, engine range mode, single mode (in-range / below-min / above-max), Celsius correctness
- Integration tests for all new API endpoints
- `VacationModeModal` and `VacationModeBanner` component tests (enable flow, dismiss flow, banner visibility, modal open paths)
- `Dashboard` and `Thermostats` page tests extended for vacation mode UI
- Fixed 5 pre-existing test files missing the new required `vacation_mode` / `vacation_hvac_mode` fields (caused TypeScript build failure in Docker)

---

## Test plan

- [x] All 542 backend tests pass (`pytest backend/tests/`) — 90.93% coverage ✓
- [x] All 140 frontend tests pass (`npm run test:coverage`) — all thresholds met ✓
- [ ] Enable vacation mode from Dashboard → button turns amber, banner appears in nav
- [ ] Set return date in the past → modal shows validation error
- [ ] Set return date with no date → modal shows validation error
- [ ] Enable with a future return date → all thermostats held within min/max per configured strategy
- [ ] Wait for return date (or set a near-future time) → scheduling resumes automatically for all thermostats
- [ ] Click "Manage" on banner → dismiss flow with two-step confirmation
- [ ] "Keep vacation mode" cancels back to info view without disabling
- [ ] Test button (range mode) on Thermostats page → HA thermostat switches to heat_cool; reverts within ~60 s
- [ ] Changing `vacation_hvac_mode` and saving persists across page reload
- [x] Thermostats page shows "Vacation mode hold strategy" section with clarifying note that vacation mode is system-wide

https://claude.ai/code/session_017u7ngnHATXg5yDZTZtuHQB