### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce File Size Limit on Database Restore

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -37,6 +37,9 @@ from . import schemas
 
 log = logging.getLogger(__name__)
 
+# Security: limit DB restore upload size to 10MB to prevent DoS via disk exhaustion.
+MAX_RESTORE_SIZE = 10 * 1024 * 1024
+
 routes = web.RouteTableDef()
 
 
@@ -1851,13 +1854,20 @@ async def restore_db(request: web.Request) -> web.Response:
     if not isinstance(field, aiohttp.BodyPartReader) or field.name != "file":
         return error("Multipart field 'file' required")
 
-    # Write upload to a temp file first so we can validate before overwriting
+    # Write upload to a temp file first so we can validate before overwriting.
+    # Security: track total bytes read and enforce MAX_RESTORE_SIZE.
+    total_read = 0
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
         while True:
             chunk = await field.read_chunk(65536)
             if not chunk:
                 break
+            total_read += len(chunk)
+            if total_read > MAX_RESTORE_SIZE:
+                tmp.close()
+                os.unlink(tmp_path)
+                return error(f"Uploaded file too large (max {MAX_RESTORE_SIZE // 1024 // 1024}MB)")
             tmp.write(chunk)
 
     try:

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -5,8 +5,8 @@ Verifies that file size limits are enforced to prevent DoS.
 
 from __future__ import annotations
 
-import pytest
 import aiohttp
+import pytest
 
 
 @pytest.mark.asyncio

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,33 @@
+"""
+Security tests for the database restore endpoint.
+Verifies that file size limits are enforced to prevent DoS.
+"""
+
+from __future__ import annotations
+
+import pytest
+import aiohttp
+
+
+@pytest.mark.asyncio
+async def test_restore_file_size_limit_enforced(client) -> None:
+    """Verify that database restore uploads exceeding 10MB are rejected."""
+    # 10MB + 1 byte
+    oversized_content = b"0" * (10 * 1024 * 1024 + 1)
+
+    data = aiohttp.FormData()
+    data.add_field(
+        "file",
+        oversized_content,
+        filename="app.db",
+        content_type="application/octet-stream",
+    )
+
+    resp = await client.post("/api/restore", data=data)
+
+    # Before the fix, this might succeed (200) or fail with 500 (if invalid SQLite)
+    # but it won't be 400 with a "too large" error.
+    assert resp.status == 400
+    json_data = await resp.json()
+    assert "error" in json_data
+    assert "too large" in json_data["error"].lower()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing file size limit on the `/api/restore` multipart upload endpoint allowed arbitrarily large files to be uploaded.
🎯 Impact: An attacker could perform a Denial of Service (DoS) attack by filling up the server's disk space, potentially crashing the application or the host system.
🔧 Fix: Implemented manual size tracking in the streaming chunk reader loop within `restore_db`. If the cumulative size exceeds 10MB, the temporary file is closed and deleted, and a 400 Bad Request error is returned.
✅ Verification: Created `smart_vent/backend/tests/integration/test_restore_security.py` which attempts to upload a file slightly larger than 10MB and verifies that it is rejected with a 400 error. Ran the full backend test suite to ensure no regressions.

---
*PR created automatically by Jules for task [6533250536125819557](https://jules.google.com/task/6533250536125819557) started by @dhruvb14*