### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent DoS via Disk Exhaustion in Restore API

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -39,6 +39,9 @@ log = logging.getLogger(__name__)
 
 routes = web.RouteTableDef()
 
+# Security: Limit database restore uploads to 10MB to prevent disk exhaustion DoS
+MAX_RESTORE_SIZE = 10 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1852,12 +1855,18 @@ async def restore_db(request: web.Request) -> web.Response:
         return error("Multipart field 'file' required")
 
     # Write upload to a temp file first so we can validate before overwriting
+    size = 0
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            size += len(chunk)
+            if size > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"Upload too large (max {MAX_RESTORE_SIZE // 1024 // 1024}MB)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,6 +1,6 @@
-import pytest
 import aiohttp
-from aiohttp import web
+import pytest
+
 
 @pytest.mark.asyncio
 async def test_restore_db_size_limit(client):
@@ -8,7 +8,7 @@ async def test_restore_db_size_limit(client):
     large_data = b"SQLite format 3\x00" + b"0" * (11 * 1024 * 1024)
 
     data = aiohttp.FormData()
-    data.add_field('file', large_data, filename='large.db')
+    data.add_field("file", large_data, filename="large.db")
 
     resp = await client.post("/api/restore", data=data)
 

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,18 @@
+import pytest
+import aiohttp
+from aiohttp import web
+
+@pytest.mark.asyncio
+async def test_restore_db_size_limit(client):
+    # Create a large "database" file (11MB)
+    large_data = b"SQLite format 3\x00" + b"0" * (11 * 1024 * 1024)
+
+    data = aiohttp.FormData()
+    data.add_field('file', large_data, filename='large.db')
+
+    resp = await client.post("/api/restore", data=data)
+
+    # It should fail with 400
+    assert resp.status == 400
+    body = await resp.json()
+    assert "too large" in body["error"]


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Prevent DoS via Disk Exhaustion in Restore API

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Missing input validation on file upload size in the `restore_db` endpoint.
**🎯 Impact:** A malicious or misconfigured client could upload an excessively large file, leading to Denial of Service (DoS) via disk space exhaustion.
**🔧 Fix:** Implemented a 10MB (`MAX_RESTORE_SIZE`) limit in `smart_vent/backend/api/routes.py` by tracking bytes read during the streaming multipart upload and terminating the connection if the limit is exceeded.
**✅ Verification:** Added `smart_vent/backend/tests/integration/test_restore_security.py` which verifies that an 11MB upload is rejected with a 400 error. All existing backend tests (544) pass.

---
*PR created automatically by Jules for task [1988643869953253436](https://jules.google.com/task/1988643869953253436) started by @dhruvb14*