### PR TITLE
🛡️ Sentinel: [MEDIUM] Add File Size Limit to Database Restore

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1807,6 +1807,8 @@ async def set_dev_mode(request: web.Request) -> web.Response:
 # Backup / Restore
 # ---------------------------------------------------------------------------
 
+MAX_RESTORE_SIZE = 10 * 1024 * 1024  # 10MB
+
 
 @docs(tags=["system"], summary="Download a database backup")
 @routes.get("/api/backup")
@@ -1854,10 +1856,16 @@ async def restore_db(request: web.Request) -> web.Response:
     # Write upload to a temp file first so we can validate before overwriting
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
+        total_size = 0
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            total_size += len(chunk)
+            if total_size > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"Upload too large (max {MAX_RESTORE_SIZE // (1024*1024)}MB)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1865,7 +1865,7 @@ async def restore_db(request: web.Request) -> web.Response:
             if total_size > MAX_RESTORE_SIZE:
                 tmp.close()
                 os.unlink(tmp_path)
-                return error(f"Upload too large (max {MAX_RESTORE_SIZE // (1024*1024)}MB)")
+                return error(f"Upload too large (max {MAX_RESTORE_SIZE // (1024 * 1024)}MB)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,64 @@
+"""Security tests for database restore file size limits."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+from aiohttp import FormData
+
+
+@pytest.mark.asyncio
+async def test_restore_oversized_file(client) -> None:
+    """Verify that a database restore exceeding 10MB is rejected."""
+    # Create 11MB of dummy data (MAX_RESTORE_SIZE is 10MB)
+    large_data = b"0" * (11 * 1024 * 1024)
+    data = FormData()
+    data.add_field("file", large_data, filename="too_big.db")
+
+    resp = await client.post("/api/restore", data=data)
+    assert resp.status == 400
+    json_data = await resp.json()
+    assert "Upload too large" in json_data["error"]
+    assert "max 10MB" in json_data["error"]
+
+
+@pytest.mark.asyncio
+async def test_restore_invalid_magic_bytes(client) -> None:
+    """Verify that a file with invalid SQLite magic bytes is rejected."""
+    data = FormData()
+    data.add_field("file", b"NOT A SQLITE FILE", filename="invalid.db")
+
+    resp = await client.post("/api/restore", data=data)
+    assert resp.status == 400
+    json_data = await resp.json()
+    assert "not a valid SQLite database" in json_data["error"]
+
+
+@pytest.mark.asyncio
+async def test_restore_valid_file(client) -> None:
+    """Verify that a valid small SQLite database is accepted for restore."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        # Create a real SQLite database
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+        conn.commit()
+        conn.close()
+
+        with open(path, "rb") as f:
+            valid_data = f.read()
+
+        data = FormData()
+        data.add_field("file", valid_data, filename="valid.db")
+
+        resp = await client.post("/api/restore", data=data)
+        assert resp.status == 200
+        json_data = await resp.json()
+        assert json_data["restored"] is True
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)


### PR DESCRIPTION
This PR adds a security enhancement by enforcing a 10MB file size limit on the database restore endpoint (`POST /api/restore`).

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Unbounded File Upload (DoS Risk)
### 🎯 Impact: An attacker could exhaust disk space by uploading excessively large files, leading to a Denial of Service.
### 🔧 Fix: Implemented explicit file size tracking during the streaming chunk-reading loop of the multipart request. If the `MAX_RESTORE_SIZE` (10MB) is exceeded, the upload is aborted, the partial file is deleted, and a 400 error is returned.
### ✅ Verification: 
- New integration tests in `smart_vent/backend/tests/integration/test_restore_security.py` cover:
    - Rejection of files > 10MB.
    - Rejection of files with invalid SQLite magic bytes.
    - Success path for valid small SQLite databases.
- Full backend test suite passed with > 90% coverage.

---
*PR created automatically by Jules for task [17502458303997150890](https://jules.google.com/task/17502458303997150890) started by @dhruvb14*