### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent DoS via Database Restore File Size Limit

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1852,13 +1852,28 @@ async def restore_db(request: web.Request) -> web.Response:
         return error("Multipart field 'file' required")
 
     # Write upload to a temp file first so we can validate before overwriting
+    # Security: enforce a max file size (10MB cap) to prevent DoS via disk exhaustion.
+    MAX_RESTORE_SIZE = 10 * 1024 * 1024  # 10MB
+    total_size = 0
+
     with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as tmp:
         tmp_path = tmp.name
-        while True:
-            chunk = await field.read_chunk(65536)
-            if not chunk:
-                break
-            tmp.write(chunk)
+        try:
+            while True:
+                chunk = await field.read_chunk(65536)
+                if not chunk:
+                    break
+                total_size += len(chunk)
+                if total_size > MAX_RESTORE_SIZE:
+                    tmp.close()
+                    os.unlink(tmp_path)
+                    return error(f"File too large (max {MAX_RESTORE_SIZE // (1024 * 1024)}MB)", 400)
+                tmp.write(chunk)
+        except Exception:
+            tmp.close()
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
 
     try:
         # Validate SQLite magic bytes

--- a/smart_vent/backend/tests/integration/test_restore_security.py
+++ b/smart_vent/backend/tests/integration/test_restore_security.py
@@ -1,0 +1,43 @@
+"""Security tests for database restore file size limits."""
+
+import io
+
+import aiohttp
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_restore_file_too_large(client):
+    """Verify that uploading a database larger than 10MB is rejected."""
+    # Create a dummy large "file" (10MB + 64KB to ensure it exceeds the limit in the first few chunks)
+    # The chunk size in routes.py is 64KB.
+    limit = 10 * 1024 * 1024
+    large_data = b"0" * (limit + 65536)
+
+    data = aiohttp.FormData()
+    data.add_field(
+        "file",
+        io.BytesIO(large_data),
+        filename="too_large.db",
+        content_type="application/octet-stream",
+    )
+
+    resp = await client.post("/api/restore", data=data)
+
+    assert resp.status == 400
+    body = await resp.json()
+    assert "error" in body
+    assert "File too large" in body["error"]
+    assert "max 10MB" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_restore_missing_file_field(client):
+    """Verify that a restore request without the 'file' field is rejected."""
+    data = aiohttp.FormData()
+    data.add_field("wrong_field", b"some data")
+
+    resp = await client.post("/api/restore", data=data)
+    assert resp.status == 400
+    body = await resp.json()
+    assert body["error"] == "Multipart field 'file' required"


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/api/restore` endpoint lacked file size validation during streaming uploads, allowing for potential Denial of Service (DoS) via disk space exhaustion.
🎯 **Impact:** An attacker could upload arbitrarily large files, filling the server's disk and causing application or system failure.
🔧 **Fix:**
- Added a `MAX_RESTORE_SIZE` constant (10MB) to the `restore_db` handler.
- Implemented size tracking during the chunked read loop.
- Ensured early abort, file closure, and unlinking if the limit is exceeded.
- Added robust error handling to clean up temporary files on any upload failure.
✅ **Verification:**
- Created `smart_vent/backend/tests/integration/test_restore_security.py` with tests for oversized uploads and missing fields.
- Verified all tests pass with `python3 -m pytest smart_vent/backend/tests/`.
- Ensured formatting compliance with `ruff`.

---
*PR created automatically by Jules for task [12777649841379143055](https://jules.google.com/task/12777649841379143055) started by @dhruvb14*