### PR TITLE
fix: revert thermostat from heat_cool mode when vacation is not active

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1390,6 +1390,22 @@ async def test_vacation_mode(request: web.Request) -> web.Response:
     )
 
 
+@docs(tags=["thermostats"], summary="Revert thermostat from vacation test mode back to off")
+@response_schema(schemas.SuccessSchema)
+@routes.delete("/api/thermostats/{entity_id:.+}/test-vacation")
+async def revert_vacation_test(request: web.Request) -> web.Response:
+    """Immediately revert a thermostat from heat_cool/auto mode back to off.
+    Use after the Test auto mode button to undo the test without waiting for
+    the engine's next tick."""
+    entity_id = request.match_info["entity_id"]
+    ha = request.app["ha"]
+    try:
+        await ha.set_thermostat_hvac_mode(entity_id, "off")
+    except Exception as exc:
+        return error(f"Failed to revert thermostat mode: {exc}", status=502)
+    return json_response({"ok": True})
+
+
 @docs(tags=["system"], summary="Restart the application")
 @response_schema(schemas.RestartResponseSchema)
 @routes.post("/api/restart")

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -203,6 +203,26 @@ class CycleEngine:
             await self._apply_vacation_hold(conn, thermo_state)
             return
 
+        # heat_cool / auto mode must ONLY be active during vacation range mode.
+        # If the thermostat is in heat_cool outside of vacation (e.g. left behind
+        # by the "Test auto mode" button), revert it to "off" immediately so the
+        # next tick can start a normal single-direction cycle if needed.
+        if thermo_state.get("state") == "heat_cool":
+            log.info(
+                "Thermostat %s in heat_cool outside vacation mode — reverting to off",
+                self.thermostat_entity_id,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Thermostat {self.thermostat_entity_id} reverted from heat_cool to off"
+                    " (vacation mode not active)",
+                    {"thermostat": self.thermostat_entity_id},
+                )
+            await self._ha.set_thermostat_hvac_mode(self.thermostat_entity_id, "off")
+            return
+
         # Determine which rooms should be active now
         new_active = await get_active_rooms(conn, self.thermostat_entity_id)
         new_active_map = {ar.room.id: ar for ar in new_active}

--- a/smart_vent/backend/tests/test_vacation_mode.py
+++ b/smart_vent/backend/tests/test_vacation_mode.py
@@ -333,6 +333,46 @@ async def test_engine_vacation_mode_already_off_no_redundant_call():
 
 
 # ---------------------------------------------------------------------------
+# Engine reverts heat_cool when vacation mode is NOT active (test-button fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_engine_reverts_heat_cool_when_vacation_inactive():
+    """If the thermostat is in heat_cool mode and vacation is OFF, the engine
+    should immediately revert it to 'off'. This covers the case where the user
+    clicked the 'Test auto mode' button but never enabled vacation mode."""
+    ha = _make_ha(hvac_mode="heat_cool", current_temp=72.0)
+    ha.get_state.return_value = {
+        "state": "heat_cool",
+        "attributes": {
+            "current_temperature": 72.0,
+            "temperature": 72.0,
+            "hvac_action": "idle",
+        },
+    }
+    engine = _make_engine(ha, vacation_mode=False)  # vacation NOT active
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="range",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_hvac_mode.assert_called_once_with(THERMO_A, "off")
+        ha.set_thermostat_temperature_range.assert_not_called()
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Celsius mode: setback temps stored in °F, displayed correctly
 # ---------------------------------------------------------------------------
 

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -717,6 +717,12 @@ export const testVacationMode = (entity_id: string) =>
     { method: "POST" }
   );
 
+export const revertVacationTest = (entity_id: string) =>
+  api<{ ok: true }>(
+    `/api/thermostats/${encodeURIComponent(entity_id)}/test-vacation`,
+    { method: "DELETE" }
+  );
+
 export const restartApp = () => api<{ restarting: true }>("/api/restart", { method: "POST" });
 
 // ---------------------------------------------------------------------------

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -718,10 +718,9 @@ export const testVacationMode = (entity_id: string) =>
   );
 
 export const revertVacationTest = (entity_id: string) =>
-  api<{ ok: true }>(
-    `/api/thermostats/${encodeURIComponent(entity_id)}/test-vacation`,
-    { method: "DELETE" }
-  );
+  api<{ ok: true }>(`/api/thermostats/${encodeURIComponent(entity_id)}/test-vacation`, {
+    method: "DELETE",
+  });
 
 export const restartApp = () => api<{ restarting: true }>("/api/restart", { method: "POST" });
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -176,7 +176,7 @@ describe("Thermostats Page — vacation mode selector", () => {
     expect(screen.getByText(/heat_cool.*auto/i)).toBeInTheDocument();
   });
 
-  it("Test button calls testVacationMode", async () => {
+  it("Test button calls testVacationMode and shows Revert button", async () => {
     vi.mocked(api.getThermostats).mockResolvedValue([
       { ...mockThermostats[0], vacation_hvac_mode: "range" as const },
     ]);
@@ -191,6 +191,28 @@ describe("Thermostats Page — vacation mode selector", () => {
     fireEvent.click(testBtn);
     await waitFor(() => expect(api.testVacationMode).toHaveBeenCalledWith("climate.test"));
     expect(await screen.findByText(/Check your thermostat/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Revert test/i })).toBeInTheDocument();
+  });
+
+  it("Revert button calls revertVacationTest", async () => {
+    vi.mocked(api.getThermostats).mockResolvedValue([
+      { ...mockThermostats[0], vacation_hvac_mode: "range" as const },
+    ]);
+    vi.mocked(api.testVacationMode).mockResolvedValue({
+      ok: true,
+      min_setpoint: 60,
+      max_setpoint: 80,
+      thermostat_state: {},
+    });
+    vi.mocked(api.revertVacationTest).mockResolvedValue({ ok: true });
+    render(<Thermostats />);
+    const testBtn = await screen.findByRole("button", { name: /Test auto mode/i });
+    fireEvent.click(testBtn);
+    const revertBtn = await screen.findByRole("button", { name: /Revert test/i });
+    fireEvent.click(revertBtn);
+    await waitFor(() => expect(api.revertVacationTest).toHaveBeenCalledWith("climate.test"));
+    expect(await screen.findByText(/Reverted/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Test auto mode/i })).toBeInTheDocument();
   });
 });
 

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -7,6 +7,7 @@ import {
   downloadBackup,
   restoreBackup,
   testVacationMode,
+  revertVacationTest,
   type ThermostatConfig,
 } from "../api";
 import EntityPicker from "../components/EntityPicker";
@@ -189,6 +190,7 @@ function ThermostatCard({
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
   const [testingVacation, setTestingVacation] = useState(false);
+  const [vacationTestActive, setVacationTestActive] = useState(false);
   const [vacationTestResult, setVacationTestResult] = useState<string | null>(null);
 
   const save = async () => {
@@ -464,28 +466,48 @@ function ThermostatCard({
       {form.vacation_hvac_mode === "range" && (
         <div className="form-group" style={{ maxWidth: 400 }}>
           <div style={{ display: "flex", alignItems: "center", gap: ".75rem", flexWrap: "wrap" }}>
-            <button
-              className="btn btn-secondary"
-              disabled={testingVacation}
-              onClick={async () => {
-                setTestingVacation(true);
-                setVacationTestResult(null);
-                try {
-                  await testVacationMode(config.thermostat_entity_id);
-                  setVacationTestResult(
-                    "Command sent. Check your thermostat in Home Assistant — it should now show heat_cool mode with your min/max bounds."
-                  );
-                } catch (e: unknown) {
-                  setVacationTestResult(
-                    "Error: " + (e instanceof Error ? e.message : "Test failed")
-                  );
-                } finally {
-                  setTestingVacation(false);
-                }
-              }}
-            >
-              {testingVacation ? "Testing…" : "Test auto mode"}
-            </button>
+            {!vacationTestActive ? (
+              <button
+                className="btn btn-secondary"
+                disabled={testingVacation}
+                onClick={async () => {
+                  setTestingVacation(true);
+                  setVacationTestResult(null);
+                  try {
+                    await testVacationMode(config.thermostat_entity_id);
+                    setVacationTestActive(true);
+                    setVacationTestResult(
+                      "heat_cool active — check your thermostat in Home Assistant."
+                    );
+                  } catch (e: unknown) {
+                    setVacationTestResult(
+                      "Error: " + (e instanceof Error ? e.message : "Test failed")
+                    );
+                  } finally {
+                    setTestingVacation(false);
+                  }
+                }}
+              >
+                {testingVacation ? "Testing…" : "Test auto mode"}
+              </button>
+            ) : (
+              <button
+                className="btn btn-warning"
+                onClick={async () => {
+                  try {
+                    await revertVacationTest(config.thermostat_entity_id);
+                    setVacationTestActive(false);
+                    setVacationTestResult("Reverted — thermostat set back to off.");
+                  } catch (e: unknown) {
+                    setVacationTestResult(
+                      "Error: " + (e instanceof Error ? e.message : "Revert failed")
+                    );
+                  }
+                }}
+              >
+                Revert test
+              </button>
+            )}
             {vacationTestResult && (
               <span
                 className={`badge ${vacationTestResult.startsWith("Error") ? "badge-red" : "badge-green"}`}
@@ -495,10 +517,10 @@ function ThermostatCard({
             )}
           </div>
           <div className="form-hint" style={{ marginTop: ".5rem" }}>
-            Clicking <em>Test auto mode</em> immediately sends the <strong>heat_cool</strong>{" "}
-            command with your current min/max setpoints to this thermostat so you can verify it
-            responded correctly in Home Assistant. After saving or closing, the system reverts the
-            thermostat within one minute.
+            <em>Test auto mode</em> sends the <strong>heat_cool</strong> command with your current
+            min/max setpoints so you can verify the thermostat responded in Home Assistant. Click{" "}
+            <em>Revert test</em> to set it back to off immediately, or the engine will revert it
+            automatically on the next tick (~60 s).
           </div>
         </div>
       )}


### PR DESCRIPTION
## Root cause

Two bugs in the vacation mode implementation from #190:

### Bug 1 — Engine never reverted `heat_cool` during idle

`_read_hvac_mode()` maps `heat_cool` → `"off"`. When the home was already comfortable (rooms within deadband), the engine would reset the setpoint to ambient temperature but never specified `hvac_mode` in that call, so the thermostat stayed in `heat_cool` mode indefinitely — even with vacation mode disabled.

The revert only happened when a new cycle started (which requires rooms to be out of range). If the house was comfortable, no cycle ever started, and the thermostat was stuck in `heat_cool` forever.

**Fix:** Added an explicit guard in `_do_tick()` immediately after the vacation mode check. If the thermostat is in `heat_cool` mode and vacation mode is **not** active, it calls `set_thermostat_hvac_mode("off")` and returns. `heat_cool` is only valid during vacation range mode — outside of it the engine should always use explicit `heat` or `cool`.

### Bug 2 — No immediate manual revert after "Test auto mode"

After clicking the test button, there was no way to undo it. The helper text said "reverts within one minute" but (due to Bug 1) it never actually did.

**Fix:**
- Added `DELETE /api/thermostats/{id}/test-vacation` endpoint that immediately sets the thermostat to `off`
- After a successful test, the "Test auto mode" button is replaced by an amber **"Revert test"** button that calls this endpoint
- Helper text updated to reflect both options (manual revert button + automatic engine revert on next tick)

---

## Changes

- **`engine/cycle_engine.py`** — `heat_cool` guard added right after vacation mode check in `_do_tick`
- **`api/routes.py`** — new `DELETE /api/thermostats/{entity_id}/test-vacation` with `@docs` + `@response_schema`
- **`frontend/src/api.ts`** — `revertVacationTest(entity_id)` calling the new DELETE endpoint
- **`frontend/src/pages/Thermostats.tsx`** — Test button swaps to "Revert test" after successful test; updated helper text
- **`backend/tests/test_vacation_mode.py`** — new test `test_engine_reverts_heat_cool_when_vacation_inactive`
- **`frontend/src/pages/Thermostats.test.tsx`** — two new tests for Revert button behaviour

## Test plan

- [ ] All 543 backend tests pass (90.77% coverage) ✓
- [ ] All 141 frontend tests pass ✓
- [ ] Click "Test auto mode" → thermostat switches to `heat_cool`
- [ ] "Revert test" button appears; clicking it immediately sets thermostat to `off`
- [ ] Alternatively: wait ~60 s without clicking Revert → engine tick detects `heat_cool` and calls `set_hvac_mode("off")` automatically
- [ ] With vacation mode disabled, engine never leaves thermostat in `heat_cool` mode even if house is comfortable and no cycle starts

https://claude.ai/code/session_017u7ngnHATXg5yDZTZtuHQB

---
_Generated by [Claude Code](https://claude.ai/code/session_017u7ngnHATXg5yDZTZtuHQB)_