### PR TITLE
Add outdoor-temperature cooling lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Feature-by-feature guides live in [`docs/`](./docs/README.md):
 - [Cycle engine](./docs/cycle-engine.md) — how a cycle runs, tick by tick
 - [Vent control methods](./docs/vent-control.md) — open/close, set_position, set_tilt_position, toggle
 - [Thermostat settings](./docs/thermostat-settings.md) — overshoot, deadband, safety limits
+- [Safety features](./docs/safety.md) — short-cycle protection, outdoor-temperature cooling lockout
 - [Schedules](./docs/schedules.md) — time blocks and overnight ranges
 - [Presence & motion](./docs/presence.md) — motion activation and holdover
 - [System modes](./docs/system-modes.md) — System On/Off and Dev Mode
@@ -53,6 +54,20 @@ Each thermostat zone gets one HVAC cycle engine. When rooms in a zone become act
 5. Once all rooms are at target, resets the thermostat setpoint to its own ambient reading — the HVAC shuts off naturally
 
 Multiple rooms sharing one thermostat are fully supported and are the primary use case.
+
+---
+
+## Safety
+
+Plenum drives real HVAC equipment, so it includes protections that exist purely to keep that equipment safe from software decisions:
+
+- **Short-cycle protection** — a minimum compressor run time and a minimum off-time between cycles, so the equipment is never rapidly stopped and restarted.
+- **Outdoor-temperature cooling lockout** — refuses to start a cooling cycle when it is too cold outside, where running an AC compressor risks liquid slugging and coil icing.
+- **Equipment-protection limits** — setpoint clamps, a minimum number of open vents (no dead-heading), a force-reopen valve for closed vents, and a cycle timeout for stuck equipment.
+
+> Plenum assumes a conventional HVAC system (furnace/air handler + AC compressor). **Heat pumps are not supported.**
+
+See [`docs/safety.md`](./docs/safety.md) for how each protection works and how to configure it.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ High-level guide to what Plenum does and how the pieces fit together. For instal
 - [Cycle engine](./cycle-engine.md) — the HVAC cycle state machine: what runs every 60s tick
 - [Vent control methods](./vent-control.md) — the four ways Plenum can drive a `cover.*` entity
 - [Thermostat settings](./thermostat-settings.md) — setpoint bounds, deadband, overshoot, timeouts, safety limits
+- [Safety features](./safety.md) — short-cycle protection, outdoor-temperature cooling lockout, equipment-protection limits
 - [Schedules](./schedules.md) — time blocks, overnight ranges, priority rules
 - [Presence & motion](./presence.md) — motion-triggered activation and holdover
 - [System modes](./system-modes.md) — the System On/Off toggle and Dev Mode

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,0 +1,53 @@
+# Safety features
+
+Plenum drives real HVAC equipment, so several settings exist purely to protect that equipment from being damaged by software decisions. This page collects them and is updated as new protections are added. Each is configured per-thermostat on the **Thermostats** page unless noted.
+
+> **Heat pumps are not supported.** Plenum assumes a conventional system — a furnace or air handler for heat and an AC compressor for cooling. The cooling lockout below has no heating equivalent for that reason.
+
+## Short-cycle protection
+
+Rapidly stopping and restarting a compressor — *short-cycling* — is one of the most common ways control software damages HVAC equipment: it stresses the motor windings and contactor and prevents oil from returning to the compressor. Plenum bounds how often a cycle can stop and start.
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Min cycle runtime** | 0 (disabled) | Once a cycle starts, it is held open at least this many minutes before it may complete normally. Recommended **10 min**. |
+| **Min compressor off-time** | 0 (disabled) | After a cycle ends, a new one may not start for this many minutes. Recommended **5 min** — the industry-standard anti-short-cycle delay that lets refrigerant pressures equalize. |
+
+### How the minimum-runtime hold works
+
+When every room in a cycle reaches its target before the minimum runtime has elapsed, Plenum does **not** stop the HVAC. It re-opens the vents of every room that was part of the cycle so the air handler keeps a full duct path — never dead-heading airflow through a single room — and the small unavoidable overshoot is spread evenly. The cycle completes normally once the runtime clock is satisfied.
+
+### Off-time lockout
+
+While the off-time lockout is active, the engine refuses to start a new cycle and writes a warning to the event log noting how long remains. An already-running cycle is never interrupted by the lockout.
+
+### Existing thermostats
+
+When you upgrade to a build that includes short-cycle protection, thermostats that already existed are **back-filled** with the recommended values (10 min runtime, 5 min off-time) — they are presumably controlling live equipment and should not be left unprotected. Thermostats registered afterwards start disabled (0) and you opt in from the UI. A thermostat you have already tuned by hand is left untouched.
+
+## Outdoor-temperature cooling lockout
+
+Running a standard AC compressor when it is cold outside risks liquid refrigerant slugging the compressor and ice forming on the evaporator coil. The cooling lockout suppresses cooling cycles in cold weather.
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Cooling lockout — pause AC below** | blank (disabled) | When set, the engine will not start a cooling cycle while the outdoor temperature is below this value. Recommended around **55 °F** for a conventional AC. Leave blank to disable. |
+
+When a cooling cycle is suppressed, the thermostat is left idle and a warning is written to the event log explaining why, so the decision is auditable.
+
+### Requires an outdoor sensor
+
+The lockout needs to know the outdoor temperature. The **outside-temperature sensor** is configured once for the whole home, at the top of the **Thermostats** page — it is a single Home Assistant `sensor.*` or `weather.*` entity and is not tied to any individual thermostat. Without it, the lockout cannot evaluate.
+
+### Fail-open behavior
+
+If a lockout threshold is configured but the outdoor sensor is unset or unreadable, Plenum **fails open** — it allows the cooling cycle and logs a warning. A dropped sensor should not silently disable cooling for the whole house in summer; the warning makes the gap visible so it can be fixed.
+
+## Related thermostat safety limits
+
+A few longer-standing limits on the [Thermostat settings](./thermostat-settings.md) page also protect equipment:
+
+- **Min / max setpoint** — hard clamps; Plenum never commands the thermostat outside this range.
+- **Min open vents** — always keep at least this many vents open, so the HVAC is never dead-headed.
+- **Max vent closed** — force-reopen a vent after this long, a safety valve for systems that need airflow.
+- **Cycle timeout** — abort a cycle that runs too long (stuck equipment, unreachable sensors).

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -708,6 +708,7 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "vacation_hvac_mode",
         "min_cycle_runtime_min",
         "min_cycle_offtime_min",
+        "cooling_lockout_below_f",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):
@@ -718,6 +719,10 @@ async def create_thermostat(request: web.Request) -> web.Response:
                 if body[field] not in ("range", "single"):
                     return error("vacation_hvac_mode must be 'range' or 'single'")
                 setattr(tc, field, body[field])
+            elif field == "cooling_lockout_below_f":
+                # Nullable absolute temperature — null disables the lockout.
+                val = body[field]
+                setattr(tc, field, _to_f(val, unit) if val is not None else None)
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -781,6 +786,7 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "vacation_hvac_mode",
         "min_cycle_runtime_min",
         "min_cycle_offtime_min",
+        "cooling_lockout_below_f",
     ):
         if field in body:
             if field in ("default_temp", "min_setpoint", "max_setpoint"):
@@ -791,6 +797,10 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
                 if body[field] not in ("range", "single"):
                     return error("vacation_hvac_mode must be 'range' or 'single'")
                 setattr(tc, field, body[field])
+            elif field == "cooling_lockout_below_f":
+                # Nullable absolute temperature — null disables the lockout.
+                val = body[field]
+                setattr(tc, field, _to_f(val, unit) if val is not None else None)
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -92,7 +92,8 @@ CREATE TABLE IF NOT EXISTS thermostat_configs (
     overshoot_delta REAL NOT NULL DEFAULT 2.0,
     cycle_timeout_hours REAL NOT NULL DEFAULT 3.0,
     min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0,
-    min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0
+    min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0,
+    cooling_lockout_below_f REAL
 );
 
 CREATE TABLE IF NOT EXISTS room_overrides (
@@ -360,6 +361,8 @@ _MIGRATIONS = [
     # Short-cycle protection (Issue #208)
     "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0",
+    # Outdoor-temperature cooling lockout (Issue #209)
+    "ALTER TABLE thermostat_configs ADD COLUMN cooling_lockout_below_f REAL",
 ]
 
 
@@ -665,6 +668,9 @@ def _row_to_tc(row) -> ThermostatConfig:
         min_cycle_offtime_min=int(row["min_cycle_offtime_min"] or 0)
         if "min_cycle_offtime_min" in keys
         else 0,
+        cooling_lockout_below_f=row["cooling_lockout_below_f"]
+        if "cooling_lockout_below_f" in keys
+        else None,
     )
 
 
@@ -674,8 +680,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
            (thermostat_entity_id,name,default_temp,min_setpoint,max_setpoint,deadband,
             max_vent_closed_min,min_open_vents,overshoot_delta,cycle_timeout_hours,
             reconciliation_interval_min,vacation_hvac_mode,
-            min_cycle_runtime_min,min_cycle_offtime_min)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            min_cycle_runtime_min,min_cycle_offtime_min,cooling_lockout_below_f)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -689,7 +695,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              reconciliation_interval_min=excluded.reconciliation_interval_min,
              vacation_hvac_mode=excluded.vacation_hvac_mode,
              min_cycle_runtime_min=excluded.min_cycle_runtime_min,
-             min_cycle_offtime_min=excluded.min_cycle_offtime_min
+             min_cycle_offtime_min=excluded.min_cycle_offtime_min,
+             cooling_lockout_below_f=excluded.cooling_lockout_below_f
         """,
         (
             tc.thermostat_entity_id,
@@ -706,6 +713,7 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             tc.vacation_hvac_mode,
             tc.min_cycle_runtime_min,
             tc.min_cycle_offtime_min,
+            tc.cooling_lockout_below_f,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -274,6 +274,71 @@ class CycleEngine:
                 await self._maybe_reconcile(conn)
                 await self._maybe_broadcast()
                 return
+
+            # Outdoor-temperature cooling lockout (Issue #209). Refuse to start
+            # a cooling cycle when it is too cold outside — running an AC
+            # compressor at low outdoor ambient risks liquid slugging and
+            # evaporator coil icing. Opt-in: needs both a configured threshold
+            # and a readable outdoor-temperature sensor. (Heat pumps are not
+            # supported, so there is no heating lockout.)
+            if inferred == "cooling":
+                lockout_state, outside_temp = await self._cooling_lockout_state(conn, tc)
+                if lockout_state == "sensor_unavailable":
+                    log.warning(
+                        "Cooling lockout configured for %s but the outdoor "
+                        "temperature sensor is unset or unreadable — allowing "
+                        "cooling (fail-open)",
+                        self.thermostat_entity_id,
+                    )
+                    if self._logger:
+                        await self._logger.log(
+                            "warning",
+                            "engine",
+                            f"Cooling lockout is configured for {self.thermostat_entity_id} "
+                            "but the outdoor-temperature sensor is unset or unreadable — "
+                            "allowing the cooling cycle (fail-open). Set the outdoor sensor "
+                            "on the Thermostats page for the lockout to take effect.",
+                            {"thermostat": self.thermostat_entity_id},
+                        )
+                elif lockout_state == "locked_out":
+                    assert outside_temp is not None  # 'locked_out' implies a reading
+                    threshold = tc.cooling_lockout_below_f
+                    assert threshold is not None
+                    log.warning(
+                        "Cooling locked out for %s — outdoor %.1f°F is below "
+                        "cooling_lockout_below_f=%.1f°F; suppressing cooling cycle",
+                        self.thermostat_entity_id,
+                        outside_temp,
+                        threshold,
+                    )
+                    if self._logger:
+                        await self._logger.log(
+                            "warning",
+                            "engine",
+                            f"Cooling cycle suppressed for {self.thermostat_entity_id} — "
+                            f"outdoor temperature {outside_temp:.1f}°F is below the cooling "
+                            f"lockout ({threshold:.1f}°F). Running the AC compressor this "
+                            "cold risks liquid slugging and coil icing.",
+                            {
+                                "thermostat": self.thermostat_entity_id,
+                                "outside_temp": outside_temp,
+                                "cooling_lockout_below_f": threshold,
+                            },
+                        )
+                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
+                    if ambient is not None:
+                        ambient_f = float(ambient)
+                        try:
+                            await self._ha.set_thermostat_temperature(
+                                self.thermostat_entity_id, ambient_f
+                            )
+                            self._last_setpoint_sent = ambient_f
+                        except Exception as exc:
+                            log.error("Failed to reset setpoint to ambient: %s: %r", exc, exc)
+                    await self._maybe_reconcile(conn)
+                    await self._maybe_broadcast()
+                    return
+
             effective_mode = inferred
         else:
             effective_mode = self._cycle_mode or hvac_mode
@@ -1387,6 +1452,32 @@ class CycleEngine:
             return self._ha.get_numeric_state(entity_id)
         except Exception:
             return None
+
+    async def _cooling_lockout_state(
+        self, conn: aiosqlite.Connection, tc: ThermostatConfig
+    ) -> tuple[str, float | None]:
+        """Evaluate the outdoor-temperature cooling lockout (Issue #209).
+
+        Returns ``(state, outside_temp)`` where ``state`` is one of:
+
+          - ``"disabled"``           — no ``cooling_lockout_below_f`` configured
+          - ``"sensor_unavailable"`` — threshold set, but the outdoor sensor is
+                                       unset or unreadable
+          - ``"locked_out"``         — outdoor temperature is below the threshold
+          - ``"allowed"``            — outdoor temperature is at/above the threshold
+
+        Fail-open by design: an unconfigured or unreadable outdoor sensor never
+        blocks cooling. The caller logs a warning for ``sensor_unavailable`` so
+        the gap is visible rather than silent.
+        """
+        if tc.cooling_lockout_below_f is None:
+            return ("disabled", None)
+        outside = await self._read_outside_temp(conn)
+        if outside is None:
+            return ("sensor_unavailable", None)
+        if outside < tc.cooling_lockout_below_f:
+            return ("locked_out", outside)
+        return ("allowed", outside)
 
     def _read_thermo_temp_and_setpoint(self) -> tuple[float | None, float | None]:
         """Read (current_temperature, temperature) from the thermostat state."""

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -153,6 +153,13 @@ class ThermostatConfig:
     # 0 disables either guard.
     min_cycle_runtime_min: int = 0
     min_cycle_offtime_min: int = 0
+    # Outdoor-temperature cooling lockout (Issue #209). When set, the engine
+    # refuses to start a cooling cycle while the configured outdoor-temperature
+    # sensor reads below this value (°F). Running a standard AC compressor in
+    # cold outdoor conditions risks liquid slugging and evaporator icing.
+    # None = disabled. NOTE: heat pumps are not supported, so there is no
+    # corresponding heating lockout.
+    cooling_lockout_below_f: float | None = None
 
 
 @dataclass

--- a/smart_vent/backend/tests/integration/test_outdoor_cooling_lockout.py
+++ b/smart_vent/backend/tests/integration/test_outdoor_cooling_lockout.py
@@ -1,0 +1,137 @@
+"""Outdoor-temperature cooling lockout integration tests (Issue #209).
+
+Running a standard AC compressor when it is cold outside risks liquid
+slugging and evaporator coil icing. These tests drive the full engine
+against a fake Home Assistant and verify:
+
+  - a cooling cycle is suppressed while the outdoor sensor reads below the
+    configured ``cooling_lockout_below_f`` threshold;
+  - cooling proceeds normally when it is warm enough outside;
+  - the lockout fails open (cooling allowed, with a warning) when a threshold
+    is configured but no outdoor sensor is set up;
+  - the new config field round-trips through the REST API.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+OUTDOOR = "sensor.outdoor_temp"
+
+
+async def _create_cooling_room(client) -> None:
+    """Create a warm room on an all-day schedule — a cooling cycle is wanted."""
+    resp = await client.post("/api/rooms", json={"name": "Bedroom", "thermostat_entity_id": THERMO})
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.test_room_temp"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.test_room_vent", "control_method": "open_close"},
+    )
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+
+
+def _seed_warm_room(fake_ha) -> None:
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "open", {})
+
+
+async def _event_messages(client, level: str) -> list[str]:
+    events = await (await client.get(f"/api/logs/events?level={level}")).json()
+    return [e["message"] for e in events]
+
+
+@pytest.mark.asyncio
+async def test_cooling_suppressed_when_outdoor_below_lockout(client, fake_ha, tick) -> None:
+    """Cold outside → the cooling cycle is locked out and does not start."""
+    _seed_warm_room(fake_ha)
+    fake_ha.seed_state(OUTDOOR, "40.0", {"unit_of_measurement": "°F"})
+    await _create_cooling_room(client)
+
+    # House-wide outdoor sensor + per-thermostat lockout threshold.
+    assert (
+        await client.put("/api/settings/outside-temp-entity", json={"entity_id": OUTDOOR})
+    ).status == 200
+    assert (
+        await client.put(f"/api/thermostats/{THERMO}", json={"cooling_lockout_below_f": 55})
+    ).status == 200
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 0, "no cooling cycle should start while locked out"
+    assert client.app["scheduler"]._engines[THERMO].cycle_state.value == "idle"
+
+    warnings = await _event_messages(client, "warning")
+    assert any("suppressed" in m and "outdoor" in m.lower() for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_cooling_proceeds_when_outdoor_above_lockout(client, fake_ha, tick) -> None:
+    """Warm enough outside → cooling proceeds normally (no regression)."""
+    _seed_warm_room(fake_ha)
+    fake_ha.seed_state(OUTDOOR, "70.0", {"unit_of_measurement": "°F"})
+    await _create_cooling_room(client)
+
+    await client.put("/api/settings/outside-temp-entity", json={"entity_id": OUTDOOR})
+    await client.put(f"/api/thermostats/{THERMO}", json={"cooling_lockout_below_f": 55})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "cooling cycle should start when it is warm enough outside"
+    assert logs[0]["mode"] == "cooling"
+
+
+@pytest.mark.asyncio
+async def test_cooling_fails_open_when_outdoor_sensor_unconfigured(client, fake_ha, tick) -> None:
+    """Threshold set but no outdoor sensor → fail open: cooling proceeds, warn."""
+    _seed_warm_room(fake_ha)
+    await _create_cooling_room(client)
+
+    # Lockout threshold configured, but no outside-temp entity is set up.
+    await client.put(f"/api/thermostats/{THERMO}", json={"cooling_lockout_below_f": 55})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "lockout must fail open when no outdoor sensor is configured"
+
+    warnings = await _event_messages(client, "warning")
+    assert any("unset or unreadable" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_cooling_lockout_config_roundtrips_through_api(client, fake_ha) -> None:
+    """cooling_lockout_below_f persists through the REST API, and null clears it."""
+    resp = await client.put(f"/api/thermostats/{THERMO}", json={"cooling_lockout_below_f": 55})
+    assert resp.status == 200
+    assert (await resp.json())["cooling_lockout_below_f"] == 55
+
+    listing = await (await client.get("/api/thermostats")).json()
+    entry = next(t for t in listing if t["thermostat_entity_id"] == THERMO)
+    assert entry["cooling_lockout_below_f"] == 55
+
+    # Passing null disables the lockout.
+    resp = await client.put(f"/api/thermostats/{THERMO}", json={"cooling_lockout_below_f": None})
+    assert resp.status == 200
+    assert (await resp.json())["cooling_lockout_below_f"] is None

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1295,3 +1295,51 @@ class TestEnterMinRuntimeHold:
 
         engine._ha.open_cover.assert_not_awaited()
         await conn.close()
+
+
+class TestCoolingLockoutState:
+    """_cooling_lockout_state — outdoor-temperature cooling lockout (Issue #209)."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_threshold_unset(self):
+        engine = _make_engine()
+        tc = _make_tc(cooling_lockout_below_f=None)
+        state, temp = await engine._cooling_lockout_state(None, tc)
+        assert state == "disabled"
+        assert temp is None
+
+    @pytest.mark.asyncio
+    async def test_sensor_unavailable_when_no_outdoor_reading(self):
+        engine = _make_engine()
+        engine._read_outside_temp = AsyncMock(return_value=None)
+        tc = _make_tc(cooling_lockout_below_f=55.0)
+        state, temp = await engine._cooling_lockout_state(None, tc)
+        assert state == "sensor_unavailable"
+        assert temp is None
+
+    @pytest.mark.asyncio
+    async def test_locked_out_when_outdoor_below_threshold(self):
+        engine = _make_engine()
+        engine._read_outside_temp = AsyncMock(return_value=45.0)
+        tc = _make_tc(cooling_lockout_below_f=55.0)
+        state, temp = await engine._cooling_lockout_state(None, tc)
+        assert state == "locked_out"
+        assert temp == 45.0
+
+    @pytest.mark.asyncio
+    async def test_allowed_when_outdoor_above_threshold(self):
+        engine = _make_engine()
+        engine._read_outside_temp = AsyncMock(return_value=68.0)
+        tc = _make_tc(cooling_lockout_below_f=55.0)
+        state, temp = await engine._cooling_lockout_state(None, tc)
+        assert state == "allowed"
+        assert temp == 68.0
+
+    @pytest.mark.asyncio
+    async def test_boundary_at_threshold_is_allowed(self):
+        engine = _make_engine()
+        engine._read_outside_temp = AsyncMock(return_value=55.0)
+        tc = _make_tc(cooling_lockout_below_f=55.0)
+        # Exactly at the threshold is not "below" it — cooling is allowed.
+        state, _temp = await engine._cooling_lockout_state(None, tc)
+        assert state == "allowed"

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -75,6 +75,10 @@ export interface ThermostatConfig {
   // min_cycle_offtime_min: wait at least this long after a cycle ends before starting a new one.
   min_cycle_runtime_min: number;
   min_cycle_offtime_min: number;
+  // Outdoor-temperature cooling lockout (°F). When set, the engine refuses to
+  // start a cooling cycle while the outdoor sensor reads below this value.
+  // null = disabled. Requires the house-wide outdoor sensor to be configured.
+  cooling_lockout_below_f: number | null;
 }
 
 export interface VacationMode {

--- a/smart_vent/frontend/src/components/OutsideTempPicker.tsx
+++ b/smart_vent/frontend/src/components/OutsideTempPicker.tsx
@@ -61,8 +61,8 @@ export default function OutsideTempPicker({
       <div className="card-title">Outside temperature sensor</div>
       <div className="text-sm text-muted" style={{ marginBottom: "1rem" }}>
         One Home Assistant sensor (or weather entity) for the whole home — it is not tied to a
-        specific thermostat. Plenum records its reading at the start and end of every cycle for
-        the metrics analytics, and it is <strong>required</strong> for the cooling lockout safety
+        specific thermostat. Plenum records its reading at the start and end of every cycle for the
+        metrics analytics, and it is <strong>required</strong> for the cooling lockout safety
         feature below to take effect.
       </div>
 

--- a/smart_vent/frontend/src/components/OutsideTempPicker.tsx
+++ b/smart_vent/frontend/src/components/OutsideTempPicker.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { getOutsideTempEntity, setOutsideTempEntity } from "../api";
+import { useUnit } from "../contexts";
+import EntityPicker from "./EntityPicker";
+
+/**
+ * House-wide outdoor-temperature sensor picker.
+ *
+ * One sensor serves the whole home — it is NOT tied to an individual
+ * thermostat. The reading is recorded at the start and end of every cycle for
+ * the metrics analytics, and drives the per-thermostat cooling lockout
+ * (Issue #209), which is why this lives on the Thermostats page.
+ *
+ * ``onChange`` fires with the configured entity id (or null) on load and on
+ * every save, so a parent can react (e.g. enable/disable dependent settings).
+ */
+export default function OutsideTempPicker({
+  onChange,
+}: {
+  onChange?: (entityId: string | null) => void;
+}) {
+  const { fmtTemp } = useUnit();
+  const [current, setCurrent] = useState<{
+    entity_id: string | null;
+    current_value: number | null;
+  } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const refresh = async () => {
+    try {
+      const cur = await getOutsideTempEntity();
+      setCurrent(cur);
+      onChange?.(cur.entity_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onSelect = async (entity_id: string | null) => {
+    setSaving(true);
+    setError("");
+    try {
+      const next = await setOutsideTempEntity(entity_id);
+      setCurrent(next);
+      onChange?.(next.entity_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="card" style={{ marginBottom: "1rem" }}>
+      <div className="card-title">Outside temperature sensor</div>
+      <div className="text-sm text-muted" style={{ marginBottom: "1rem" }}>
+        One Home Assistant sensor (or weather entity) for the whole home — it is not tied to a
+        specific thermostat. Plenum records its reading at the start and end of every cycle for
+        the metrics analytics, and it is <strong>required</strong> for the cooling lockout safety
+        feature below to take effect.
+      </div>
+
+      {error && (
+        <div className="badge badge-red" style={{ marginBottom: ".75rem" }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: ".75rem", alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ flex: "1 1 320px", minWidth: 200 }}>
+          <EntityPicker
+            domain={["sensor", "weather"]}
+            placeholder="Search sensor / weather entities…"
+            onSelect={(id) => void onSelect(id)}
+          />
+        </div>
+
+        {current?.entity_id ? (
+          <>
+            <span className="badge badge-blue">
+              {current.entity_id}
+              {current.current_value !== null && ` · ${fmtTemp(current.current_value)}`}
+            </span>
+            <button
+              className="btn btn-secondary"
+              onClick={() => void onSelect(null)}
+              disabled={saving}
+              type="button"
+            >
+              Clear
+            </button>
+          </>
+        ) : (
+          <span className="text-sm text-muted">— None configured —</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -64,6 +64,7 @@ describe("Dashboard Page", () => {
         vacation_hvac_mode: "single" as const,
         min_cycle_runtime_min: 0,
         min_cycle_offtime_min: 0,
+        cooling_lockout_below_f: null,
       },
     ]);
   });

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -42,6 +42,7 @@ describe("Metrics Page", () => {
         vacation_hvac_mode: "single" as const,
         min_cycle_runtime_min: 0,
         min_cycle_offtime_min: 0,
+        cooling_lockout_below_f: null,
       },
     ]);
     vi.mocked(api.getMetricsHomeSummary).mockResolvedValue(mockSummary);
@@ -131,21 +132,6 @@ describe("Metrics Page", () => {
         "climate.test",
         expect.anything()
       );
-    });
-  });
-
-  it("handles outside temp entity change", async () => {
-    render(<Metrics />);
-
-    const searchInput = await screen.findByPlaceholderText(/Search sensor \/ weather entities/i);
-    fireEvent.focus(searchInput);
-    fireEvent.change(searchInput, { target: { value: "outside" } });
-
-    const option = await screen.findByText("Outside Temp");
-    fireEvent.mouseDown(option);
-
-    await waitFor(() => {
-      expect(api.setOutsideTempEntity).toHaveBeenCalledWith("sensor.outside_temp");
     });
   });
 

--- a/smart_vent/frontend/src/pages/Metrics.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.tsx
@@ -153,8 +153,8 @@ function EmptyStateBanners({
           <strong>Outside-temperature sensor not configured.</strong>{" "}
           <span className="text-muted">
             Set one on the <strong>Thermostats</strong> page to unlock the
-            cycles-vs-outside-temperature scatter and the average outside-temp summary tile.
-            Cycles still log without it; only the temperature columns stay NULL.
+            cycles-vs-outside-temperature scatter and the average outside-temp summary tile. Cycles
+            still log without it; only the temperature columns stay NULL.
           </span>
         </div>
       )}

--- a/smart_vent/frontend/src/pages/Metrics.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.tsx
@@ -5,12 +5,10 @@ import {
   getMetricsThermostatSummary,
   getOutsideTempEntity,
   getThermostats,
-  setOutsideTempEntity,
   type MetricsRange,
   type MetricsSummary,
   type ThermostatConfig,
 } from "../api";
-import EntityPicker from "../components/EntityPicker";
 import { ChartGrid } from "../components/charts/MetricsCharts";
 import { useUnit } from "../contexts";
 
@@ -41,97 +39,6 @@ function formatSeconds(s: number): string {
   const m = Math.round((s % 3600) / 60);
   if (h >= 1) return `${h}h ${m}m`;
   return `${m}m`;
-}
-
-// ---------------------------------------------------------------------------
-// Outside-temperature picker (Phase 3c)
-// ---------------------------------------------------------------------------
-
-function OutsideTempPanel({ onChange }: { onChange?: (entityId: string | null) => void }) {
-  const { fmtTemp } = useUnit();
-  const [current, setCurrent] = useState<{
-    entity_id: string | null;
-    current_value: number | null;
-  } | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-
-  const refresh = async () => {
-    try {
-      const cur = await getOutsideTempEntity();
-      setCurrent(cur);
-      onChange?.(cur.entity_id);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load");
-    }
-  };
-
-  useEffect(() => {
-    void refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onSelect = async (entity_id: string | null) => {
-    setSaving(true);
-    setError("");
-    try {
-      const next = await setOutsideTempEntity(entity_id);
-      setCurrent(next);
-      onChange?.(next.entity_id);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Save failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="card" style={{ marginBottom: "1rem" }}>
-      <div className="card-title">Outside temperature source</div>
-      <div className="text-sm text-muted" style={{ marginBottom: "1rem" }}>
-        Select a Home Assistant entity (sensor or weather) whose numeric state Plenum should record
-        at the start and end of every cycle. Used for the heating/cooling vs outdoor-temperature
-        analytics.
-      </div>
-
-      {error && (
-        <div className="badge badge-red" style={{ marginBottom: ".75rem" }}>
-          {error}
-        </div>
-      )}
-
-      <div style={{ display: "flex", gap: ".75rem", alignItems: "center", flexWrap: "wrap" }}>
-        <div style={{ flex: "1 1 320px", minWidth: 200 }}>
-          <EntityPicker
-            domain={["sensor", "weather"]}
-            placeholder="Search sensor / weather entities…"
-            onSelect={(id) => void onSelect(id)}
-          />
-        </div>
-
-        {current?.entity_id ? (
-          <>
-            <span className="badge badge-blue">
-              {current.entity_id}
-              {current.current_value !== null && ` · ${fmtTemp(current.current_value)}`}
-            </span>
-            <button
-              className="btn btn-secondary"
-              onClick={() => void onSelect(null)}
-              disabled={saving}
-              type="button"
-            >
-              Clear
-            </button>
-          </>
-        ) : (
-          <span className="text-sm text-muted">
-            — None (don&apos;t track outside temperature) —
-          </span>
-        )}
-      </div>
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -243,11 +150,11 @@ function EmptyStateBanners({
       )}
       {!outsideEntityConfigured && (
         <div className="card" style={{ borderLeft: "3px solid #3b82f6" }}>
-          <strong>Outside-temperature entity not configured.</strong>{" "}
+          <strong>Outside-temperature sensor not configured.</strong>{" "}
           <span className="text-muted">
-            Set one above to unlock the cycles-vs-outside-temperature scatter and the average
-            outside-temp summary tile. Cycles still log without it; only the temperature columns
-            stay NULL.
+            Set one on the <strong>Thermostats</strong> page to unlock the
+            cycles-vs-outside-temperature scatter and the average outside-temp summary tile.
+            Cycles still log without it; only the temperature columns stay NULL.
           </span>
         </div>
       )}
@@ -273,6 +180,14 @@ export default function Metrics() {
     getThermostats()
       .then(setThermostats)
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load thermostats"));
+  }, []);
+
+  // The outside-temperature sensor is configured on the Thermostats page; here
+  // we only need to know whether one is set, to surface the right empty-state.
+  useEffect(() => {
+    getOutsideTempEntity()
+      .then((r) => setOutsideEntity(r.entity_id))
+      .catch(() => setOutsideEntity(null));
   }, []);
 
   // Re-fetch summary whenever the selector or range changes.
@@ -321,8 +236,6 @@ export default function Metrics() {
           </div>
         </div>
       </div>
-
-      <OutsideTempPanel onChange={setOutsideEntity} />
 
       <div className="card" style={{ marginBottom: "1rem" }}>
         <div

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -22,6 +22,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     vacation_hvac_mode: "single" as const,
     min_cycle_runtime_min: 0,
     min_cycle_offtime_min: 0,
+    cooling_lockout_below_f: null,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Settings.test.tsx
+++ b/smart_vent/frontend/src/pages/Settings.test.tsx
@@ -22,6 +22,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     vacation_hvac_mode: "single" as const,
     min_cycle_runtime_min: 0,
     min_cycle_offtime_min: 0,
+    cooling_lockout_below_f: null,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -22,12 +22,17 @@ const mockThermostats: api.ThermostatConfig[] = [
     vacation_hvac_mode: "single" as const,
     min_cycle_runtime_min: 0,
     min_cycle_offtime_min: 0,
+    cooling_lockout_below_f: null,
   },
 ];
 
 describe("Thermostats Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: null,
+      current_value: null,
+    });
     vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
     vi.mocked(api.getHAEntities).mockResolvedValue([
       { entity_id: "climate.hallway", friendly_name: "Hallway", state: "" },
@@ -125,6 +130,70 @@ describe("Thermostats Page", () => {
     });
   });
 
+  it("edits and saves the cooling lockout temperature", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    render(<Thermostats />);
+
+    const lockoutInput = await screen.findByLabelText(/Cooling lockout/i);
+    fireEvent.change(lockoutInput, { target: { value: "55" } });
+
+    const card = lockoutInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({ cooling_lockout_below_f: 55 })
+      );
+    });
+  });
+
+  it("clears the cooling lockout when the field is emptied", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    render(<Thermostats />);
+
+    const lockoutInput = await screen.findByLabelText(/Cooling lockout/i);
+    fireEvent.change(lockoutInput, { target: { value: "55" } });
+    fireEvent.change(lockoutInput, { target: { value: "" } });
+
+    const card = lockoutInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({ cooling_lockout_below_f: null })
+      );
+    });
+  });
+
+  it("renders the house-wide outside temperature sensor picker", async () => {
+    render(<Thermostats />);
+    expect(await screen.findByText("Outside temperature sensor")).toBeInTheDocument();
+  });
+
+  it("saves the outside temperature sensor selection", async () => {
+    vi.mocked(api.getHAEntities).mockResolvedValue([
+      { entity_id: "sensor.outdoor", friendly_name: "Outdoor", state: "50" },
+    ]);
+    vi.mocked(api.setOutsideTempEntity).mockResolvedValue({
+      entity_id: "sensor.outdoor",
+      current_value: 50,
+    });
+    render(<Thermostats />);
+
+    const searchInput = await screen.findByPlaceholderText(/Search sensor \/ weather entities/i);
+    fireEvent.focus(searchInput);
+    fireEvent.change(searchInput, { target: { value: "outdoor" } });
+
+    const option = await screen.findByText("Outdoor");
+    fireEvent.mouseDown(option);
+
+    await waitFor(() => {
+      expect(api.setOutsideTempEntity).toHaveBeenCalledWith("sensor.outdoor");
+    });
+  });
+
   it("shows validation error for min >= max setpoint", async () => {
     render(<Thermostats />);
 
@@ -175,6 +244,10 @@ describe("Thermostats Page", () => {
 describe("Thermostats Page — vacation mode selector", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: null,
+      current_value: null,
+    });
     vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
     vi.mocked(api.getHAEntities).mockResolvedValue([]);
     vi.mocked(api.downloadBackup).mockReturnValue(undefined);
@@ -251,6 +324,10 @@ describe("Thermostats Page — Celsius mode", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: null,
+      current_value: null,
+    });
     vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
     vi.mocked(api.getHAEntities).mockResolvedValue([]);
     vi.mocked(api.downloadBackup).mockReturnValue(undefined);

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -11,6 +11,7 @@ import {
   type ThermostatConfig,
 } from "../api";
 import EntityPicker from "../components/EntityPicker";
+import OutsideTempPicker from "../components/OutsideTempPicker";
 import { useUnit } from "../contexts";
 
 // ---------------------------------------------------------------------------
@@ -370,6 +371,41 @@ function ThermostatCard({
         })}
       </div>
 
+      {/* Outdoor-temperature cooling lockout (Issue #209). Nullable (blank =
+          disabled), so it is rendered outside the SAFETY_FIELDS loop. */}
+      <div className="form-group" style={{ maxWidth: 280, marginTop: "1rem" }}>
+        <label
+          className="form-label"
+          htmlFor={`thermo-${config.thermostat_entity_id}-cooling-lockout`}
+        >
+          Cooling lockout — pause AC below ({unitLabel})
+        </label>
+        <input
+          id={`thermo-${config.thermostat_entity_id}-cooling-lockout`}
+          className="form-control"
+          type="number"
+          step="0.5"
+          placeholder="Disabled"
+          value={
+            form.cooling_lockout_below_f != null ? toDisplay(form.cooling_lockout_below_f) : ""
+          }
+          onChange={(e) => {
+            const raw = e.target.value;
+            setForm((f) => ({
+              ...f,
+              cooling_lockout_below_f: raw === "" ? null : toStorage(parseFloat(raw) || 0),
+            }));
+          }}
+        />
+        <div className="form-hint">
+          Skip cooling cycles while the outdoor temperature is below this, to protect the AC
+          compressor from cold-weather operation (liquid slugging, evaporator coil icing).
+          Recommended around 55°F (about 13°C). Leave blank to disable. Requires the
+          outside-temperature sensor (configured at the top of this page). Heat pumps are not
+          supported.
+        </div>
+      </div>
+
       <hr className="divider" />
 
       {/* Drift correction — rendered separately because max depends on cycle_timeout_hours */}
@@ -656,6 +692,8 @@ export default function Thermostats() {
           + Register thermostat
         </button>
       </div>
+
+      <OutsideTempPicker />
 
       {configs.length === 0 ? (
         <div className="card">


### PR DESCRIPTION
## Summary

Closes #209. The engine read an outdoor-temperature entity only for diagnostics. Running a standard AC compressor when it is cold outside risks **liquid slugging** and **evaporator coil icing** — and `_infer_mode`'s "ties go to cooling" path can pick cooling in shoulder season. This PR turns the outdoor reading into a protective interlock.

- **`cooling_lockout_below_f`** — a new nullable per-thermostat `ThermostatConfig` field (°F; `null` = disabled). When set, `_do_tick`'s IDLE branch evaluates `_cooling_lockout_state` before starting a cooling cycle: if the outdoor sensor reads below the threshold the cooling cycle is **suppressed**, the setpoint is reset to ambient, and a warning event is logged.
- **Fail-open by design.** If a threshold is configured but the outdoor sensor is unset or unreadable, cooling proceeds and a warning is logged — a dropped sensor should not silently disable cooling for the whole house in summer.
- **No heating lockout.** Heat pumps are not supported (Plenum assumes a conventional furnace/air-handler + AC); this is stated in the README, `docs/safety.md`, and the field's UI help text.

## Outdoor sensor moved to the Thermostats page

The lockout needs the outdoor temperature. The outside-temperature sensor was previously only configurable on the Metrics page. It is now a prominent **house-wide** section at the top of the **Thermostats** page (new `OutsideTempPicker` component) — one `sensor.*`/`weather.*` entity for the whole home, not tied to any thermostat. The Metrics page still reads it for its empty-state banner (text now points at the Thermostats page).

## UI

- New **"Cooling lockout — pause AC below"** field on each thermostat card. Nullable (blank = disabled), so it is rendered outside the `SAFETY_FIELDS` loop; help text gives the recommended ~55 °F and notes heat pumps are unsupported.
- `cooling_lockout_below_f` added to the `ThermostatConfig` TS interface; `ThermostatConfig` mocks updated across the five page test suites.

## Docs

- New [`docs/safety.md`](docs/safety.md) — a living guide to the equipment-protection features, currently short-cycle protection (#208) and this cooling lockout. Linked from `docs/README.md`.
- New **Safety** section in the main README.

## Changes

**Backend** — `models.py` (`cooling_lockout_below_f`), `db.py` (DDL + migration + row/upsert mapping), `api/routes.py` (both thermostat endpoints; nullable absolute-temp handling), `engine/cycle_engine.py` (`_cooling_lockout_state` + IDLE-branch enforcement).

**Frontend** — `api.ts`, new `components/OutsideTempPicker.tsx`, `pages/Thermostats.tsx`, `pages/Metrics.tsx`.

## Test plan

Developed test-first (TDD):

- [x] Backend unit tests — `_cooling_lockout_state`: disabled, sensor-unavailable, locked-out, allowed, and the threshold boundary.
- [x] Backend integration tests — cooling suppressed below the threshold (with the warning event); cooling proceeds above it; fail-open with a warning when no outdoor sensor is configured; config field round-trips through the REST API (including `null` to clear).
- [x] Frontend tests — Thermostats page edits/clears the lockout field and renders/saves the house-wide outdoor sensor picker; obsolete Metrics picker test removed.
- [x] Full backend suite: 587 passed, no regressions. Coverage 94% (gate 90%).
- [x] Full frontend suite: 145 passed; `tsc`, ESLint, Prettier clean.
- [x] `ruff check` + `ruff format --check` + `mypy` clean.

## Notes

- Enforcement is at the `_do_tick` IDLE gate (the point a cooling cycle is decided). A cooling cycle already RUNNING when the outdoor temp drops is not interrupted — it ends shortly and the next IDLE tick gates the restart.
- `cooling_lockout_below_f` defaults to disabled (`null`); there is no back-fill migration — the lockout also needs an outdoor sensor most installs won't have, so it is opt-in.

https://claude.ai/code/session_01FeWMqLrVNdSQH4ntAEc3Xx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWMqLrVNdSQH4ntAEc3Xx)_