### PR TITLE
Guard the cycle engine from stale temperature readings

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -47,9 +47,16 @@ If a lockout threshold is configured but the outdoor sensor is unset or unreadab
 
 A battery-powered Zigbee or Z-Wave temperature sensor that drops off the mesh does not always flip to `unavailable` in Home Assistant — HA keeps showing the **last numeric value it heard**. If Plenum averaged that stale value into a room temperature, it would confidently make the wrong control decision: wrong mode, vents closing on a room that hasn't actually reached target, no cycle starting on a room that's actually warm. The kind of silent failure that only shows up as a comfort complaint.
 
-The engine treats a sensor reading as stale once its Home Assistant `last_updated` timestamp is older than **30 minutes** (the `SENSOR_STALE_AFTER_MIN` constant in `cycle_engine.py`). Stale readings are excluded from `_get_avg_temp`, so they never contribute to the value that drives mode inference, vent-close decisions, or at-target checks. If every sensor in a room is stale, the room temperature falls through to the thermostat's own `current_temperature` attribute, exactly the same fallback used when a room has no sensors configured.
+The engine treats a sensor reading as stale once its Home Assistant `last_updated` timestamp is older than the configured **sensor-staleness threshold** (default **30 minutes**, adjustable on the **Settings** page from 1 minute to 24 hours). Stale readings are excluded from `_get_avg_temp`, so they never contribute to the value that drives mode inference, vent-close decisions, or at-target checks. If every sensor in a room is stale, the room temperature falls through to the thermostat's own `current_temperature` attribute, exactly the same fallback used when a room has no sensors configured.
 
-The first tick a sensor crosses into staleness, the engine writes a `warning` event naming the entity and how long it's been silent, so the dead sensor surfaces in the event log instead of being noticed by occupants. Further warnings for that same sensor are suppressed until it reports again, at which point a recovery `info` event is logged.
+The engine refreshes the threshold at the start of each tick, so changes from the Settings page take effect within 60 seconds without a restart.
+
+### UI surfacing
+
+- **Dashboard** — a top-of-page banner appears the moment any configured room sensor crosses the threshold, listing each affected room and entity with its age. The banner disappears as soon as every sensor is fresh again.
+- **Rooms page** — each room card carries a small orange "stale sensor" badge with a hover-tooltip naming each stale entity and how long it's been silent.
+- **Settings page** — a "Sensor-staleness threshold" field lets you tune the value to your sensor population.
+- **Event log** — the first tick a sensor crosses into staleness, the engine writes a `warning` event naming the entity and its age; further warnings for that same sensor are suppressed until it reports again, at which point a recovery `info` event is logged.
 
 > The outdoor sensor used by the cooling lockout is read separately and is **not** gated by this staleness check — it serves analytics that tolerate slow updates (a weather entity may report hourly). The cooling lockout's existing fail-open behavior already covers a missing reading.
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -43,6 +43,16 @@ The lockout needs to know the outdoor temperature. The **outside-temperature sen
 
 If a lockout threshold is configured but the outdoor sensor is unset or unreadable, Plenum **fails open** — it allows the cooling cycle and logs a warning. A dropped sensor should not silently disable cooling for the whole house in summer; the warning makes the gap visible so it can be fixed.
 
+## Sensor-staleness guard
+
+A battery-powered Zigbee or Z-Wave temperature sensor that drops off the mesh does not always flip to `unavailable` in Home Assistant — HA keeps showing the **last numeric value it heard**. If Plenum averaged that stale value into a room temperature, it would confidently make the wrong control decision: wrong mode, vents closing on a room that hasn't actually reached target, no cycle starting on a room that's actually warm. The kind of silent failure that only shows up as a comfort complaint.
+
+The engine treats a sensor reading as stale once its Home Assistant `last_updated` timestamp is older than **30 minutes** (the `SENSOR_STALE_AFTER_MIN` constant in `cycle_engine.py`). Stale readings are excluded from `_get_avg_temp`, so they never contribute to the value that drives mode inference, vent-close decisions, or at-target checks. If every sensor in a room is stale, the room temperature falls through to the thermostat's own `current_temperature` attribute, exactly the same fallback used when a room has no sensors configured.
+
+The first tick a sensor crosses into staleness, the engine writes a `warning` event naming the entity and how long it's been silent, so the dead sensor surfaces in the event log instead of being noticed by occupants. Further warnings for that same sensor are suppressed until it reports again, at which point a recovery `info` event is logged.
+
+> The outdoor sensor used by the cooling lockout is read separately and is **not** gated by this staleness check — it serves analytics that tolerate slow updates (a weather entity may report hourly). The cooling lockout's existing fail-open behavior already covers a missing reading.
+
 ## Related thermostat safety limits
 
 A few longer-standing limits on the [Thermostat settings](./thermostat-settings.md) page also protect equipment:

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1243,6 +1243,103 @@ async def set_outside_temp_entity(request: web.Request) -> web.Response:
     return json_response({"entity_id": entity_id, "current_value": value})
 
 
+@docs(tags=["settings"], summary="Get sensor-staleness threshold (Issue #211)")
+@response_schema(schemas.SensorStalenessSettingSchema)
+@routes.get("/api/settings/sensor-staleness")
+async def get_sensor_staleness(request: web.Request) -> web.Response:
+    """Return the configured sensor-staleness threshold in minutes (Issue #211)."""
+    conn = await get_conn(request)
+    from backend.engine.cycle_engine import SENSOR_STALE_AFTER_MIN
+
+    raw = await db.get_system_setting(conn, "sensor_stale_after_min", str(SENSOR_STALE_AFTER_MIN))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        value = SENSOR_STALE_AFTER_MIN
+    return json_response({"stale_after_min": value})
+
+
+@docs(tags=["settings"], summary="Set sensor-staleness threshold (Issue #211)")
+@request_schema(schemas.SensorStalenessSettingSchema)
+@response_schema(schemas.SensorStalenessSettingSchema)
+@routes.put("/api/settings/sensor-staleness")
+async def set_sensor_staleness(request: web.Request) -> web.Response:
+    """Set the sensor-staleness threshold. Range: 1 minute — 24 hours."""
+    body = await request.json()
+    val = body.get("stale_after_min")
+    if not isinstance(val, (int, float)):
+        return error("stale_after_min must be a number (minutes)")
+    if not (1 <= val <= 24 * 60):
+        return error("stale_after_min must be between 1 and 1440 minutes")
+    conn = await get_conn(request)
+    await db.set_system_setting(conn, "sensor_stale_after_min", str(float(val)))
+    return json_response({"stale_after_min": float(val)})
+
+
+@docs(tags=["diagnostics"], summary="Per-room sensor freshness summary (Issue #211)")
+@response_schema(schemas.SensorHealthSchema)
+@routes.get("/api/sensor-health")
+async def get_sensor_health(request: web.Request) -> web.Response:
+    """Per-room sensor freshness — drives the Dashboard banner and Room badges
+    (Issue #211).
+
+    Returns every configured room temperature sensor that has not reported
+    within the active staleness threshold, with its age. A Home-Assistant entity
+    not in the cache at all is reported with ``age_seconds=null`` so the UI can
+    distinguish "stale" from "never seen". Rooms with no stale sensors are
+    omitted from the response.
+    """
+    from backend.engine.cycle_engine import SENSOR_STALE_AFTER_MIN
+
+    conn = await get_conn(request)
+    raw = await db.get_system_setting(conn, "sensor_stale_after_min", str(SENSOR_STALE_AFTER_MIN))
+    try:
+        threshold_min = float(raw)
+    except (TypeError, ValueError):
+        threshold_min = SENSOR_STALE_AFTER_MIN
+
+    ha = request.app["ha"]
+    rooms = await db.get_all_rooms(conn)
+    stale_rooms: list[dict] = []
+    for room in rooms:
+        sensors = await db.get_room_sensors(conn, room.id)
+        stale_sensors: list[dict] = []
+        for s in sensors:
+            age_s = ha.get_state_age_seconds(s.entity_id)
+            if age_s is None:
+                # Never seen in the cache — the room never had a fresh reading.
+                stale_sensors.append(
+                    {
+                        "entity_id": s.entity_id,
+                        "age_seconds": None,
+                        "reason": "not_in_cache",
+                    }
+                )
+            elif age_s > threshold_min * 60:
+                stale_sensors.append(
+                    {
+                        "entity_id": s.entity_id,
+                        "age_seconds": age_s,
+                        "reason": "stale",
+                    }
+                )
+        if stale_sensors:
+            stale_rooms.append(
+                {
+                    "room_id": room.id,
+                    "room_name": room.name,
+                    "thermostat_entity_id": room.thermostat_entity_id,
+                    "stale_sensors": stale_sensors,
+                }
+            )
+    return json_response(
+        {
+            "stale_after_min": threshold_min,
+            "rooms": stale_rooms,
+        }
+    )
+
+
 @docs(tags=["settings"], summary="Get log retention settings")
 @response_schema(schemas.LogRetentionSettingsSchema)
 @routes.get("/api/settings/log-retention")

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -186,6 +186,28 @@ class OutsideTempEntitySettingSchema(Schema):
     current_value = fields.Float(allow_none=True)
 
 
+class SensorStalenessSettingSchema(Schema):
+    stale_after_min = fields.Float()
+
+
+class StaleSensorSchema(Schema):
+    entity_id = fields.Str()
+    age_seconds = fields.Float(allow_none=True)
+    reason = fields.Str()
+
+
+class StaleRoomSchema(Schema):
+    room_id = fields.Str()
+    room_name = fields.Str()
+    thermostat_entity_id = fields.Str()
+    stale_sensors = fields.List(fields.Nested(StaleSensorSchema))
+
+
+class SensorHealthSchema(Schema):
+    stale_after_min = fields.Float()
+    rooms = fields.List(fields.Nested(StaleRoomSchema))
+
+
 class VacationModeSchema(Schema):
     enabled = fields.Bool()
     return_at = fields.Str(allow_none=True)

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -38,6 +38,12 @@ log = logging.getLogger(__name__)
 # Callback type for broadcasting state changes to WebSocket clients
 BroadcastFn = Callable[[str, dict], Coroutine]
 
+# Sensor-staleness guard (Issue #211). Battery-powered Zigbee/Z-Wave temperature
+# sensors that drop off the mesh keep their last numeric state in HA. Readings
+# older than this threshold (minutes) are excluded from room-temperature
+# averages so the engine never drives control decisions off stale data.
+SENSOR_STALE_AFTER_MIN: float = 30.0
+
 
 class CycleState(Enum):
     IDLE = "idle"
@@ -90,6 +96,11 @@ class CycleEngine:
         # off-time lockout before a new cycle may start. In-memory only — a
         # server restart resets it (a restart is itself a multi-minute gap).
         self._last_cycle_ended_at: datetime | None = None
+
+        # Sensor-staleness episodes already announced via the event log
+        # (Issue #211). Tracked per-engine so we warn once per stale episode
+        # rather than every 60-second tick.
+        self._stale_warned: set[str] = set()
 
     # ------------------------------------------------------------------
     # Public
@@ -232,6 +243,10 @@ class CycleEngine:
         # Determine which rooms should be active now
         new_active = await get_active_rooms(conn, self.thermostat_entity_id)
         new_active_map = {ar.room.id: ar for ar in new_active}
+
+        # Surface room-sensor staleness before any decisions are made off the
+        # (now stale-filtered) data. Once-per-episode rate-limited internally.
+        await self._emit_sensor_freshness_warnings(new_active_map)
 
         if not new_active_map:
             if self._state != CycleState.IDLE:
@@ -1545,13 +1560,77 @@ class CycleEngine:
                 pass
         return detail
 
+    async def _emit_sensor_freshness_warnings(self, active_rooms: dict[str, ActiveRoom]) -> None:
+        """Surface room-sensor staleness in the event log (Issue #211).
+
+        Walks each active room's sensors and compares their age against
+        ``SENSOR_STALE_AFTER_MIN``. The first tick a sensor crosses into
+        staleness writes a ``warning`` event naming the entity and its age;
+        the engine then suppresses further warnings for that entity until it
+        reports a fresh reading again, at which point a ``info`` recovery
+        event is written. This keeps the event feed signal-heavy rather than
+        spamming a stuck sensor every 60 seconds.
+        """
+        now_stale: set[str] = set()
+        for ar in active_rooms.values():
+            sensor_ids = self._sensor_ids_for_room.get(ar.room.id, [])
+            for eid in sensor_ids:
+                age_s = self._ha.get_state_age_seconds(eid)
+                if age_s is None:
+                    continue  # entity not in cache at all — separate failure mode
+                if age_s <= SENSOR_STALE_AFTER_MIN * 60:
+                    continue
+                now_stale.add(eid)
+                if eid in self._stale_warned:
+                    continue
+                self._stale_warned.add(eid)
+                age_min = age_s / 60
+                log.warning(
+                    "Sensor %s for room %r is stale (age %.0f min); excluding from room average",
+                    eid,
+                    ar.room.name,
+                    age_min,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "warning",
+                        "engine",
+                        f"Temperature sensor {eid} for room '{ar.room.name}' has "
+                        f"not reported in {age_min:.0f} minutes; excluded from the "
+                        "room temperature average. Check the sensor's battery or "
+                        "connection.",
+                        {
+                            "entity_id": eid,
+                            "room": ar.room.name,
+                            "age_seconds": age_s,
+                        },
+                    )
+
+        # Sensors no longer stale → emit a recovery info event and drop them
+        # from the warned set so a future stale episode warns again.
+        recovered = self._stale_warned - now_stale
+        for eid in recovered:
+            self._stale_warned.discard(eid)
+            log.info("Sensor %s is reporting again (fresh reading)", eid)
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Temperature sensor {eid} is reporting again (fresh reading received).",
+                    {"entity_id": eid},
+                )
+
     def _get_avg_temp(self, room: Room) -> float | None:
         readings: list[float] = []
 
-        # Re-query the cache for all sensors belonging to this room
+        # Re-query the cache for all sensors belonging to this room. Readings
+        # older than SENSOR_STALE_AFTER_MIN are excluded so a battery sensor
+        # that has dropped off cannot silently drive control decisions
+        # (Issue #211). Warning events are emitted from _do_tick on the
+        # transition into staleness, not here, to keep this method sync.
         sensor_ids = self._sensor_ids_for_room.get(room.id, [])
         for eid in sensor_ids:
-            val = self._ha.get_numeric_state(eid)
+            val = self._ha.get_numeric_state(eid, max_age_min=SENSOR_STALE_AFTER_MIN)
             if val is not None:
                 readings.append(val)
 

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -101,6 +101,10 @@ class CycleEngine:
         # (Issue #211). Tracked per-engine so we warn once per stale episode
         # rather than every 60-second tick.
         self._stale_warned: set[str] = set()
+        # Active staleness threshold (minutes). Refreshed at the start of each
+        # tick from the ``sensor_stale_after_min`` system setting so changes
+        # from the Settings page take effect on the next tick.
+        self._stale_after_min: float = SENSOR_STALE_AFTER_MIN
 
     # ------------------------------------------------------------------
     # Public
@@ -183,6 +187,16 @@ class CycleEngine:
         # Expire holdovers and overrides first
         await expire_holdovers(conn)
         await db.clear_expired_overrides(conn)
+
+        # Refresh the sensor-staleness threshold so Settings-page changes take
+        # effect on the next tick. Stored as a string in system_settings.
+        raw = await db.get_system_setting(
+            conn, "sensor_stale_after_min", str(SENSOR_STALE_AFTER_MIN)
+        )
+        try:
+            self._stale_after_min = float(raw)
+        except (TypeError, ValueError):
+            self._stale_after_min = SENSOR_STALE_AFTER_MIN
 
         # Thermostat availability check — always runs, even when system is
         # disabled or vacation mode is active. Transient outages are tolerated.
@@ -1578,7 +1592,7 @@ class CycleEngine:
                 age_s = self._ha.get_state_age_seconds(eid)
                 if age_s is None:
                     continue  # entity not in cache at all — separate failure mode
-                if age_s <= SENSOR_STALE_AFTER_MIN * 60:
+                if age_s <= self._stale_after_min * 60:
                     continue
                 now_stale.add(eid)
                 if eid in self._stale_warned:
@@ -1630,7 +1644,7 @@ class CycleEngine:
         # transition into staleness, not here, to keep this method sync.
         sensor_ids = self._sensor_ids_for_room.get(room.id, [])
         for eid in sensor_ids:
-            val = self._ha.get_numeric_state(eid, max_age_min=SENSOR_STALE_AFTER_MIN)
+            val = self._ha.get_numeric_state(eid, max_age_min=self._stale_after_min)
             if val is not None:
                 readings.append(val)
 

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -18,6 +18,7 @@ import os
 import ssl
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import aiohttp
@@ -107,8 +108,14 @@ class HAClient:
             return default
         return state.get("attributes", {}).get(attribute, default)
 
-    def get_numeric_state(self, entity_id: str) -> float | None:
-        """Return entity state as float, handling °C→°F conversion."""
+    def get_numeric_state(self, entity_id: str, max_age_min: float | None = None) -> float | None:
+        """Return entity state as float, handling °C→°F conversion.
+
+        If *max_age_min* is provided, ``None`` is returned for cached readings
+        whose ``last_updated`` is more than that many minutes in the past — the
+        freshness guard for control-loop reads (Issue #211). Callers that omit
+        the argument see no behaviour change.
+        """
         state = self._state_cache.get(entity_id)
         if state is None:
             return None
@@ -116,10 +123,36 @@ class HAClient:
             value = float(state["state"])
         except (ValueError, KeyError, TypeError):
             return None
+        if max_age_min is not None and self._state_age(state) > timedelta(minutes=max_age_min):
+            return None
         unit = state.get("attributes", {}).get("unit_of_measurement", "")
         if unit == "°C":
             value = value * 9 / 5 + 32
         return value
+
+    def get_state_age_seconds(self, entity_id: str) -> float | None:
+        """Seconds since the entity last reported, or ``None`` if not cached.
+
+        Used to surface a sensor's age in warning event logs (Issue #211).
+        A missing or unparseable ``last_updated`` is reported as ``+inf`` so the
+        caller treats it as stale rather than silently dropping the signal.
+        """
+        state = self._state_cache.get(entity_id)
+        if state is None:
+            return None
+        return self._state_age(state).total_seconds()
+
+    @staticmethod
+    def _state_age(state: dict) -> timedelta:
+        """Age of a cached state. Defaults to ``+inf`` on missing/bad timestamps."""
+        raw = state.get("last_updated") or state.get("last_changed")
+        if not raw:
+            return timedelta.max
+        try:
+            ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return timedelta.max
+        return datetime.now(UTC) - ts
 
     async def fetch_states(self) -> list[dict]:
         """Fetch all entity states via REST and populate cache."""

--- a/smart_vent/backend/tests/integration/fake_ha.py
+++ b/smart_vent/backend/tests/integration/fake_ha.py
@@ -15,6 +15,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 StateCallback = Callable[[str, dict], Coroutine]
@@ -44,22 +45,41 @@ class FakeHomeAssistant:
     # Test helpers
     # ------------------------------------------------------------------
 
-    def seed_state(self, entity_id: str, state: str, attributes: dict | None = None) -> None:
-        """Set an entity's state without firing subscribers (setup)."""
+    def seed_state(
+        self,
+        entity_id: str,
+        state: str,
+        attributes: dict | None = None,
+        *,
+        last_updated: str | None = None,
+    ) -> None:
+        """Set an entity's state without firing subscribers (setup).
+
+        ``last_updated`` defaults to ``now`` so seeded readings are treated as
+        fresh by the sensor-staleness guard (Issue #211). Pass an older ISO
+        timestamp to seed a stale reading explicitly.
+        """
         self._state[entity_id] = {
             "entity_id": entity_id,
             "state": state,
             "attributes": dict(attributes or {}),
+            "last_updated": last_updated or datetime.now(UTC).isoformat(),
         }
 
     async def set_entity_state(
-        self, entity_id: str, state: str, attributes: dict | None = None
+        self,
+        entity_id: str,
+        state: str,
+        attributes: dict | None = None,
+        *,
+        last_updated: str | None = None,
     ) -> None:
         """Mutate state and dispatch subscribers (simulates state_changed)."""
         self._state[entity_id] = {
             "entity_id": entity_id,
             "state": state,
             "attributes": dict(attributes or {}),
+            "last_updated": last_updated or datetime.now(UTC).isoformat(),
         }
         await self._dispatch(entity_id)
 
@@ -97,7 +117,7 @@ class FakeHomeAssistant:
             return default
         return s.get("attributes", {}).get(attribute, default)
 
-    def get_numeric_state(self, entity_id: str) -> float | None:
+    def get_numeric_state(self, entity_id: str, max_age_min: float | None = None) -> float | None:
         s = self._state.get(entity_id)
         if s is None:
             return None
@@ -105,10 +125,29 @@ class FakeHomeAssistant:
             value = float(s["state"])
         except (ValueError, KeyError, TypeError):
             return None
+        if max_age_min is not None and self._state_age(s) > timedelta(minutes=max_age_min):
+            return None
         unit = s.get("attributes", {}).get("unit_of_measurement", "")
         if unit == "°C":
             value = value * 9 / 5 + 32
         return value
+
+    def get_state_age_seconds(self, entity_id: str) -> float | None:
+        s = self._state.get(entity_id)
+        if s is None:
+            return None
+        return self._state_age(s).total_seconds()
+
+    @staticmethod
+    def _state_age(state: dict) -> timedelta:
+        raw = state.get("last_updated") or state.get("last_changed")
+        if not raw:
+            return timedelta.max
+        try:
+            ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return timedelta.max
+        return datetime.now(UTC) - ts
 
     async def fetch_states(self) -> list[dict]:
         return list(self._state.values())

--- a/smart_vent/backend/tests/integration/test_sensor_staleness.py
+++ b/smart_vent/backend/tests/integration/test_sensor_staleness.py
@@ -107,3 +107,93 @@ async def test_all_room_sensors_stale_falls_back_to_thermostat_ambient(
     logs = await (await client.get("/api/logs")).json()
     assert len(logs) == 1
     assert logs[0]["mode"] == "cooling"
+
+
+@pytest.mark.asyncio
+async def test_sensor_staleness_setting_roundtrip(client) -> None:
+    """The threshold defaults to 30 min and persists across GET/PUT cycles
+    so the Settings page can configure it. Invalid values are rejected."""
+    resp = await client.get("/api/settings/sensor-staleness")
+    assert resp.status == 200
+    assert (await resp.json())["stale_after_min"] == 30.0
+
+    resp = await client.put("/api/settings/sensor-staleness", json={"stale_after_min": 45})
+    assert resp.status == 200
+    assert (await resp.json())["stale_after_min"] == 45.0
+
+    # Persists on next GET.
+    assert (await (await client.get("/api/settings/sensor-staleness")).json())[
+        "stale_after_min"
+    ] == 45.0
+
+    # Out of range — rejected.
+    resp = await client.put("/api/settings/sensor-staleness", json={"stale_after_min": 0})
+    assert resp.status == 400
+    resp = await client.put("/api/settings/sensor-staleness", json={"stale_after_min": 24 * 60 + 1})
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_setting_change_takes_effect_on_next_tick(client, fake_ha, tick) -> None:
+    """Raising the threshold past a sensor's age must un-stale it on the next
+    tick — proving the engine reads the setting live rather than caching the
+    constant at startup."""
+    # Seed a room sensor that is 45 minutes old. Default threshold is 30 →
+    # the engine treats it as stale and the warning we already covered fires.
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(
+        "sensor.fresh_temp",
+        "78.0",
+        {"unit_of_measurement": "°F"},
+        last_updated=(datetime.now(UTC) - timedelta(minutes=45)).isoformat(),
+    )
+    fake_ha.seed_state("sensor.dead_battery", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.bedroom_vent", "open", {})
+    await _create_room_with_two_sensors(client)
+
+    # Raise the threshold to 60 minutes — 45-min reading is now fresh.
+    await client.put("/api/settings/sensor-staleness", json={"stale_after_min": 60})
+    await tick()
+
+    # Sensor-health reports zero stale sensors with the new threshold.
+    health = await (await client.get("/api/sensor-health")).json()
+    assert health["stale_after_min"] == 60.0
+    assert health["rooms"] == []
+
+
+@pytest.mark.asyncio
+async def test_sensor_health_lists_stale_sensors(client, fake_ha, tick) -> None:
+    """/api/sensor-health drives the Dashboard banner and the Room badges.
+    It must list every configured room sensor whose age exceeds the
+    threshold, naming both the room and the entity."""
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.fresh_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(
+        "sensor.dead_battery",
+        "60.0",
+        {"unit_of_measurement": "°F"},
+        last_updated=(datetime.now(UTC) - timedelta(hours=2)).isoformat(),
+    )
+    fake_ha.seed_state("cover.bedroom_vent", "open", {})
+    await _create_room_with_two_sensors(client)
+
+    health = await (await client.get("/api/sensor-health")).json()
+    assert health["stale_after_min"] == 30.0
+    assert len(health["rooms"]) == 1
+    room = health["rooms"][0]
+    assert room["room_name"] == "Bedroom"
+
+    stale_ids = {s["entity_id"] for s in room["stale_sensors"]}
+    assert stale_ids == {"sensor.dead_battery"}
+    dead = next(s for s in room["stale_sensors"] if s["entity_id"] == "sensor.dead_battery")
+    # Roughly 2 hours, with execution slack.
+    assert 2 * 3600 - 60 < dead["age_seconds"] < 2 * 3600 + 60
+    assert dead["reason"] == "stale"

--- a/smart_vent/backend/tests/integration/test_sensor_staleness.py
+++ b/smart_vent/backend/tests/integration/test_sensor_staleness.py
@@ -1,0 +1,109 @@
+"""Sensor-staleness guard integration test (Issue #211).
+
+A battery sensor that drops off the mesh keeps its last numeric state in HA.
+If the engine averages that stale value into the room temperature, it can
+silently make the *wrong* control decision — the worst kind of failure mode
+because nothing surfaces as broken. This test pins the end-to-end behaviour:
+a stale reading at a wrong-direction value does NOT poison the room average,
+the cycle is decided from the fresh sensor alone, and a warning event is
+written naming the offending sensor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+
+
+async def _create_room_with_two_sensors(client) -> str:
+    """Cooling scenario: warm room on an all-day schedule, target 72°F."""
+    resp = await client.post("/api/rooms", json={"name": "Bedroom", "thermostat_entity_id": THERMO})
+    room_id: str = (await resp.json())["id"]
+    for eid in ("sensor.fresh_temp", "sensor.dead_battery"):
+        await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": eid})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.bedroom_vent", "control_method": "open_close"},
+    )
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+    return room_id
+
+
+@pytest.mark.asyncio
+async def test_stale_sensor_does_not_poison_room_average(client, fake_ha, tick) -> None:
+    """The fresh sensor says the room is warm (78°F) and needs cooling. The
+    stale sensor would inject 60°F into the average and invert the decision —
+    if the engine trusted it. The guard must keep that from happening."""
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.fresh_temp", "78.0", {"unit_of_measurement": "°F"})
+    # A 3-hour-old reading at a wrong-direction value: without the guard, the
+    # average would be (78 + 60) / 2 = 69°F → engine infers "off", no cycle.
+    fake_ha.seed_state(
+        "sensor.dead_battery",
+        "60.0",
+        {"unit_of_measurement": "°F"},
+        last_updated=(datetime.now(UTC) - timedelta(hours=3)).isoformat(),
+    )
+    fake_ha.seed_state("cover.bedroom_vent", "open", {})
+    await _create_room_with_two_sensors(client)
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "cooling cycle must start from the fresh reading alone"
+    assert logs[0]["mode"] == "cooling"
+
+    # And the dead sensor is surfaced in the event log so it can be fixed.
+    events = await (await client.get("/api/logs/events?level=warning")).json()
+    messages = [e["message"] for e in events]
+    assert any("sensor.dead_battery" in m and "minutes" in m for m in messages), messages
+
+
+@pytest.mark.asyncio
+async def test_all_room_sensors_stale_falls_back_to_thermostat_ambient(
+    client, fake_ha, tick
+) -> None:
+    """When every room sensor is stale, _get_avg_temp returns None and
+    _infer_mode falls through to the thermostat's own ambient reading — the
+    cycle is still decided correctly rather than going dark."""
+    # Thermostat ambient 78°F (warm) — its own sensor still reports.
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "idle"},
+    )
+    stale_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    fake_ha.seed_state(
+        "sensor.fresh_temp", "70.0", {"unit_of_measurement": "°F"}, last_updated=stale_ts
+    )
+    fake_ha.seed_state(
+        "sensor.dead_battery", "70.0", {"unit_of_measurement": "°F"}, last_updated=stale_ts
+    )
+    fake_ha.seed_state("cover.bedroom_vent", "open", {})
+    await _create_room_with_two_sensors(client)
+
+    await tick()
+
+    # The fallback path uses the thermostat's 78°F vs target 72°F → still
+    # infers cooling. The cycle starts; the stale sensors did not block it.
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1
+    assert logs[0]["mode"] == "cooling"

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -257,7 +257,7 @@ class TestFilterRoomsForMode:
         }
 
         # Mock sensor readings: r1=78 (needs cooling), r2=70 (needs heating)
-        def get_numeric(eid):
+        def get_numeric(eid, max_age_min=None):
             return None
 
         ha.get_numeric_state.side_effect = get_numeric
@@ -269,7 +269,7 @@ class TestFilterRoomsForMode:
         # Let's set up with actual sensor map instead
         engine._sensor_map = {"r1": ["sensor.r1"], "r2": ["sensor.r2"]}
 
-        def get_numeric_state(eid):
+        def get_numeric_state(eid, max_age_min=None):
             if eid == "sensor.r1":
                 return 78.0  # needs cooling
             if eid == "sensor.r2":
@@ -299,7 +299,7 @@ class TestFilterRoomsForMode:
 
         engine._sensor_map = {"r1": ["sensor.r1"], "r2": ["sensor.r2"]}
 
-        def get_numeric_state(eid):
+        def get_numeric_state(eid, max_age_min=None):
             if eid == "sensor.r1":
                 return 70.0  # needs heating
             if eid == "sensor.r2":
@@ -553,7 +553,10 @@ class TestInferMode:
         ha = _make_ha(ambient=78.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
-        ha.get_numeric_state.side_effect = lambda eid: {"s1": 80.0, "s2": 79.0}.get(eid)
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s1": 80.0,
+            "s2": 79.0,
+        }.get(eid)
 
         rooms = {
             "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
@@ -568,7 +571,10 @@ class TestInferMode:
         ha = _make_ha(ambient=68.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
-        ha.get_numeric_state.side_effect = lambda eid: {"s1": 65.0, "s2": 66.0}.get(eid)
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s1": 65.0,
+            "s2": 66.0,
+        }.get(eid)
 
         rooms = {
             "r1": ActiveRoom(room=_make_room("r1"), target_temp=74.0, source="schedule"),
@@ -598,7 +604,7 @@ class TestInferMode:
         ha = _make_ha(ambient=74.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1"], "r2": ["s2"], "r3": ["s3"]}
-        ha.get_numeric_state.side_effect = lambda eid: {
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
             "s1": 80.0,  # needs cool
             "s2": 79.0,  # needs cool
             "s3": 65.0,  # needs heat
@@ -619,7 +625,7 @@ class TestInferMode:
         ha = _make_ha(ambient=74.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
-        ha.get_numeric_state.side_effect = lambda eid: {
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
             "s1": 80.0,  # needs cool
             "s2": 65.0,  # needs heat
         }.get(eid)
@@ -688,7 +694,10 @@ class TestGetAvgTemp:
         ha = _make_ha(ambient=72.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1", "s2"]}
-        ha.get_numeric_state.side_effect = lambda eid: {"s1": 70.0, "s2": 80.0}.get(eid)
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s1": 70.0,
+            "s2": 80.0,
+        }.get(eid)
 
         room = _make_room("r1")
         assert engine._get_avg_temp(room) == 75.0
@@ -717,7 +726,10 @@ class TestGetAvgTemp:
         ha = _make_ha(ambient=72.0)
         engine = _make_engine(ha)
         engine._sensor_map = {"r1": ["s1", "s2"]}
-        ha.get_numeric_state.side_effect = lambda eid: {"s1": 76.0, "s2": None}.get(eid)
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s1": 76.0,
+            "s2": None,
+        }.get(eid)
 
         room = _make_room("r1")
         # Only s1 has data → 76.0
@@ -1184,7 +1196,7 @@ class TestAllActiveRoomsSatisfied:
         engine = _make_engine(ha)
         engine._sensor_map = {rid: [f"s_{rid}"] for rid in temps}
         readings = {f"s_{rid}": t for rid, t in temps.items()}
-        ha.get_numeric_state.side_effect = lambda eid: readings.get(eid)
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: readings.get(eid)
         return engine
 
     def test_all_rooms_at_target_returns_true(self):
@@ -1343,3 +1355,112 @@ class TestCoolingLockoutState:
         # Exactly at the threshold is not "below" it — cooling is allowed.
         state, _temp = await engine._cooling_lockout_state(None, tc)
         assert state == "allowed"
+
+
+class TestSensorStalenessGuard:
+    """_get_avg_temp + _emit_sensor_freshness_warnings — Issue #211.
+
+    A battery sensor that drops off the mesh keeps its last numeric state in
+    HA. Without a freshness guard, the engine would average that stale value
+    into the room temperature and confidently make the wrong control decision.
+    These tests pin both the math (stale readings excluded from the average)
+    and the user-visible signal (a warning event written once per episode).
+    """
+
+    def _make_room(self, room_id: str = "r1") -> Room:
+        return _make_room(room_id, name="Bedroom")
+
+    def test_get_avg_temp_excludes_stale_sensors(self):
+        room = self._make_room()
+        engine = _make_engine()
+        engine._sensor_map = {room.id: ["sensor.fresh", "sensor.stale"]}
+
+        # Mock the HAClient to honor max_age_min: a stale call returns None.
+        def get_numeric(eid: str, max_age_min: float | None = None) -> float | None:
+            if eid == "sensor.fresh":
+                return 70.0
+            return None  # stale → guard returns None
+
+        engine._ha.get_numeric_state.side_effect = get_numeric
+
+        avg = engine._get_avg_temp(room)
+        # Only the fresh sensor counts toward the average.
+        assert avg == 70.0
+
+    def test_get_avg_temp_returns_none_when_all_sensors_stale(self):
+        room = self._make_room()
+        engine = _make_engine()
+        engine._sensor_map = {room.id: ["sensor.a", "sensor.b"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: None
+        # No thermostat ambient fallback for this room.
+        room.include_thermostat_sensor = False
+
+        assert engine._get_avg_temp(room) is None
+
+    @pytest.mark.asyncio
+    async def test_emit_warning_once_per_stale_episode(self):
+        """Warns the first tick a sensor goes stale; silent on subsequent ticks
+        until the sensor recovers."""
+        room = self._make_room()
+        engine = _make_engine()
+        engine._sensor_map = {room.id: ["sensor.dead"]}
+        engine._logger = MagicMock()
+        engine._logger.log = AsyncMock()
+        # 90 minutes stale — well past the 30-minute threshold.
+        engine._ha.get_state_age_seconds = MagicMock(return_value=90 * 60)
+
+        ar = ActiveRoom(room=room, source="schedule", target_temp=72.0)
+
+        await engine._emit_sensor_freshness_warnings({room.id: ar})
+        await engine._emit_sensor_freshness_warnings({room.id: ar})
+        await engine._emit_sensor_freshness_warnings({room.id: ar})
+
+        # Exactly one warning event despite three ticks against the same stale
+        # sensor — the rate-limit is doing its job.
+        warn_calls = [c for c in engine._logger.log.await_args_list if c.args[0] == "warning"]
+        assert len(warn_calls) == 1
+        msg = warn_calls[0].args[2]
+        assert "sensor.dead" in msg
+        # Message names the age so a technician can act on it.
+        assert "90" in msg
+
+    @pytest.mark.asyncio
+    async def test_recovery_emits_info_and_rearms_warning(self):
+        """When a stale sensor reports a fresh reading again, the engine emits a
+        recovery info event AND clears its 'already warned' flag so a future
+        stale episode warns again."""
+        room = self._make_room()
+        engine = _make_engine()
+        engine._sensor_map = {room.id: ["sensor.flaky"]}
+        engine._logger = MagicMock()
+        engine._logger.log = AsyncMock()
+
+        age_seq = iter([90 * 60, 30, 90 * 60])  # stale → fresh → stale again
+        engine._ha.get_state_age_seconds = MagicMock(side_effect=lambda _eid: next(age_seq))
+        ar = ActiveRoom(room=room, source="schedule", target_temp=72.0)
+
+        await engine._emit_sensor_freshness_warnings({room.id: ar})  # stale → warn
+        await engine._emit_sensor_freshness_warnings({room.id: ar})  # fresh → recovery
+        await engine._emit_sensor_freshness_warnings({room.id: ar})  # stale → warn again
+
+        levels = [c.args[0] for c in engine._logger.log.await_args_list]
+        # The "info" recovery sits between the two warnings — proving both that
+        # recovery is announced and that the warned-set was cleared.
+        assert levels == ["warning", "info", "warning"]
+
+    @pytest.mark.asyncio
+    async def test_missing_entity_not_warned(self):
+        """An entity that has never been seen in the state cache returns None
+        from get_state_age_seconds and is silently skipped — only sensors HA
+        knows about but is no longer hearing from are flagged."""
+        room = self._make_room()
+        engine = _make_engine()
+        engine._sensor_map = {room.id: ["sensor.never_existed"]}
+        engine._logger = MagicMock()
+        engine._logger.log = AsyncMock()
+        engine._ha.get_state_age_seconds = MagicMock(return_value=None)
+
+        ar = ActiveRoom(room=room, source="schedule", target_temp=72.0)
+        await engine._emit_sensor_freshness_warnings({room.id: ar})
+
+        engine._logger.log.assert_not_awaited()

--- a/smart_vent/backend/tests/test_ha_client.py
+++ b/smart_vent/backend/tests/test_ha_client.py
@@ -9,6 +9,7 @@ alone (they use FakeHA and never touch the real WS client).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -101,6 +102,84 @@ class TestStateCache:
 
     def test_get_numeric_state_missing_entity(self):
         assert self.client.get_numeric_state("nope.entity") is None
+
+
+class TestSensorStalenessGuard:
+    """get_numeric_state(max_age_min=...) and get_state_age_seconds — Issue #211.
+
+    A non-numeric state is already returned as None, but a numeric state from
+    a sensor that has stopped reporting (battery Zigbee/Z-Wave devices keep
+    their last numeric value) would silently drive the wrong control decision.
+    The freshness guard makes such readings opt-in via *max_age_min*.
+    """
+
+    def setup_method(self):
+        self.client = HAClient("http://ha.local", "tok")
+        now = datetime.now(UTC)
+        self.client._state_cache = {
+            "sensor.fresh": {
+                "state": "70.0",
+                "attributes": {"unit_of_measurement": "°F"},
+                "last_updated": (now - timedelta(minutes=2)).isoformat(),
+            },
+            "sensor.stale": {
+                "state": "70.0",
+                "attributes": {"unit_of_measurement": "°F"},
+                "last_updated": (now - timedelta(hours=3)).isoformat(),
+            },
+            "sensor.celsius_fresh": {
+                "state": "21.1",
+                "attributes": {"unit_of_measurement": "°C"},
+                "last_updated": (now - timedelta(seconds=30)).isoformat(),
+            },
+            "sensor.zulu_fresh": {
+                "state": "70.0",
+                "attributes": {"unit_of_measurement": "°F"},
+                "last_updated": (now - timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            },
+            "sensor.no_timestamp": {
+                "state": "70.0",
+                "attributes": {"unit_of_measurement": "°F"},
+            },
+        }
+
+    def test_no_threshold_means_no_freshness_check(self):
+        # Backward compat: callers that omit max_age_min see the existing behaviour.
+        assert self.client.get_numeric_state("sensor.stale") == 70.0
+
+    def test_fresh_reading_passes(self):
+        assert self.client.get_numeric_state("sensor.fresh", max_age_min=30) == 70.0
+
+    def test_stale_reading_dropped(self):
+        # 3 hours old, threshold 30 min → stale → None.
+        assert self.client.get_numeric_state("sensor.stale", max_age_min=30) is None
+
+    def test_celsius_conversion_still_applied_when_fresh(self):
+        v = self.client.get_numeric_state("sensor.celsius_fresh", max_age_min=30)
+        assert v is not None
+        assert abs(v - (21.1 * 9 / 5 + 32)) < 0.001
+
+    def test_zulu_timestamp_format_parsed(self):
+        # HA states often serialize last_updated with a trailing Z.
+        assert self.client.get_numeric_state("sensor.zulu_fresh", max_age_min=30) == 70.0
+
+    def test_missing_timestamp_treated_as_stale(self):
+        # Defensive: a cached state with no last_updated is treated as stale
+        # rather than silently accepted as fresh.
+        assert self.client.get_numeric_state("sensor.no_timestamp", max_age_min=30) is None
+
+    def test_get_state_age_seconds_fresh(self):
+        age = self.client.get_state_age_seconds("sensor.fresh")
+        assert age is not None
+        assert 110 < age < 130  # ~120 seconds (2 minutes), with execution slack
+
+    def test_get_state_age_seconds_missing_entity(self):
+        assert self.client.get_state_age_seconds("nope.entity") is None
+
+    def test_get_state_age_seconds_missing_timestamp(self):
+        # No last_updated → reported as +inf so the caller treats it as stale.
+        age = self.client.get_state_age_seconds("sensor.no_timestamp")
+        assert age == timedelta.max.total_seconds()
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -9,6 +9,8 @@ vi.mock("./api");
 describe("App Root", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
+    vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
     vi.mocked(api.getSystemStatus).mockResolvedValue({ enabled: true, dev_mode: false });
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "F",

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -685,6 +685,44 @@ export const setOutsideTempEntity = (entity_id: string | null) =>
     body: JSON.stringify({ entity_id }),
   });
 
+// Sensor-staleness guard (Issue #211). The threshold is a single
+// system-wide setting in minutes. /api/sensor-health summarises which
+// configured room sensors have not reported within that threshold — used by
+// the Dashboard banner and the per-room badges on the Rooms page.
+
+export interface SensorStalenessSetting {
+  stale_after_min: number;
+}
+
+export interface StaleSensor {
+  entity_id: string;
+  age_seconds: number | null;
+  reason: "stale" | "not_in_cache";
+}
+
+export interface StaleRoom {
+  room_id: string;
+  room_name: string;
+  thermostat_entity_id: string;
+  stale_sensors: StaleSensor[];
+}
+
+export interface SensorHealth {
+  stale_after_min: number;
+  rooms: StaleRoom[];
+}
+
+export const getSensorStaleness = () =>
+  api<SensorStalenessSetting>("/api/settings/sensor-staleness");
+
+export const setSensorStaleness = (stale_after_min: number) =>
+  api<SensorStalenessSetting>("/api/settings/sensor-staleness", {
+    method: "PUT",
+    body: JSON.stringify({ stale_after_min }),
+  });
+
+export const getSensorHealth = () => api<SensorHealth>("/api/sensor-health");
+
 export const triggerDailyRollup = (days_back?: number) =>
   api<{ rows_written: number; days_back: number }>("/api/metrics/rollup/daily", {
     method: "POST",

--- a/smart_vent/frontend/src/components/StaleSensorsBanner.tsx
+++ b/smart_vent/frontend/src/components/StaleSensorsBanner.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { getSensorHealth, type SensorHealth } from "../api";
+
+/**
+ * Surfaces sensor-staleness on the Dashboard (Issue #211).
+ *
+ * Polls ``/api/sensor-health`` every 30 s. Renders nothing when every
+ * configured room sensor is fresh; renders an amber card listing the stale
+ * sensors otherwise. A control loop that quietly trusts a dead battery is the
+ * worst failure mode this app has, so the banner is deliberately loud.
+ */
+export default function StaleSensorsBanner() {
+  const [health, setHealth] = useState<SensorHealth | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      getSensorHealth()
+        .then((h) => {
+          if (!cancelled) setHealth(h);
+        })
+        .catch(() => {
+          /* network blip — leave previous state in place */
+        });
+    };
+    refresh();
+    const interval = setInterval(refresh, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!health || health.rooms.length === 0) return null;
+
+  const total = health.rooms.reduce((n, r) => n + r.stale_sensors.length, 0);
+
+  return (
+    <div
+      className="card"
+      role="alert"
+      data-testid="stale-sensors-banner"
+      style={{ borderLeft: "3px solid #f59e0b", marginBottom: "1rem" }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: ".5rem" }}>
+        <strong>
+          ⚠ {total} sensor{total === 1 ? "" : "s"} not reporting
+        </strong>
+        <span className="text-sm text-muted">
+          (threshold: {Math.round(health.stale_after_min)} min — configurable on the Settings page)
+        </span>
+      </div>
+      <div className="text-sm" style={{ marginTop: ".5rem", color: "var(--gray-700)" }}>
+        These rooms are running on partial sensor coverage; check the device batteries or
+        connectivity. The engine excludes stale readings from the room temperature average so
+        control decisions are not driven by them.
+      </div>
+      <ul style={{ margin: "0.5rem 0 0", paddingLeft: "1.25rem" }}>
+        {health.rooms.map((room) => (
+          <li key={room.room_id} style={{ marginBottom: ".25rem" }}>
+            <strong>{room.room_name}</strong>{" "}
+            {room.stale_sensors.map((s, i) => (
+              <span key={s.entity_id}>
+                {i > 0 && ", "}
+                <code>{s.entity_id}</code>{" "}
+                <span className="text-sm text-muted">({formatAge(s)})</span>
+              </span>
+            ))}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function formatAge(s: { age_seconds: number | null; reason: string }): string {
+  if (s.reason === "not_in_cache" || s.age_seconds === null) return "never seen by HA";
+  const minutes = Math.round(s.age_seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${hours.toFixed(1)} h ago`;
+  return `${Math.round(hours / 24)} d ago`;
+}

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -127,9 +127,7 @@ describe("Dashboard Page", () => {
           room_id: "r1",
           room_name: "Bedroom",
           thermostat_entity_id: "climate.test",
-          stale_sensors: [
-            { entity_id: "sensor.bedroom_temp", age_seconds: 5400, reason: "stale" },
-          ],
+          stale_sensors: [{ entity_id: "sensor.bedroom_temp", age_seconds: 5400, reason: "stale" }],
         },
       ],
     });

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -33,6 +33,8 @@ const mockStatus: api.ZoneStatus[] = [
 describe("Dashboard Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
+    vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
     vi.mocked(api.getStatus).mockResolvedValue(mockStatus);
     vi.mocked(api.connectWS).mockReturnValue(() => {});
     vi.mocked(api.getVacationMode).mockResolvedValue({ enabled: false, return_at: null });
@@ -115,5 +117,45 @@ describe("Dashboard Page", () => {
     expect(screen.getByText(/Schedules paused until/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Vacation mode active/i }));
     expect(screen.getByText(/End vacation mode early/i)).toBeInTheDocument();
+  });
+
+  it("surfaces stale sensors as a top-of-Dashboard banner (Issue #211)", async () => {
+    vi.mocked(api.getSensorHealth).mockResolvedValue({
+      stale_after_min: 30,
+      rooms: [
+        {
+          room_id: "r1",
+          room_name: "Bedroom",
+          thermostat_entity_id: "climate.test",
+          stale_sensors: [
+            { entity_id: "sensor.bedroom_temp", age_seconds: 5400, reason: "stale" },
+          ],
+        },
+      ],
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    const banner = await screen.findByTestId("stale-sensors-banner");
+    expect(banner).toHaveTextContent("1 sensor not reporting");
+    expect(banner).toHaveTextContent("Bedroom");
+    expect(banner).toHaveTextContent("sensor.bedroom_temp");
+    expect(banner).toHaveTextContent("1.5 h ago");
+  });
+
+  it("does not render the stale-sensors banner when everything is fresh", async () => {
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    await screen.findByText("Dashboard");
+    expect(screen.queryByTestId("stale-sensors-banner")).not.toBeInTheDocument();
   });
 });

--- a/smart_vent/frontend/src/pages/Dashboard.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import {
   type VacationMode,
 } from "../api";
 import { useUnit } from "../contexts";
+import StaleSensorsBanner from "../components/StaleSensorsBanner";
 import VacationModeModal from "../components/VacationModeModal";
 
 function modeColor(mode: string): string {
@@ -218,6 +219,8 @@ export default function Dashboard() {
           ↻ Refresh
         </button>
       </div>
+
+      <StaleSensorsBanner />
 
       {/* Vacation mode button — sits above climate cards */}
       <div style={{ marginBottom: "1rem" }}>

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -438,4 +438,29 @@ describe("Rooms Page — Clear presence button", () => {
       expect(api.getRoomActiveStatuses).toHaveBeenCalledTimes(2);
     });
   });
+
+  it("shows a stale-sensor badge on the room card when the API reports one (Issue #211)", async () => {
+    vi.mocked(api.getSensorHealth).mockResolvedValue({
+      stale_after_min: 30,
+      rooms: [
+        {
+          room_id: "room-1",
+          room_name: "Living Room",
+          thermostat_entity_id: "climate.test",
+          stale_sensors: [
+            { entity_id: "sensor.dead_battery", age_seconds: 7200, reason: "stale" },
+          ],
+        },
+      ],
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+    const badge = await screen.findByTestId("stale-badge-room-1");
+    expect(badge).toHaveTextContent("1 stale sensor");
+    // Title attribute carries the per-sensor detail used by browsers as a tooltip.
+    expect(badge.getAttribute("title")).toContain("sensor.dead_battery");
+  });
 });

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -447,9 +447,7 @@ describe("Rooms Page — Clear presence button", () => {
           room_id: "room-1",
           room_name: "Living Room",
           thermostat_entity_id: "climate.test",
-          stale_sensors: [
-            { entity_id: "sensor.dead_battery", age_seconds: 7200, reason: "stale" },
-          ],
+          stale_sensors: [{ entity_id: "sensor.dead_battery", age_seconds: 7200, reason: "stale" }],
         },
       ],
     });

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -17,6 +17,8 @@ import {
   getThermostats,
   getEntityStates,
   getRoomActiveStatuses,
+  getSensorHealth,
+  type StaleSensor,
   CONTROL_METHOD_LABELS,
   type ControlMethod,
   type Room,
@@ -677,6 +679,15 @@ function RoomConfigure({
 // Live state + countdown helpers
 // ---------------------------------------------------------------------------
 
+function formatStaleAge(s: StaleSensor): string {
+  if (s.reason === "not_in_cache" || s.age_seconds === null) return "never seen by HA";
+  const minutes = Math.round(s.age_seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = s.age_seconds / 3600;
+  if (hours < 24) return `${hours.toFixed(1)} h ago`;
+  return `${Math.round(hours / 24)} d ago`;
+}
+
 function formatCountdown(totalSeconds: number): string {
   if (totalSeconds <= 0) return "ending…";
   const h = Math.floor(totalSeconds / 3600);
@@ -725,6 +736,7 @@ function RoomCard({
   thermostats,
   status,
   statusFetchedAt,
+  staleSensors,
   onConfigure,
   onEdit,
   onDelete,
@@ -734,6 +746,7 @@ function RoomCard({
   thermostats: ThermostatConfig[];
   status: RoomActiveStatus | null;
   statusFetchedAt: number; // Date.now() when status was fetched
+  staleSensors: StaleSensor[];
   onConfigure: () => void;
   onEdit: () => void;
   onDelete: () => void;
@@ -794,6 +807,16 @@ function RoomCard({
       <div className="flex-between" style={{ marginBottom: ".5rem" }}>
         <div className="card-title" style={{ marginBottom: 0 }}>
           {room.name}
+          {staleSensors.length > 0 && (
+            <span
+              className="badge badge-orange"
+              data-testid={`stale-badge-${room.id}`}
+              title={staleSensors.map((s) => `${s.entity_id} — ${formatStaleAge(s)}`).join("\n")}
+              style={{ marginLeft: ".5rem", verticalAlign: "middle", fontSize: ".75rem" }}
+            >
+              ⚠ {staleSensors.length} stale sensor{staleSensors.length === 1 ? "" : "s"}
+            </span>
+          )}
         </div>
         <button className="btn btn-danger btn-sm" onClick={onDelete}>
           Delete
@@ -962,7 +985,20 @@ export default function Rooms() {
   const [configRoom, setConfigRoom] = useState<Room | null>(null);
   const [statuses, setStatuses] = useState<Record<string, RoomActiveStatus>>({});
   const [statusFetchedAt, setStatusFetchedAt] = useState<number>(Date.now());
+  // room_id → stale sensors. Drives the per-card badge (Issue #211).
+  const [staleByRoom, setStaleByRoom] = useState<Record<string, StaleSensor[]>>({});
   const roomsRef = useRef<Room[]>([]);
+
+  const refreshSensorHealth = async () => {
+    try {
+      const h = await getSensorHealth();
+      const map: Record<string, StaleSensor[]> = {};
+      for (const r of h.rooms) map[r.room_id] = r.stale_sensors;
+      setStaleByRoom(map);
+    } catch {
+      // ignore — banner-style information, not critical for the page to render
+    }
+  };
 
   const fetchStatuses = async (roomList: Room[]) => {
     if (roomList.length === 0) return;
@@ -982,7 +1018,7 @@ export default function Rooms() {
     roomsRef.current = detailed;
     setThermostats(tcs);
     setLoading(false);
-    await fetchStatuses(detailed);
+    await Promise.all([fetchStatuses(detailed), refreshSensorHealth()]);
   };
 
   useEffect(() => {
@@ -994,7 +1030,10 @@ export default function Rooms() {
   // Re-fetch statuses every 30s. Mount-only — uses ref to read latest rooms
   // without re-subscribing.
   useEffect(() => {
-    const interval = setInterval(() => fetchStatuses(roomsRef.current), 30_000);
+    const interval = setInterval(() => {
+      fetchStatuses(roomsRef.current);
+      refreshSensorHealth();
+    }, 30_000);
     return () => clearInterval(interval);
   }, []);
 
@@ -1060,6 +1099,7 @@ export default function Rooms() {
               thermostats={thermostats}
               status={statuses[room.id] ?? null}
               statusFetchedAt={statusFetchedAt}
+              staleSensors={staleByRoom[room.id] ?? []}
               onConfigure={() => setConfigRoom(room)}
               onEdit={() => {
                 setEditRoom(room);

--- a/smart_vent/frontend/src/pages/Settings.test.tsx
+++ b/smart_vent/frontend/src/pages/Settings.test.tsx
@@ -29,6 +29,10 @@ const mockThermostats: api.ThermostatConfig[] = [
 describe("Settings Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
+    vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
+    vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
+    vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
     vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
     vi.mocked(api.getRooms).mockResolvedValue([]);
     vi.mocked(api.updateThermostat).mockResolvedValue(mockThermostats[0]);
@@ -132,6 +136,34 @@ describe("Settings Page — Celsius mode", () => {
         "climate.test",
         expect.objectContaining({ min_setpoint: 60.8 })
       );
+    });
+  });
+});
+
+describe("Settings Page — Sensor-staleness threshold (Issue #211)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
+    vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
+    vi.mocked(api.getThermostats).mockResolvedValue(mockThermostats);
+    vi.mocked(api.getRooms).mockResolvedValue([]);
+  });
+
+  it("renders the configured threshold and saves a new value", async () => {
+    vi.mocked(api.setSensorStaleness).mockResolvedValue({ stale_after_min: 45 });
+    render(<Settings />);
+
+    const input = (await screen.findByLabelText(/^Minutes$/i)) as HTMLInputElement;
+    // Defaults to the GET response.
+    expect(input.value).toBe("30");
+
+    fireEvent.change(input, { target: { value: "45" } });
+    // The "Save" button next to the field — pick the first one (the SensorStalenessCard
+    // sits above thermostat cards, each of which has its own "Save changes" button).
+    fireEvent.click(screen.getAllByRole("button", { name: /^Save$/i })[0]);
+
+    await waitFor(() => {
+      expect(api.setSensorStaleness).toHaveBeenCalledWith(45);
     });
   });
 });

--- a/smart_vent/frontend/src/pages/Settings.tsx
+++ b/smart_vent/frontend/src/pages/Settings.tsx
@@ -1,6 +1,81 @@
 import { useEffect, useState } from "react";
-import { getThermostats, updateThermostat, getRooms, type ThermostatConfig } from "../api";
+import {
+  getThermostats,
+  updateThermostat,
+  getRooms,
+  getSensorStaleness,
+  setSensorStaleness,
+  type ThermostatConfig,
+} from "../api";
 import { useUnit } from "../contexts";
+
+function SensorStalenessCard() {
+  const [value, setValue] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  useEffect(() => {
+    getSensorStaleness()
+      .then((s) => setValue(s.stale_after_min))
+      .catch(() => setValue(30));
+  }, []);
+
+  const save = async () => {
+    if (value === null) return;
+    setSaving(true);
+    setStatus(null);
+    try {
+      const r = await setSensorStaleness(value);
+      setValue(r.stale_after_min);
+      setStatus({ ok: true, msg: "Saved" });
+    } catch (err) {
+      setStatus({ ok: false, msg: (err as Error).message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="card" style={{ marginBottom: "1rem" }}>
+      <div className="card-title">Sensor-staleness threshold</div>
+      <div className="form-hint" style={{ marginBottom: ".75rem" }}>
+        Temperature sensor readings older than this are excluded from the room temperature average
+        so the engine never drives control decisions off stale data (Issue&nbsp;#211).
+        Battery-powered Zigbee/Z-Wave sensors that drop off the mesh keep showing their last numeric
+        value in Home Assistant — without this guard, that stale value would silently poison the
+        average. Typical: <strong>30 min</strong>. Increase if your sensors report infrequently;
+        decrease if you want a tighter check.
+      </div>
+      <div style={{ display: "flex", gap: ".5rem", alignItems: "center" }}>
+        <label htmlFor="settings-sensor-stale-min" className="form-label" style={{ margin: 0 }}>
+          Minutes
+        </label>
+        <input
+          id="settings-sensor-stale-min"
+          className="form-control"
+          type="number"
+          min={1}
+          max={24 * 60}
+          step={1}
+          value={value ?? ""}
+          onChange={(e) => setValue(parseFloat(e.target.value) || 0)}
+          style={{ width: 120 }}
+        />
+        <button className="btn btn-primary" onClick={() => void save()} disabled={saving}>
+          Save
+        </button>
+        {status && (
+          <span
+            className={status.ok ? "text-success" : "text-danger"}
+            style={{ marginLeft: ".5rem" }}
+          >
+            {status.msg}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
 const FIELDS: {
   key: keyof ThermostatConfig;
@@ -209,6 +284,8 @@ export default function Settings() {
           </div>
         </div>
       )}
+
+      <SensorStalenessCard />
 
       {configs.map((c) => (
         <ThermostatCard key={c.thermostat_entity_id} config={c} />


### PR DESCRIPTION
## Summary

Closes #211. A battery-powered Zigbee/Z-Wave temperature sensor that drops off the mesh does not always flip to `unavailable` in Home Assistant — HA keeps returning the last numeric value it heard. The engine was averaging that stale value into the room temperature and silently making the **wrong** control decision: wrong mode, vents closing on a room that hadn't actually reached target, no cycle starting on a room that was warm. The kind of silent failure that only surfaces as a comfort complaint.

This PR adds a freshness guard in `HAClient.get_numeric_state`, threads it through `_get_avg_temp`, surfaces stale sensors in three UI places, and makes the threshold configurable from the Settings page.

## What changed

### Backend — the guard (commits `40064a5`, `fcfc9da`)
- `HAClient.get_numeric_state(entity_id, max_age_min=None)` — opt-in freshness check. Existing callers (the outdoor sensor used by the cooling lockout, raw state reads for analytics) keep their behaviour. Missing or unparseable `last_updated` timestamps are treated as stale so a malformed cache entry can't bypass the guard.
- `get_state_age_seconds()` + shared static `_state_age` — expose the age for warning logs.
- `SENSOR_STALE_AFTER_MIN = 30` is now a **default**. The engine reads `sensor_stale_after_min` from `system_settings` at the start of every tick, so Settings-page changes take effect within 60 seconds without a restart.
- `_get_avg_temp` excludes stale sensors from the average that drives mode inference, vent-close decisions, and at-target checks. All-stale falls through to the existing thermostat-ambient fallback.
- `_emit_sensor_freshness_warnings` (async, called once per tick from `_do_tick`) writes a `warning` event the first time each sensor crosses into staleness, an `info` recovery event when it reports again. Rate-limited via `self._stale_warned` so a stuck sensor doesn't spam the feed every 60s.

### Backend — new endpoints
- `GET /api/settings/sensor-staleness` — returns `{stale_after_min}`.
- `PUT /api/settings/sensor-staleness` — accepts 1 – 1440 minutes.
- `GET /api/sensor-health` — returns per-room stale-sensor summary, omitting rooms with no stale sensors. Drives both the Dashboard banner and the Rooms-page badges.

### Frontend — UI surfacing (the "feature without UI is useless" pass)
- **Dashboard** — new `StaleSensorsBanner` component at the top of the page lists every affected room and entity with its age. Polled every 30s; renders nothing when everything is fresh.
- **Rooms page** — each room card grows a small "⚠ N stale sensor(s)" badge with a hover-tooltip naming each specific entity and age.
- **Settings page** — a "Sensor-staleness threshold" card lets the operator tune the value, with help text explaining the guard.

### Fixture update
`FakeHomeAssistant.seed_state` / `set_entity_state` now populate `last_updated` (defaulting to `now`); `get_numeric_state` / `get_state_age_seconds` mirror the new production signatures. Default is fresh, so the existing integration suite is unchanged.

### Docs
`docs/safety.md` gains a **Sensor-staleness guard** section explaining the threshold (now configurable), the warning lifecycle, the deliberate scope (room sensors only), and a "UI surfacing" subsection covering all three places the guard is visible.

## Test plan

- [x] **HAClient unit tests** (9) — backward compat, fresh / stale / boundary / Zulu / missing-timestamp / `get_state_age_seconds` cases.
- [x] **Engine unit tests** (5) — `_get_avg_temp` excludes stale; returns `None` when all stale; warns exactly once per stale episode; recovery emits `info` and re-arms the warning; missing entities don't trigger spurious warnings.
- [x] **Backend integration tests** (5) — stale sensor doesn't poison the average; all-stale falls through to thermostat ambient; setting round-trips & validates; threshold change takes effect on next tick; `/api/sensor-health` lists stale sensors with the right shape.
- [x] **Frontend tests** (3) — Dashboard renders the banner when sensors are stale and hides it when fresh; Rooms shows the per-card badge with a tooltip; Settings renders and saves the threshold.
- [x] **606 backend tests pass** (coverage 94%, gate 90%); **149 frontend tests pass** (above all thresholds).
- [x] `ruff check`, `ruff format --check`, `mypy`, `tsc`, ESLint, Prettier all clean.

## Notes

- The "configurable threshold + UI" pass was added after the initial backend-only commit on reviewer feedback that a feature without UI is incomplete. The two commits on this branch (`40064a5` engine guard, `fcfc9da` UI + configurability) are kept separate so the engine change is independently reviewable.
- The outdoor sensor used by the cooling lockout is deliberately **not** gated by this staleness check — it serves analytics that tolerate slow updates (a weather entity may report hourly), and the lockout's existing fail-open behavior already covers a missing reading. Documented in `docs/safety.md`.

https://claude.ai/code/session_01FeWMqLrVNdSQH4ntAEc3Xx