### PR TITLE
Add compressor short-cycle protection to the cycle engine

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -706,6 +706,8 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "cycle_timeout_hours",
         "reconciliation_interval_min",
         "vacation_hvac_mode",
+        "min_cycle_runtime_min",
+        "min_cycle_offtime_min",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):
@@ -777,6 +779,8 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "cycle_timeout_hours",
         "reconciliation_interval_min",
         "vacation_hvac_mode",
+        "min_cycle_runtime_min",
+        "min_cycle_offtime_min",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -90,7 +90,9 @@ CREATE TABLE IF NOT EXISTS thermostat_configs (
     max_vent_closed_min INTEGER NOT NULL DEFAULT 0,
     min_open_vents INTEGER NOT NULL DEFAULT 1,
     overshoot_delta REAL NOT NULL DEFAULT 2.0,
-    cycle_timeout_hours REAL NOT NULL DEFAULT 3.0
+    cycle_timeout_hours REAL NOT NULL DEFAULT 3.0,
+    min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0,
+    min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS room_overrides (
@@ -303,6 +305,9 @@ _MIGRATIONS = [
     "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_end REAL",
     # Vacation mode thermostat hold strategy
     "ALTER TABLE thermostat_configs ADD COLUMN vacation_hvac_mode TEXT NOT NULL DEFAULT 'single'",
+    # Short-cycle protection (Issue #208)
+    "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0",
 ]
 
 
@@ -602,6 +607,12 @@ def _row_to_tc(row) -> ThermostatConfig:
         cycle_timeout_hours=row["cycle_timeout_hours"],
         reconciliation_interval_min=int(row["reconciliation_interval_min"] or 0),
         vacation_hvac_mode=row["vacation_hvac_mode"] if "vacation_hvac_mode" in keys else "single",
+        min_cycle_runtime_min=int(row["min_cycle_runtime_min"] or 0)
+        if "min_cycle_runtime_min" in keys
+        else 0,
+        min_cycle_offtime_min=int(row["min_cycle_offtime_min"] or 0)
+        if "min_cycle_offtime_min" in keys
+        else 0,
     )
 
 
@@ -610,8 +621,9 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
         """INSERT INTO thermostat_configs
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
             max_vent_closed_min,min_open_vents,overshoot_delta,cycle_timeout_hours,
-            reconciliation_interval_min,vacation_hvac_mode)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
+            reconciliation_interval_min,vacation_hvac_mode,
+            min_cycle_runtime_min,min_cycle_offtime_min)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -623,7 +635,9 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              overshoot_delta=excluded.overshoot_delta,
              cycle_timeout_hours=excluded.cycle_timeout_hours,
              reconciliation_interval_min=excluded.reconciliation_interval_min,
-             vacation_hvac_mode=excluded.vacation_hvac_mode
+             vacation_hvac_mode=excluded.vacation_hvac_mode,
+             min_cycle_runtime_min=excluded.min_cycle_runtime_min,
+             min_cycle_offtime_min=excluded.min_cycle_offtime_min
         """,
         (
             tc.thermostat_entity_id,
@@ -638,6 +652,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             tc.cycle_timeout_hours,
             tc.reconciliation_interval_min,
             tc.vacation_hvac_mode,
+            tc.min_cycle_runtime_min,
+            tc.min_cycle_offtime_min,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -238,6 +238,8 @@ async def init_db(conn: aiosqlite.Connection) -> None:
             pass  # column already exists
     # Data migration: fix holdover timestamps stored in local time (Issue #65)
     await _migrate_holdover_timestamps_to_utc(conn)
+    # Data migration: enable short-cycle protection on pre-existing thermostats
+    await _migrate_short_cycle_defaults(conn)
     log.info("Database initialised")
 
 
@@ -273,6 +275,56 @@ async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> Non
                 len(rows),
             )
         await conn.commit()
+
+    await conn.execute(
+        """INSERT INTO system_settings(key,value) VALUES(?,?)
+           ON CONFLICT(key) DO UPDATE SET value=excluded.value""",
+        (sentinel, "1"),
+    )
+    await conn.commit()
+
+
+# Short-cycle protection (Issue #208): recommended HVAC minimums applied to
+# thermostats that already existed before the feature shipped. New thermostats
+# keep the disabled (0) default and the user opts in via the UI, which shows
+# these same recommended values.
+RECOMMENDED_MIN_CYCLE_RUNTIME_MIN = 10
+RECOMMENDED_MIN_CYCLE_OFFTIME_MIN = 5
+
+
+async def _migrate_short_cycle_defaults(conn: aiosqlite.Connection) -> None:
+    """One-time migration: enable short-cycle protection on existing thermostats.
+
+    ``min_cycle_runtime_min`` / ``min_cycle_offtime_min`` are added with a
+    column default of 0 (disabled). A thermostat that already had a config row
+    before this feature shipped is presumably controlling live equipment, so
+    back-fill it with the recommended minimums rather than leaving the
+    equipment unprotected until the user happens to find the setting.
+
+    Runs exactly once (sentinel-guarded). Thermostats registered afterwards are
+    not touched — they keep the 0 default and the user configures them
+    explicitly. Rows the user has already tuned to non-zero values are left
+    alone.
+    """
+    sentinel = "migration_short_cycle_defaults_v1"
+    async with conn.execute("SELECT value FROM system_settings WHERE key=?", (sentinel,)) as cur:
+        if await cur.fetchone():
+            return
+
+    cursor = await conn.execute(
+        """UPDATE thermostat_configs
+              SET min_cycle_runtime_min=?, min_cycle_offtime_min=?
+            WHERE min_cycle_runtime_min=0 AND min_cycle_offtime_min=0""",
+        (RECOMMENDED_MIN_CYCLE_RUNTIME_MIN, RECOMMENDED_MIN_CYCLE_OFFTIME_MIN),
+    )
+    if cursor.rowcount and cursor.rowcount > 0:
+        log.info(
+            "Short-cycle defaults migration: enabled protection on %d existing "
+            "thermostat(s) (runtime=%d min, off-time=%d min)",
+            cursor.rowcount,
+            RECOMMENDED_MIN_CYCLE_RUNTIME_MIN,
+            RECOMMENDED_MIN_CYCLE_OFFTIME_MIN,
+        )
 
     await conn.execute(
         """INSERT INTO system_settings(key,value) VALUES(?,?)

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -771,6 +771,23 @@ class CycleEngine:
                 except Exception as exc:
                     log.debug("Failed to record temp sample: %s", exc)
 
+        # Minimum cycle runtime hold (Issue #208). If every room in the cycle
+        # has reached target but the cycle has not yet run min_cycle_runtime_min,
+        # hold it open rather than completing a too-short cycle: re-open ALL of
+        # the cycle's vents so the air handler keeps a full duct path (no
+        # high-static-pressure dead-heading through whichever room finished
+        # last) and the unavoidable overshoot is distributed evenly across the
+        # rooms that were part of the cycle. The cycle terminates normally once
+        # the runtime clock is satisfied. With min_cycle_runtime_min = 0 the
+        # guard is disabled and this never fires.
+        if (
+            self._active_rooms
+            and not self._cycle_runtime_satisfied(tc)
+            and self._all_active_rooms_satisfied(hvac_mode)
+        ):
+            await self._enter_min_runtime_hold(conn)
+            return
+
         all_at_target = True
         for room_id, ar in self._active_rooms.items():
             rcs = self._room_cycle_states.get(room_id)
@@ -806,37 +823,6 @@ class CycleEngine:
                     sum(1 for r in self._room_cycle_states.values() if r.vent_closed_at is None)
                     == 1
                 )
-                # Minimum cycle runtime (Issue #208). If this is the final room
-                # left to satisfy and the cycle has not yet run long enough,
-                # hold its vent open so the HVAC keeps running rather than
-                # completing a too-short cycle. The room overshoots slightly —
-                # bounded by min_cycle_runtime_min — which is far preferable to
-                # short-cycling the compressor. Earlier rooms still close on
-                # schedule; only the last one is held to keep the cycle alive.
-                if is_last_vent_to_close and not self._cycle_runtime_satisfied(tc):
-                    log.info(
-                        "Room %s at target but holding cycle open for %s — "
-                        "minimum runtime (%d min) not yet met",
-                        ar.room.name,
-                        self.thermostat_entity_id,
-                        tc.min_cycle_runtime_min,
-                    )
-                    if self._logger:
-                        await self._logger.log(
-                            "info",
-                            "engine",
-                            f"Room {ar.room.name} reached target but cycle held open "
-                            f"for {self.thermostat_entity_id} — minimum runtime "
-                            f"{tc.min_cycle_runtime_min} min not yet met",
-                            {
-                                "thermostat": self.thermostat_entity_id,
-                                "room_id": room_id,
-                                "room_name": ar.room.name,
-                                "min_cycle_runtime_min": tc.min_cycle_runtime_min,
-                            },
-                        )
-                    all_at_target = False
-                    continue
                 if is_last_vent_to_close and tc.min_open_vents > 0:
                     open_count = self._vent._count_open_vents(all_zone_vents)
                     would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
@@ -2268,6 +2254,91 @@ class CycleEngine:
         if now is None:
             now = datetime.now(UTC)
         return now - self._cycle_log.started_at >= timedelta(minutes=tc.min_cycle_runtime_min)
+
+    def _all_active_rooms_satisfied(self, hvac_mode: str) -> bool:
+        """Return True if every active room has reached target this cycle.
+
+        A room whose vent already closed counts as satisfied. A room with no
+        sensor reading cannot block — it is treated as satisfied, mirroring
+        ``_monitor_rooms``. Used to detect when a cycle would normally
+        terminate, so the minimum-runtime hold can engage instead.
+        """
+        for room_id, ar in self._active_rooms.items():
+            rcs = self._room_cycle_states.get(room_id)
+            if rcs is None:
+                return False
+            if rcs.vent_closed_at is not None:
+                continue
+            avg = self._get_avg_temp(ar.room)
+            if avg is None:
+                continue
+            if not _is_at_target(avg + ar.room.temp_offset, rcs.target_temp, hvac_mode):
+                return False
+        return True
+
+    async def _enter_min_runtime_hold(self, conn: aiosqlite.Connection) -> None:
+        """Hold a satisfied-but-too-young cycle open without dead-heading.
+
+        Every room in the cycle has reached target but the cycle has not yet
+        run ``min_cycle_runtime_min``. Re-open the vents of any cycle rooms
+        that closed earlier so the air handler keeps a full duct path and the
+        leftover heat/cool is spread across every room that was part of the
+        cycle — rather than dumped into whichever room finished last, which
+        would dead-head the system through a single vent.
+
+        Idempotent: once every cycle vent is open again this is a no-op until
+        the runtime clock expires and the cycle terminates normally. Idle and
+        opposite-direction rooms are deliberately left closed — the HVAC is
+        still running, so opening them would waste conditioning or drive a
+        room the wrong way.
+        """
+        reopened: list[str] = []
+        for room_id in self._active_rooms:
+            rcs = self._room_cycle_states.get(room_id)
+            if rcs is None or rcs.vent_closed_at is None:
+                continue
+            vents = self._room_vents.get(room_id, [])
+            await self._vent.open_room_vents(vents)
+            rcs.vent_closed_at = None
+            await db.upsert_room_cycle_state(conn, rcs)
+            reopened.append(room_id)
+            if self._cycle_log:
+                ts = datetime.now(UTC)
+                for v in vents:
+                    try:
+                        await db.insert_cycle_vent_event(
+                            conn,
+                            self._cycle_log.id,
+                            ts,
+                            v.entity_id,
+                            room_id,
+                            "reopened_min_runtime_hold",
+                            "cycle satisfied — held open for minimum runtime",
+                        )
+                    except Exception as exc:
+                        log.debug("Failed to record reopened_min_runtime_hold event: %s", exc)
+
+        if reopened:
+            room_names = [self._active_rooms[r].room.name for r in reopened]
+            log.info(
+                "Cycle for %s reached target before its minimum runtime — "
+                "re-opened %d room(s) %s to hold the cycle open with full airflow",
+                self.thermostat_entity_id,
+                len(reopened),
+                room_names,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Cycle for {self.thermostat_entity_id} reached target before its "
+                    f"minimum runtime — re-opened {room_names} so the HVAC keeps running "
+                    f"with full airflow until the minimum runtime is met",
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "reopened_rooms": room_names,
+                    },
+                )
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -85,6 +85,12 @@ class CycleEngine:
         self._last_reconciled_at: datetime | None = None
         self._sensor_map: dict[str, list[str]] = {}
 
+        # Short-cycle protection (Issue #208): wall-clock time the most recent
+        # cycle ended (terminated or aborted). Used to enforce the compressor
+        # off-time lockout before a new cycle may start. In-memory only — a
+        # server restart resets it (a restart is itself a multi-minute gap).
+        self._last_cycle_ended_at: datetime | None = None
+
     # ------------------------------------------------------------------
     # Public
     # ------------------------------------------------------------------
@@ -283,6 +289,35 @@ class CycleEngine:
         if not new_active_map:
             if self._state != CycleState.IDLE:
                 await self._abort_cycle(conn, reason="no compatible rooms after filtering")
+            await self._maybe_reconcile(conn)
+            await self._maybe_broadcast()
+            return
+
+        # Compressor off-time lockout (Issue #208). When the engine is IDLE and
+        # a cycle ended recently, defer starting a new one until the configured
+        # off-time has elapsed. This only gates a fresh IDLE→RUNNING start; an
+        # already-running cycle is never interrupted by the lockout.
+        if self._state == CycleState.IDLE and self._in_offtime_lockout(tc):
+            remaining = self._offtime_lockout_remaining(tc)
+            log.warning(
+                "Compressor off-time lockout active for %s — %.1f min remaining, "
+                "deferring new cycle",
+                self.thermostat_entity_id,
+                remaining,
+            )
+            if self._logger:
+                await self._logger.log(
+                    "warning",
+                    "engine",
+                    f"Compressor off-time lockout for {self.thermostat_entity_id} — "
+                    f"new cycle deferred {remaining:.1f} min "
+                    f"(min_cycle_offtime_min={tc.min_cycle_offtime_min})",
+                    {
+                        "thermostat": self.thermostat_entity_id,
+                        "min_cycle_offtime_min": tc.min_cycle_offtime_min,
+                        "lockout_remaining_min": round(remaining, 1),
+                    },
+                )
             await self._maybe_reconcile(conn)
             await self._maybe_broadcast()
             return
@@ -771,6 +806,37 @@ class CycleEngine:
                     sum(1 for r in self._room_cycle_states.values() if r.vent_closed_at is None)
                     == 1
                 )
+                # Minimum cycle runtime (Issue #208). If this is the final room
+                # left to satisfy and the cycle has not yet run long enough,
+                # hold its vent open so the HVAC keeps running rather than
+                # completing a too-short cycle. The room overshoots slightly —
+                # bounded by min_cycle_runtime_min — which is far preferable to
+                # short-cycling the compressor. Earlier rooms still close on
+                # schedule; only the last one is held to keep the cycle alive.
+                if is_last_vent_to_close and not self._cycle_runtime_satisfied(tc):
+                    log.info(
+                        "Room %s at target but holding cycle open for %s — "
+                        "minimum runtime (%d min) not yet met",
+                        ar.room.name,
+                        self.thermostat_entity_id,
+                        tc.min_cycle_runtime_min,
+                    )
+                    if self._logger:
+                        await self._logger.log(
+                            "info",
+                            "engine",
+                            f"Room {ar.room.name} reached target but cycle held open "
+                            f"for {self.thermostat_entity_id} — minimum runtime "
+                            f"{tc.min_cycle_runtime_min} min not yet met",
+                            {
+                                "thermostat": self.thermostat_entity_id,
+                                "room_id": room_id,
+                                "room_name": ar.room.name,
+                                "min_cycle_runtime_min": tc.min_cycle_runtime_min,
+                            },
+                        )
+                    all_at_target = False
+                    continue
                 if is_last_vent_to_close and tc.min_open_vents > 0:
                     open_count = self._vent._count_open_vents(all_zone_vents)
                     would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
@@ -939,6 +1005,9 @@ class CycleEngine:
         self._active_rooms = {}
         self._room_cycle_states = {}
         self._room_vents = {}
+        # Start the compressor off-time lockout clock (Issue #208). Both normal
+        # termination and abort stop the HVAC, so both arm the lockout.
+        self._last_cycle_ended_at = datetime.now(UTC)
 
         if all_zone_vents:
             log.info(
@@ -1074,6 +1143,9 @@ class CycleEngine:
         self._active_rooms = {}
         self._room_cycle_states = {}
         self._room_vents = {}
+        # Start the compressor off-time lockout clock (Issue #208). Both normal
+        # termination and abort stop the HVAC, so both arm the lockout.
+        self._last_cycle_ended_at = datetime.now(UTC)
 
     # ------------------------------------------------------------------
     # Presence (called externally, then tick is triggered)
@@ -2153,6 +2225,49 @@ class CycleEngine:
         for room_id in room_ids:
             sensors = await db.get_room_sensors(conn, room_id)
             self._sensor_map[room_id] = [s.entity_id for s in sensors]
+
+    # ------------------------------------------------------------------
+    # Short-cycle protection (Issue #208)
+    # ------------------------------------------------------------------
+
+    def _in_offtime_lockout(self, tc: ThermostatConfig, now: datetime | None = None) -> bool:
+        """Return True if the compressor off-time lockout is still active.
+
+        After a cycle ends, the equipment must stay off for at least
+        ``min_cycle_offtime_min`` before a new cycle may start. Restarting a
+        compressor before its internal pressures have equalised is a primary
+        cause of motor and contactor failure.
+        """
+        if tc.min_cycle_offtime_min <= 0 or self._last_cycle_ended_at is None:
+            return False
+        if now is None:
+            now = datetime.now(UTC)
+        return now - self._last_cycle_ended_at < timedelta(minutes=tc.min_cycle_offtime_min)
+
+    def _offtime_lockout_remaining(
+        self, tc: ThermostatConfig, now: datetime | None = None
+    ) -> float:
+        """Return minutes left on the off-time lockout (0.0 if not locked out)."""
+        if not self._in_offtime_lockout(tc, now):
+            return 0.0
+        if now is None:
+            now = datetime.now(UTC)
+        assert self._last_cycle_ended_at is not None
+        elapsed_min = (now - self._last_cycle_ended_at).total_seconds() / 60
+        return tc.min_cycle_offtime_min - elapsed_min
+
+    def _cycle_runtime_satisfied(self, tc: ThermostatConfig, now: datetime | None = None) -> bool:
+        """Return True if the current cycle has run at least ``min_cycle_runtime_min``.
+
+        A cycle that completes seconds after it started has short-cycled the
+        compressor. Normal completion is deferred until this returns True. With
+        no cycle log (nothing running) or the guard disabled, returns True.
+        """
+        if tc.min_cycle_runtime_min <= 0 or self._cycle_log is None:
+            return True
+        if now is None:
+            now = datetime.now(UTC)
+        return now - self._cycle_log.started_at >= timedelta(minutes=tc.min_cycle_runtime_min)
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -142,6 +142,17 @@ class ThermostatConfig:
     # "range"   → set heat_cool/auto mode with low=min_setpoint, high=max_setpoint
     # "single"  → turn off; re-engage heat/cool when a bound is breached
     vacation_hvac_mode: str = "single"
+    # Short-cycle protection (Issue #208). Rapid stop/start of a compressor is a
+    # primary equipment-failure mode.
+    # min_cycle_runtime_min: once a cycle starts, defer its normal completion
+    #   until it has run at least this long — prevents stopping the compressor
+    #   moments after it started.
+    # min_cycle_offtime_min: after a cycle ends, refuse to start a new one until
+    #   this much time has elapsed — the classic compressor anti-short-cycle
+    #   off-timer.
+    # 0 disables either guard.
+    min_cycle_runtime_min: int = 0
+    min_cycle_offtime_min: int = 0
 
 
 @dataclass

--- a/smart_vent/backend/tests/integration/test_short_cycle_protection.py
+++ b/smart_vent/backend/tests/integration/test_short_cycle_protection.py
@@ -1,0 +1,177 @@
+"""Short-cycle protection integration tests (Issue #208).
+
+A compressor that stops and restarts within a few minutes is being damaged.
+These tests drive the full engine against a fake Home Assistant and verify:
+
+  - off-time lockout — a new cycle cannot start until ``min_cycle_offtime_min``
+    has elapsed since the previous cycle ended;
+  - minimum runtime — a cycle that reaches target almost immediately is held
+    open (HVAC keeps running) until ``min_cycle_runtime_min`` has elapsed,
+    rather than completing a too-short cycle;
+  - the new config fields round-trip through the REST API and the DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from .fake_ha import SeededEntities
+
+THERMO = "climate.test_thermostat"
+
+
+async def _create_room_with_schedule(client, target_temp: float = 72.0) -> SeededEntities:
+    """Create a room + sensor + vent + an all-day schedule covering "now"."""
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Bedroom", "thermostat_entity_id": THERMO},
+    )
+    room_id = (await resp.json())["id"]
+
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
+    )
+
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+    return SeededEntities(
+        thermostat=THERMO,
+        sensor="sensor.test_room_temp",
+        vent="cover.test_room_vent",
+        presence="binary_sensor.test_room_presence",
+    )
+
+
+def _engine(client):
+    return client.app["scheduler"]._engines[THERMO]
+
+
+def _seed_cooling_zone(fake_ha) -> None:
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "cooling"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+
+
+@pytest.mark.asyncio
+async def test_offtime_lockout_blocks_new_cycle(client, fake_ha, tick) -> None:
+    """After a cycle completes, the off-time lockout must defer the next one."""
+    _seed_cooling_zone(fake_ha)
+    ents = await _create_room_with_schedule(client, target_temp=72.0)
+
+    # 5-minute compressor off-time lockout.
+    resp = await client.put(f"/api/thermostats/{THERMO}", json={"min_cycle_offtime_min": 5})
+    assert resp.status == 200
+
+    # Tick 1: cooling cycle starts.
+    await tick()
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1 and logs[0]["ended_at"] is None
+
+    # Room reaches target → the cycle completes on the next tick.
+    await fake_ha.set_entity_state(ents.sensor, "72.0", {"unit_of_measurement": "°F"})
+    await tick()
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_at"] is not None, "cycle should have completed"
+    assert _engine(client)._last_cycle_ended_at is not None
+
+    # Room is warm again immediately — but the compressor off-time lockout
+    # is still active, so no new cycle may start.
+    await fake_ha.set_entity_state(ents.sensor, "80.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "off-time lockout must prevent a second cycle from starting"
+    assert not fake_ha.calls_for("set_temperature"), "no HVAC command should be sent during lockout"
+
+
+@pytest.mark.asyncio
+async def test_offtime_lockout_releases_after_window(client, fake_ha, tick) -> None:
+    """Once the off-time window elapses, a new cycle is allowed to start."""
+    _seed_cooling_zone(fake_ha)
+    ents = await _create_room_with_schedule(client, target_temp=72.0)
+    await client.put(f"/api/thermostats/{THERMO}", json={"min_cycle_offtime_min": 5})
+
+    await tick()  # cycle 1 starts
+    await fake_ha.set_entity_state(ents.sensor, "72.0", {"unit_of_measurement": "°F"})
+    await tick()  # cycle 1 completes
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1 and logs[0]["ended_at"] is not None
+
+    # Pretend the previous cycle ended 6 minutes ago — past the lockout.
+    _engine(client)._last_cycle_ended_at = datetime.now(UTC) - timedelta(minutes=6)
+
+    await fake_ha.set_entity_state(ents.sensor, "80.0", {"unit_of_measurement": "°F"})
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 2, "a new cycle should start once the off-time lockout has elapsed"
+
+
+@pytest.mark.asyncio
+async def test_min_runtime_holds_cycle_open(client, fake_ha, tick) -> None:
+    """A cycle that reaches target too soon is held open, not completed."""
+    _seed_cooling_zone(fake_ha)
+    ents = await _create_room_with_schedule(client, target_temp=72.0)
+    await client.put(f"/api/thermostats/{THERMO}", json={"min_cycle_runtime_min": 15})
+
+    await tick()  # cycle starts
+    eng = _engine(client)
+    assert eng.cycle_state.value == "running"
+
+    # Room reaches target almost immediately after the cycle started.
+    await fake_ha.set_entity_state(ents.sensor, "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+    await tick()
+
+    # Minimum runtime not met → cycle must stay open and the vent stay open
+    # (the HVAC keeps running rather than short-cycling the compressor).
+    assert eng.cycle_state.value == "running", "cycle must not complete before min runtime"
+    assert not fake_ha.calls_for("close_cover"), "vent must stay open during the min-runtime hold"
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_at"] is None
+
+    # Backdate the cycle start past the minimum runtime, then tick again.
+    eng._cycle_log.started_at = datetime.now(UTC) - timedelta(minutes=16)
+    await tick()
+
+    assert eng.cycle_state.value == "idle", "cycle should complete once min runtime is satisfied"
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_short_cycle_config_roundtrips_through_api(client, fake_ha) -> None:
+    """The new config fields persist through the REST API and the DB."""
+    resp = await client.put(
+        f"/api/thermostats/{THERMO}",
+        json={"min_cycle_runtime_min": 12, "min_cycle_offtime_min": 7},
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["min_cycle_runtime_min"] == 12
+    assert body["min_cycle_offtime_min"] == 7
+
+    # Re-read from the DB through the list endpoint.
+    listing = await (await client.get("/api/thermostats")).json()
+    entry = next(t for t in listing if t["thermostat_entity_id"] == THERMO)
+    assert entry["min_cycle_runtime_min"] == 12
+    assert entry["min_cycle_offtime_min"] == 7

--- a/smart_vent/backend/tests/integration/test_short_cycle_protection.py
+++ b/smart_vent/backend/tests/integration/test_short_cycle_protection.py
@@ -158,6 +158,94 @@ async def test_min_runtime_holds_cycle_open(client, fake_ha, tick) -> None:
     assert logs[0]["ended_at"] is not None
 
 
+async def _create_room(client, name: str, sensor: str, vent: str, target_temp: float = 72.0) -> str:
+    """Create a room + sensor + vent + all-day schedule. Returns the room id."""
+    resp = await client.post("/api/rooms", json={"name": name, "thermostat_entity_id": THERMO})
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": vent, "control_method": "open_close"},
+    )
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+    return room_id
+
+
+@pytest.mark.asyncio
+async def test_min_runtime_hold_reopens_all_cycle_rooms(client, fake_ha, tick) -> None:
+    """When a multi-room cycle is satisfied before its minimum runtime, a room
+    whose vent closed early is re-opened — the air handler keeps a full duct
+    path instead of dead-heading through whichever room finished last."""
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 80.0, "temperature": 78.0, "hvac_action": "cooling"},
+    )
+    fake_ha.seed_state("sensor.bedroom", "80.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("sensor.office", "80.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.bedroom_vent", "closed", {})
+    fake_ha.seed_state("cover.office_vent", "closed", {})
+
+    await _create_room(client, "Bedroom", "sensor.bedroom", "cover.bedroom_vent", 72.0)
+    await _create_room(client, "Office", "sensor.office", "cover.office_vent", 72.0)
+    await client.put(
+        f"/api/thermostats/{THERMO}",
+        json={"min_cycle_runtime_min": 15, "min_open_vents": 1},
+    )
+
+    # Tick 1: cooling cycle starts, both vents open.
+    await tick()
+    eng = _engine(client)
+    assert eng.cycle_state.value == "running"
+    cycle_id = (await (await client.get("/api/logs")).json())[0]["id"]
+
+    # Tick 2: Bedroom reaches target while Office is still warm → Bedroom vent
+    # closes (normal progressive zoning).
+    await fake_ha.set_entity_state("sensor.bedroom", "72.0", {"unit_of_measurement": "°F"})
+    await tick()
+    assert fake_ha.get_state("cover.bedroom_vent")["state"] == "closed"
+    assert fake_ha.get_state("cover.office_vent")["state"] == "open"
+
+    # Tick 3: Office reaches target too. The cycle would normally complete, but
+    # the minimum runtime is not met → hold: Bedroom's vent is RE-OPENED so the
+    # leftover cooling is spread across both rooms, not dumped into Office.
+    await fake_ha.set_entity_state("sensor.office", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+    await tick()
+
+    assert eng.cycle_state.value == "running", "cycle must hold open below min runtime"
+    assert fake_ha.get_state("cover.bedroom_vent")["state"] == "open", (
+        "the early-closed room must be re-opened during the min-runtime hold"
+    )
+    assert fake_ha.get_state("cover.office_vent")["state"] == "open"
+    assert fake_ha.calls_for("open_cover"), "the hold should re-open the early-closed vent"
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_at"] is None
+
+    # The re-open is recorded in the cycle diagnostics stream.
+    detail = await (await client.get(f"/api/logs/{cycle_id}/detail")).json()
+    actions = [e["action"] for e in detail["vent_events"]]
+    assert "reopened_min_runtime_hold" in actions
+
+    # Advance past the minimum runtime → the cycle completes normally.
+    eng._cycle_log.started_at = datetime.now(UTC) - timedelta(minutes=16)
+    await tick()
+    assert eng.cycle_state.value == "idle", "cycle should complete once min runtime is met"
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_at"] is not None
+
+
 @pytest.mark.asyncio
 async def test_short_cycle_config_roundtrips_through_api(client, fake_ha) -> None:
     """The new config fields persist through the REST API and the DB."""

--- a/smart_vent/backend/tests/integration/test_short_cycle_protection.py
+++ b/smart_vent/backend/tests/integration/test_short_cycle_protection.py
@@ -161,7 +161,7 @@ async def test_min_runtime_holds_cycle_open(client, fake_ha, tick) -> None:
 async def _create_room(client, name: str, sensor: str, vent: str, target_temp: float = 72.0) -> str:
     """Create a room + sensor + vent + all-day schedule. Returns the room id."""
     resp = await client.post("/api/rooms", json={"name": name, "thermostat_entity_id": THERMO})
-    room_id = (await resp.json())["id"]
+    room_id: str = (await resp.json())["id"]
     await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
     await client.post(
         f"/api/rooms/{room_id}/vents",

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -1049,4 +1050,126 @@ class TestTerminateCycleDbClose:
         open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
         assert len(open_logs) == 0, "DB record must be closed despite vent failure"
         assert engine.cycle_state == CycleState.IDLE
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Short-cycle protection (Issue #208)
+# ---------------------------------------------------------------------------
+
+
+class TestOfftimeLockout:
+    """_in_offtime_lockout — compressor minimum off-time between cycles.
+
+    Rapid restart of a compressor is a primary equipment-failure mode. After a
+    cycle ends, a new one must not start until min_cycle_offtime_min elapses.
+    """
+
+    def test_disabled_when_offtime_zero(self):
+        engine = _make_engine()
+        engine._last_cycle_ended_at = datetime.now(UTC)
+        tc = _make_tc(min_cycle_offtime_min=0)
+        assert engine._in_offtime_lockout(tc) is False
+
+    def test_no_lockout_when_no_prior_cycle(self):
+        engine = _make_engine()
+        assert engine._last_cycle_ended_at is None
+        tc = _make_tc(min_cycle_offtime_min=5)
+        assert engine._in_offtime_lockout(tc) is False
+
+    def test_locked_out_within_window(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._last_cycle_ended_at = now - timedelta(minutes=2)
+        tc = _make_tc(min_cycle_offtime_min=5)
+        assert engine._in_offtime_lockout(tc, now=now) is True
+
+    def test_not_locked_out_after_window(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._last_cycle_ended_at = now - timedelta(minutes=6)
+        tc = _make_tc(min_cycle_offtime_min=5)
+        assert engine._in_offtime_lockout(tc, now=now) is False
+
+    def test_boundary_exactly_at_limit_is_expired(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._last_cycle_ended_at = now - timedelta(minutes=5)
+        tc = _make_tc(min_cycle_offtime_min=5)
+        # At exactly the limit the lockout has elapsed — a cycle may start.
+        assert engine._in_offtime_lockout(tc, now=now) is False
+
+    def test_remaining_minutes_reported(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._last_cycle_ended_at = now - timedelta(minutes=2)
+        tc = _make_tc(min_cycle_offtime_min=5)
+        assert engine._offtime_lockout_remaining(tc, now=now) == pytest.approx(3.0)
+
+    def test_remaining_is_zero_when_not_locked(self):
+        engine = _make_engine()
+        tc = _make_tc(min_cycle_offtime_min=5)
+        assert engine._offtime_lockout_remaining(tc) == 0.0
+
+
+class TestCycleRuntimeSatisfied:
+    """_cycle_runtime_satisfied — compressor minimum run time.
+
+    A cycle that completes seconds after it started has short-cycled the
+    compressor. Normal completion is deferred until min_cycle_runtime_min.
+    """
+
+    def test_satisfied_when_runtime_zero(self):
+        engine = _make_engine()
+        engine._cycle_log = CycleLog.create(
+            thermostat_entity_id=THERMO_ID, mode="cooling", rooms_json="{}"
+        )
+        tc = _make_tc(min_cycle_runtime_min=0)
+        assert engine._cycle_runtime_satisfied(tc) is True
+
+    def test_satisfied_when_no_cycle_log(self):
+        engine = _make_engine()
+        engine._cycle_log = None
+        tc = _make_tc(min_cycle_runtime_min=10)
+        assert engine._cycle_runtime_satisfied(tc) is True
+
+    def test_not_satisfied_before_minimum(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._cycle_log = CycleLog.create(
+            thermostat_entity_id=THERMO_ID, mode="cooling", rooms_json="{}"
+        )
+        engine._cycle_log.started_at = now - timedelta(minutes=3)
+        tc = _make_tc(min_cycle_runtime_min=10)
+        assert engine._cycle_runtime_satisfied(tc, now=now) is False
+
+    def test_satisfied_after_minimum(self):
+        engine = _make_engine()
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        engine._cycle_log = CycleLog.create(
+            thermostat_entity_id=THERMO_ID, mode="cooling", rooms_json="{}"
+        )
+        engine._cycle_log.started_at = now - timedelta(minutes=11)
+        tc = _make_tc(min_cycle_runtime_min=10)
+        assert engine._cycle_runtime_satisfied(tc, now=now) is True
+
+
+class TestCycleEndRecordsTimestamp:
+    """_terminate_cycle and _abort_cycle must record when the cycle ended so
+    the off-time lockout can gate the next cycle (Issue #208)."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_records_end_timestamp(self):
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        assert engine._last_cycle_ended_at is None
+        await engine._terminate_cycle(conn)
+        assert engine._last_cycle_ended_at is not None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_records_end_timestamp(self):
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        assert engine._last_cycle_ended_at is None
+        await engine._abort_cycle(conn, reason="test")
+        assert engine._last_cycle_ended_at is not None
         await conn.close()

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1173,3 +1173,125 @@ class TestCycleEndRecordsTimestamp:
         await engine._abort_cycle(conn, reason="test")
         assert engine._last_cycle_ended_at is not None
         await conn.close()
+
+
+class TestAllActiveRoomsSatisfied:
+    """_all_active_rooms_satisfied — detecting when a cycle would terminate,
+    so the minimum-runtime hold can engage (Issue #208)."""
+
+    def _engine_with_rooms(self, temps: dict[str, float]) -> CycleEngine:
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        engine._sensor_map = {rid: [f"s_{rid}"] for rid in temps}
+        readings = {f"s_{rid}": t for rid, t in temps.items()}
+        ha.get_numeric_state.side_effect = lambda eid: readings.get(eid)
+        return engine
+
+    def test_all_rooms_at_target_returns_true(self):
+        engine = self._engine_with_rooms({"r1": 72.0, "r2": 71.0})
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=72.0, source="schedule"),
+        }
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id="c", room_id="r1", target_temp=72.0),
+            "r2": RoomCycleState(cycle_id="c", room_id="r2", target_temp=72.0),
+        }
+        assert engine._all_active_rooms_satisfied("cooling") is True
+
+    def test_one_room_not_at_target_returns_false(self):
+        engine = self._engine_with_rooms({"r1": 72.0, "r2": 78.0})
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=72.0, source="schedule"),
+        }
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id="c", room_id="r1", target_temp=72.0),
+            "r2": RoomCycleState(cycle_id="c", room_id="r2", target_temp=72.0),
+        }
+        assert engine._all_active_rooms_satisfied("cooling") is False
+
+    def test_already_closed_room_counts_as_satisfied(self):
+        # r1's vent closed earlier — counts as satisfied even though it now
+        # reads warm (it has drifted since its vent shut).
+        engine = self._engine_with_rooms({"r1": 99.0, "r2": 72.0})
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=72.0, source="schedule"),
+        }
+        rcs1 = RoomCycleState(cycle_id="c", room_id="r1", target_temp=72.0)
+        rcs1.vent_closed_at = datetime.now(UTC)
+        engine._room_cycle_states = {
+            "r1": rcs1,
+            "r2": RoomCycleState(cycle_id="c", room_id="r2", target_temp=72.0),
+        }
+        assert engine._all_active_rooms_satisfied("cooling") is True
+
+    def test_room_without_reading_is_skipped(self):
+        # r1 has no sensor reading — it cannot block, mirroring _monitor_rooms.
+        engine = self._engine_with_rooms({"r2": 72.0})
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+            "r2": ActiveRoom(room=_make_room("r2"), target_temp=72.0, source="schedule"),
+        }
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id="c", room_id="r1", target_temp=72.0),
+            "r2": RoomCycleState(cycle_id="c", room_id="r2", target_temp=72.0),
+        }
+        assert engine._all_active_rooms_satisfied("cooling") is True
+
+    def test_missing_cycle_state_returns_false(self):
+        engine = self._engine_with_rooms({"r1": 72.0})
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=_make_room("r1"), target_temp=72.0, source="schedule"),
+        }
+        engine._room_cycle_states = {}
+        assert engine._all_active_rooms_satisfied("cooling") is False
+
+
+class TestEnterMinRuntimeHold:
+    """_enter_min_runtime_hold — re-open early-closed cycle rooms so the air
+    handler is not dead-headed through one room during the hold (Issue #208)."""
+
+    @pytest.mark.asyncio
+    async def test_reopens_room_that_closed_early(self):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+
+        # Add a second room; r1 closed early, r2 still open.
+        room2 = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        room2.id = "r2"
+        await db.upsert_room(conn, room2)
+        engine._active_rooms["r2"] = ActiveRoom(room=room2, target_temp=74.0, source="schedule")
+        rcs1 = RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=74.0)
+        rcs1.vent_closed_at = datetime.now(UTC)
+        rcs2 = RoomCycleState(cycle_id=cycle.id, room_id="r2", target_temp=74.0)
+        engine._room_cycle_states = {"r1": rcs1, "r2": rcs2}
+        await db.upsert_room_cycle_state(conn, rcs1)
+        await db.upsert_room_cycle_state(conn, rcs2)
+        engine._room_vents = {
+            "r1": [RoomVent.create("r1", "cover.vent_r1")],
+            "r2": [RoomVent.create("r2", "cover.vent_r2")],
+        }
+
+        await engine._enter_min_runtime_hold(conn)
+
+        opened = [c.args[0] for c in engine._ha.open_cover.await_args_list]
+        assert "cover.vent_r1" in opened, "the early-closed room's vent must be re-opened"
+        assert rcs1.vent_closed_at is None, "vent_closed_at must be cleared on re-open"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_room_was_closed(self):
+        from backend.models import RoomVent
+
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        # r1's vent_closed_at is None (never closed) — nothing to re-open.
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+
+        await engine._enter_min_runtime_hold(conn)
+
+        engine._ha.open_cover.assert_not_awaited()
+        await conn.close()

--- a/smart_vent/backend/tests/test_db_migration.py
+++ b/smart_vent/backend/tests/test_db_migration.py
@@ -1,12 +1,20 @@
 """
-Tests for the one-shot flair.db → app.db rename helper in backend.main.
+Tests for the one-shot flair.db → app.db rename helper in backend.main,
+and for sentinel-guarded data migrations in backend.db.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import aiosqlite
+import pytest
+
+from backend import db
 from backend.main import _migrate_db_filename
+from backend.models import ThermostatConfig
+
+_SHORT_CYCLE_SENTINEL = "migration_short_cycle_defaults_v1"
 
 
 def test_fresh_dir_is_noop(tmp_path: Path) -> None:
@@ -56,3 +64,113 @@ def test_idempotent_second_call(tmp_path: Path) -> None:
 
     assert not (tmp_path / "flair.db").exists()
     assert (tmp_path / "app.db").read_bytes() == b"data"
+
+
+# ---------------------------------------------------------------------------
+# Short-cycle protection default back-fill (Issue #208)
+# ---------------------------------------------------------------------------
+
+
+async def _fresh_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _clear_short_cycle_sentinel(conn: aiosqlite.Connection) -> None:
+    """Drop the migration sentinel so _migrate_short_cycle_defaults runs again,
+    simulating the first startup after the feature is deployed."""
+    await conn.execute("DELETE FROM system_settings WHERE key=?", (_SHORT_CYCLE_SENTINEL,))
+    await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_existing_thermostat_gets_recommended_short_cycle_values() -> None:
+    """A thermostat that existed before the feature is back-filled with the
+    recommended minimums."""
+    conn = await _fresh_db()
+    try:
+        # A pre-existing thermostat with the short-cycle guards still disabled.
+        await db.upsert_thermostat_config(
+            conn, ThermostatConfig(thermostat_entity_id="climate.old")
+        )
+        # Re-run the migration as if for the first time after deploy.
+        await _clear_short_cycle_sentinel(conn)
+        await db._migrate_short_cycle_defaults(conn)
+
+        tc = await db.get_thermostat_config(conn, "climate.old")
+        assert tc.min_cycle_runtime_min == db.RECOMMENDED_MIN_CYCLE_RUNTIME_MIN
+        assert tc.min_cycle_offtime_min == db.RECOMMENDED_MIN_CYCLE_OFFTIME_MIN
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_new_thermostat_keeps_disabled_default() -> None:
+    """A thermostat registered after the migration has already run keeps the
+    0 (disabled) default — it is not back-filled."""
+    conn = await _fresh_db()
+    try:
+        # init_db already ran the migration and set the sentinel. A thermostat
+        # created now represents a brand-new registration.
+        await db.upsert_thermostat_config(
+            conn, ThermostatConfig(thermostat_entity_id="climate.new")
+        )
+        await db._migrate_short_cycle_defaults(conn)  # sentinel present → no-op
+
+        tc = await db.get_thermostat_config(conn, "climate.new")
+        assert tc.min_cycle_runtime_min == 0
+        assert tc.min_cycle_offtime_min == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_user_tuned_values() -> None:
+    """The back-fill must not overwrite a thermostat the user already tuned to
+    non-zero short-cycle values."""
+    conn = await _fresh_db()
+    try:
+        await db.upsert_thermostat_config(
+            conn,
+            ThermostatConfig(
+                thermostat_entity_id="climate.tuned",
+                min_cycle_runtime_min=20,
+                min_cycle_offtime_min=8,
+            ),
+        )
+        await _clear_short_cycle_sentinel(conn)
+        await db._migrate_short_cycle_defaults(conn)
+
+        tc = await db.get_thermostat_config(conn, "climate.tuned")
+        assert tc.min_cycle_runtime_min == 20
+        assert tc.min_cycle_offtime_min == 8
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_runs_only_once() -> None:
+    """Once the sentinel is set the migration is a no-op, so a value the user
+    later resets to 0 is not force-enabled again on the next startup."""
+    conn = await _fresh_db()
+    try:
+        await db.upsert_thermostat_config(conn, ThermostatConfig(thermostat_entity_id="climate.x"))
+        # First run back-fills the existing thermostat.
+        await _clear_short_cycle_sentinel(conn)
+        await db._migrate_short_cycle_defaults(conn)
+
+        # User deliberately disables it again.
+        tc = await db.get_thermostat_config(conn, "climate.x")
+        tc.min_cycle_runtime_min = 0
+        tc.min_cycle_offtime_min = 0
+        await db.upsert_thermostat_config(conn, tc)
+
+        # A later startup must not re-enable it (sentinel already set).
+        await db._migrate_short_cycle_defaults(conn)
+        tc = await db.get_thermostat_config(conn, "climate.x")
+        assert tc.min_cycle_runtime_min == 0
+        assert tc.min_cycle_offtime_min == 0
+    finally:
+        await conn.close()

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -70,6 +70,11 @@ export interface ThermostatConfig {
   // "range"  → heat_cool/auto with low=min_setpoint, high=max_setpoint
   // "single" → turn off; correct when a bound is breached
   vacation_hvac_mode: "range" | "single";
+  // Short-cycle protection. 0 = disabled for either guard.
+  // min_cycle_runtime_min: hold a cycle open at least this long before completing.
+  // min_cycle_offtime_min: wait at least this long after a cycle ends before starting a new one.
+  min_cycle_runtime_min: number;
+  min_cycle_offtime_min: number;
 }
 
 export interface VacationMode {

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -62,6 +62,8 @@ describe("Dashboard Page", () => {
         cycle_timeout_hours: 2,
         reconciliation_interval_min: 5,
         vacation_hvac_mode: "single" as const,
+        min_cycle_runtime_min: 0,
+        min_cycle_offtime_min: 0,
       },
     ]);
   });

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -40,6 +40,8 @@ describe("Metrics Page", () => {
         cycle_timeout_hours: 2,
         reconciliation_interval_min: 5,
         vacation_hvac_mode: "single" as const,
+        min_cycle_runtime_min: 0,
+        min_cycle_offtime_min: 0,
       },
     ]);
     vi.mocked(api.getMetricsHomeSummary).mockResolvedValue(mockSummary);

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -20,6 +20,8 @@ const mockThermostats: api.ThermostatConfig[] = [
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
     vacation_hvac_mode: "single" as const,
+    min_cycle_runtime_min: 0,
+    min_cycle_offtime_min: 0,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Settings.test.tsx
+++ b/smart_vent/frontend/src/pages/Settings.test.tsx
@@ -20,6 +20,8 @@ const mockThermostats: api.ThermostatConfig[] = [
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
     vacation_hvac_mode: "single" as const,
+    min_cycle_runtime_min: 0,
+    min_cycle_offtime_min: 0,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -20,6 +20,8 @@ const mockThermostats: api.ThermostatConfig[] = [
     cycle_timeout_hours: 2,
     reconciliation_interval_min: 5,
     vacation_hvac_mode: "single" as const,
+    min_cycle_runtime_min: 0,
+    min_cycle_offtime_min: 0,
   },
 ];
 
@@ -95,6 +97,29 @@ describe("Thermostats Page", () => {
         "climate.test",
         expect.objectContaining({
           name: "Updated Name",
+        })
+      );
+    });
+  });
+
+  it("edits and saves the short-cycle protection settings", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    render(<Thermostats />);
+
+    const runtimeInput = await screen.findByLabelText(/Min cycle runtime/i);
+    const offtimeInput = await screen.findByLabelText(/Min compressor off-time/i);
+    fireEvent.change(runtimeInput, { target: { value: "10" } });
+    fireEvent.change(offtimeInput, { target: { value: "5" } });
+
+    const card = runtimeInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({
+          min_cycle_runtime_min: 10,
+          min_cycle_offtime_min: 5,
         })
       );
     });

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -84,7 +84,7 @@ const SAFETY_FIELDS: {
   {
     key: "min_cycle_runtime_min",
     label: "Min cycle runtime (min)",
-    help: "Keep the HVAC running at least this long before completing a cycle, to protect the compressor from short-cycling. 0 = disabled.",
+    help: "Keep the HVAC running at least this long before completing a cycle, to protect the compressor from short-cycling. Recommended: 10 min (long enough to return oil to the compressor and condition effectively). 0 = disabled.",
     step: "1",
     min: "0",
     kind: "other",
@@ -92,7 +92,7 @@ const SAFETY_FIELDS: {
   {
     key: "min_cycle_offtime_min",
     label: "Min compressor off-time (min)",
-    help: "Wait at least this long after a cycle ends before starting a new one, so the compressor is not restarted too soon. 0 = disabled.",
+    help: "Wait at least this long after a cycle ends before starting a new one, so the compressor is not restarted too soon. Recommended: 5 min — the industry-standard anti-short-cycle delay that lets refrigerant pressures equalize. 0 = disabled.",
     step: "1",
     min: "0",
     kind: "other",

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -81,6 +81,22 @@ const SAFETY_FIELDS: {
     min: "0.5",
     kind: "other",
   },
+  {
+    key: "min_cycle_runtime_min",
+    label: "Min cycle runtime (min)",
+    help: "Keep the HVAC running at least this long before completing a cycle, to protect the compressor from short-cycling. 0 = disabled.",
+    step: "1",
+    min: "0",
+    kind: "other",
+  },
+  {
+    key: "min_cycle_offtime_min",
+    label: "Min compressor off-time (min)",
+    help: "Wait at least this long after a cycle ends before starting a new one, so the compressor is not restarted too soon. 0 = disabled.",
+    step: "1",
+    min: "0",
+    kind: "other",
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #208. The cycle engine previously bounded cycle duration only on the **upper** end (`cycle_timeout_hours`). Nothing prevented it from rapidly stopping and restarting HVAC equipment — short-cycling, the single most common way control software damages a compressor. This PR adds two guards:

- **Compressor off-time lockout** — after a cycle ends, `_do_tick` refuses to start a new `IDLE→RUNNING` cycle until `min_cycle_offtime_min` has elapsed. `_terminate_cycle` / `_abort_cycle` record `_last_cycle_ended_at` to arm the lockout. A *running* cycle is never interrupted by the lockout. Each deferral writes a `warning` event log with the remaining lockout time.

- **Minimum cycle runtime — with an airflow-safe hold.** When every room in a cycle reaches target before the cycle has run `min_cycle_runtime_min`, `_monitor_rooms` enters an explicit **minimum-runtime hold**: it re-opens the vents of *every room in the cycle* so the air handler keeps a full duct path, then waits out the runtime clock and terminates normally.

### Why the hold re-opens all cycle rooms (design note)

The first cut held a *single* vent open. As flagged in review, that funnels the air handler's full CFM through one room — a high-static-pressure / low-airflow condition that risks a **furnace high-limit trip** or **evaporator coil icing**, and dumps all the overshoot into one room. The redesigned hold re-opens every cycle room: full duct path, static pressure normal, overshoot distributed evenly. Idle and opposite-direction rooms stay **closed** (the HVAC is still running). It is idempotent — no per-tick vent-actuator chatter.

Both settings are new `ThermostatConfig` fields, persisted through the DB (table DDL + migration) and the thermostat REST endpoints, and **editable from the Thermostats page UI**.

## Defaults and the existing-thermostat back-fill

- **New thermostats** ship with both fields at `0` (disabled); the user opts in from the Thermostats UI, which shows the recommended values inline.
- **Thermostats that already existed** before this feature are presumably controlling live equipment, so a one-time, sentinel-guarded data migration (`_migrate_short_cycle_defaults`) back-fills their `thermostat_configs` rows with the recommended minimums rather than leaving the equipment unprotected. It only touches rows still at `0/0` (a user who already tuned the values keeps them) and runs **exactly once** (a value later reset to `0` is not force-enabled again).

### Recommended values (industry-standard minimums)

- **Min compressor off-time: 5 min** — standard anti-short-cycle delay; lets refrigerant high/low-side pressures equalize so the compressor doesn't restart against high head pressure.
- **Min cycle runtime: 10 min** — long enough to return oil to the compressor crankcase and do meaningful conditioning/dehumidification.

These constants live in `db.py` (`RECOMMENDED_MIN_CYCLE_RUNTIME_MIN` / `RECOMMENDED_MIN_CYCLE_OFFTIME_MIN`) and the Thermostats UI help text.

> **Release note:** upgrading enables short-cycle protection on existing thermostats (10 min runtime / 5 min off-time). Behavior is protective and visible in the event log when the hold/lockout engages.

## Changes

**Backend**
- `models.py` — `min_cycle_runtime_min`, `min_cycle_offtime_min` on `ThermostatConfig`.
- `db.py` — new `thermostat_configs` columns (DDL + two `ALTER TABLE` migrations); `_row_to_tc` / `upsert_thermostat_config` updated; `_migrate_short_cycle_defaults` one-time back-fill.
- `api/routes.py` — both thermostat config endpoints accept the new fields.
- `engine/cycle_engine.py` — `_in_offtime_lockout`, `_offtime_lockout_remaining`, `_cycle_runtime_satisfied`, `_all_active_rooms_satisfied`, `_enter_min_runtime_hold`; off-time gate in `_do_tick`; minimum-runtime hold pre-check in `_monitor_rooms`; `_last_cycle_ended_at` recorded on cycle end. New `reopened_min_runtime_hold` diagnostic vent event.

**Frontend**
- `api.ts` — the two fields on the `ThermostatConfig` interface.
- `pages/Thermostats.tsx` — both fields in "Safety & cycle settings"; help text carries the recommended minimums.

## Test plan

Developed test-first (TDD):

- [x] Backend unit tests — lockout/runtime helpers and boundaries; `_terminate_cycle`/`_abort_cycle` record the end timestamp; `_all_active_rooms_satisfied`; `_enter_min_runtime_hold` re-open behavior.
- [x] Backend integration tests — off-time lockout blocks then releases a second cycle; single-room cycle held open until min runtime; multi-room cycle re-opens the early-closed room during the hold and records the `reopened_min_runtime_hold` diagnostic; config fields round-trip through the REST API and DB.
- [x] Migration tests — existing thermostat is back-filled with the recommended values; a thermostat created after the migration keeps `0`; user-tuned non-zero values are preserved; the migration runs only once.
- [x] Full backend suite: 578 passed, no regressions. Coverage 94% (gate 90%).
- [x] Full frontend suite: 142 passed; `tsc`, ESLint, Prettier clean.
- [x] `ruff check` + `ruff format --check` + `mypy` clean.

## Notes / follow-ups

- `_last_cycle_ended_at` is in-memory only — a server restart resets the lockout. A restart is itself a multi-minute gap, so this is acceptable; noted in code comments.
- Debouncing the mid-cycle `trigger_changed` teardown is tracked separately in #215 — the off-time lockout already mitigates rapid trigger flapping.

https://claude.ai/code/session_01FeWMqLrVNdSQH4ntAEc3Xx