### PR TITLE
Pin airflow-floor bypass invariants + surface idle-room deferral

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -862,6 +862,21 @@ class CycleEngine:
                     zone_room.name,
                     required,
                 )
+                if self._logger:
+                    await self._logger.log(
+                        "warning",
+                        "engine",
+                        f"Idle room {zone_room.name} vents kept open — closing them would drop "
+                        f"the zone below the airflow floor (requires {required} open). Add "
+                        f"more smart vents or lower the minimum-open fraction to allow closure.",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room": zone_room.name,
+                            "required_open_vents": required,
+                            "open_count": open_count,
+                            "would_close": would_close,
+                        },
+                    )
             if can_close:
                 for v in idle_vents:
                     try:

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -520,6 +520,11 @@ class CycleEngine:
             or new_active_map[rid].target_temp != self._active_rooms[rid].target_temp
         }
 
+        # Capture the prior room-vent map BEFORE overwriting it — the removed
+        # loop below needs the vent list for rooms that are no longer in
+        # ``new_active_map`` (otherwise ``self._room_vents.get(removed_id)``
+        # returns [] and the close path is silently a no-op).
+        prev_room_vents = self._room_vents
         self._active_rooms = new_active_map
         self._room_vents = new_room_vents
 
@@ -699,10 +704,17 @@ class CycleEngine:
             for room_id in removed:
                 # Close vents for removed rooms, respecting the airflow floor.
                 # Previously closed directly via ha.close_cover(), bypassing the
-                # VentController safety check (issue #26 Bug 3).
-                vents = self._room_vents.get(room_id, [])
+                # VentController safety check (issue #26 Bug 3).  ``vents``
+                # comes from the captured ``prev_room_vents`` because
+                # ``self._room_vents`` has already been overwritten with the
+                # new active set above (#210).
+                vents = prev_room_vents.get(room_id, [])
                 if vents:
-                    all_zone_vents_now = [v for vl in self._room_vents.values() for v in vl]
+                    # All vents still present on the zone: the (now removed)
+                    # room's vents PLUS the new active rooms' vents.  This is
+                    # what the airflow floor needs to compare against, not
+                    # just the new active set.
+                    all_zone_vents_now = [v for vl in self._room_vents.values() for v in vl] + vents
                     required = required_open_vents(tc, len(all_zone_vents_now))
                     open_count = self._vent._count_open_vents(all_zone_vents_now)
                     would_close = sum(1 for v in vents if self._vent._is_open(v.entity_id))
@@ -713,6 +725,22 @@ class CycleEngine:
                             room_id,
                             required,
                         )
+                        if self._logger:
+                            await self._logger.log(
+                                "warning",
+                                "engine",
+                                f"Removed room {room_id} vents kept open — closing them would "
+                                f"drop the zone below the airflow floor (requires {required} "
+                                "open). Add more smart vents or lower the minimum-open "
+                                "fraction to allow closure.",
+                                {
+                                    "thermostat": self.thermostat_entity_id,
+                                    "room_id": room_id,
+                                    "required_open_vents": required,
+                                    "open_count": open_count,
+                                    "would_close": would_close,
+                                },
+                            )
                     if can_close:
                         for v in vents:
                             try:

--- a/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
+++ b/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
@@ -1,0 +1,278 @@
+"""Airflow-floor bypass & whole-zone enforcement tests (Issue #210).
+
+Three protections cooperate to keep duct static pressure safe, and they
+interact subtly enough that the issue called for explicit coverage:
+
+  1. ``_monitor_rooms`` has a deliberate **last-vent bypass** — when the last
+     room needing to close would drop open vents below the airflow floor, the
+     engine closes it anyway because the cycle is about to terminate and the
+     terminate-reopen brings every zone vent back open.
+  2. ``_close_idle_room_vents`` and the ``_start_or_update_cycle`` removed-room
+     loop must respect the airflow floor across the **whole zone** (active +
+     idle), not just the rooms in the cycle.
+  3. After the bypass, ``_terminate_cycle`` must immediately reopen all zone
+     vents in the same tick — otherwise an all-vents-closed window with the
+     blower coasting on thermal lag would dead-head the system.
+
+Issue #213 consolidated the per-tick floor calculation into the shared
+``required_open_vents`` helper.  This file pins the engine-side invariants
+those callsites still owe.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _all_day_schedule(client, room_id: str, target: float) -> str:
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    resp = await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target,
+        },
+    )
+    sched_id: str = (await resp.json())["id"]
+    return sched_id
+
+
+async def _heating_room(
+    client,
+    fake_ha,
+    name: str,
+    sensor: str,
+    vent: str,
+    target: float | None,
+    room_temp: float,
+) -> str:
+    """Create a room with the given sensor + vent; schedule it if ``target`` set."""
+    fake_ha.seed_state(sensor, str(room_temp), {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(vent, "open", {})
+    resp = await client.post("/api/rooms", json={"name": name, "thermostat_entity_id": THERMO})
+    room_id: str = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": vent, "control_method": "open_close"},
+    )
+    if target is not None:
+        await _all_day_schedule(client, room_id, target)
+    return room_id
+
+
+def _seed_heating_thermostat(fake_ha, ambient: float = 65.0) -> None:
+    fake_ha.seed_state(
+        THERMO,
+        "heat",
+        {"current_temperature": ambient, "temperature": ambient, "hvac_action": "idle"},
+    )
+
+
+async def _warning_messages(client) -> list[str]:
+    events = await (await client.get("/api/logs/events?level=warning")).json()
+    return [e["message"] for e in events]
+
+
+async def _register_thermostat(client, **fields) -> None:
+    """Register THERMO with the given airflow config; total_vents_count required (#213)."""
+    body = {"thermostat_entity_id": THERMO, **fields}
+    body.setdefault("total_vents_count", 2)
+    resp = await client.post("/api/thermostats", json=body)
+    assert resp.status == 201, await resp.json()
+
+
+# ===========================================================================
+# Last-vent bypass — invariants the issue called out
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_last_vent_bypass_close_is_paired_with_immediate_reopen(
+    client, fake_ha, tick
+) -> None:
+    """The whole point of #210's concern: when the last vent is closed via the
+    airflow-floor bypass, the cycle terminates in the same tick and
+    ``_terminate_cycle`` re-opens all zone vents.  The vent must end up *open*,
+    even though it was momentarily closed."""
+    _seed_heating_thermostat(fake_ha)
+    # Floor = ceil(1 * 1.0) = 1 → with one smart vent, the close would be
+    # blocked except for the last-vent bypass.
+    await _register_thermostat(client, total_vents_count=1, min_open_vents_fraction=1.0)
+    await _heating_room(
+        client, fake_ha, "Bedroom", "sensor.bed", "cover.bed", target=68.0, room_temp=60.0
+    )
+
+    await tick()  # cycle starts; vent already open
+    assert len(await (await client.get("/api/logs")).json()) == 1
+
+    # Room reaches target — the engine wants to close its only vent. The
+    # airflow floor would block the close, but the last-vent bypass kicks in
+    # and the close happens anyway, immediately followed by the terminate
+    # re-opening all vents.
+    await fake_ha.set_entity_state("sensor.bed", "68.0", {"unit_of_measurement": "°F"})
+    await tick()
+
+    # close_cover *was* called (the bypass) AND open_cover *was* called (the
+    # terminate reopen).
+    close_calls = fake_ha.calls_for("close_cover")
+    open_calls = fake_ha.calls_for("open_cover")
+    assert any(c.data.get("entity_id") == "cover.bed" for c in close_calls), close_calls
+    assert any(c.data.get("entity_id") == "cover.bed" for c in open_calls), open_calls
+
+    # Final state: the vent is open. The bypass window must not be observable
+    # after the tick.
+    assert fake_ha.get_state("cover.bed")["state"] == "open"
+
+    # The cycle ended cleanly.
+    closed = (await (await client.get("/api/logs")).json())[0]
+    assert closed["ended_at"] is not None
+    assert closed["ended_reason"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_last_vent_bypass_emits_a_warning_so_it_is_auditable(client, fake_ha, tick) -> None:
+    """The bypass is a *deliberate* safety relaxation, so it must surface in
+    the event log — a technician reading the cycle's events should be able to
+    see it happened."""
+    _seed_heating_thermostat(fake_ha)
+    await _register_thermostat(client, total_vents_count=1, min_open_vents_fraction=1.0)
+    await _heating_room(
+        client, fake_ha, "Bedroom", "sensor.bed", "cover.bed", target=68.0, room_temp=60.0
+    )
+    await tick()
+    await fake_ha.set_entity_state("sensor.bed", "68.0", {"unit_of_measurement": "°F"})
+    await tick()
+
+    warnings = await _warning_messages(client)
+    assert any("bypassing the airflow floor" in m for m in warnings), warnings
+
+
+# ===========================================================================
+# Whole-zone airflow floor — _close_idle_room_vents must look at active + idle
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_idle_room_close_respects_floor_across_active_and_idle(client, fake_ha, tick) -> None:
+    """Two smart vents on the same thermostat. With total=2 and fraction=1.0
+    the floor is 2 open — there's no room to close anything. The idle room's
+    vent must not be closed at cycle start, because doing so would drop the
+    zone-wide open count below the floor."""
+    _seed_heating_thermostat(fake_ha)
+    # total=2 smart, fraction=1.0 → required=2 → no closes permitted while
+    # the cycle runs (the last-vent bypass only fires at terminate).
+    await _register_thermostat(client, total_vents_count=2, min_open_vents_fraction=1.0)
+
+    # Active room: cold, schedule active → joins the cycle.
+    await _heating_room(
+        client, fake_ha, "Active", "sensor.active", "cover.active", target=68.0, room_temp=60.0
+    )
+    # Idle room: no schedule, so it never joins. Its vent should be closed by
+    # _close_idle_room_vents at cycle start — but the floor forbids it.
+    await _heating_room(
+        client, fake_ha, "Idle", "sensor.idle", "cover.idle", target=None, room_temp=72.0
+    )
+
+    await tick()
+
+    # The active room's vent is open; the idle room's vent stays open because
+    # closing it would violate the floor.
+    assert fake_ha.get_state("cover.active")["state"] == "open"
+    assert fake_ha.get_state("cover.idle")["state"] == "open", (
+        "idle vent must stay open — closing it would drop zone-wide below the floor"
+    )
+    # Nothing was issued to the idle vent at all.
+    close_calls = fake_ha.calls_for("close_cover")
+    assert not any(c.data.get("entity_id") == "cover.idle" for c in close_calls), close_calls
+
+    # The deferral is logged for the operator — both in the engine's python
+    # log (technician console) and as a warning event in the UI Live Feed.
+    warnings = await _warning_messages(client)
+    assert any("airflow floor" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_idle_room_close_proceeds_when_passive_vents_satisfy_the_floor(
+    client, fake_ha, tick
+) -> None:
+    """Mirror of the above: total_vents_count=12 with 2 smart vents leaves 10
+    passive registers always open. The airflow floor is satisfied by the
+    passive vents alone, so the idle-room close is allowed."""
+    _seed_heating_thermostat(fake_ha)
+    # ceil(12 * 1/3) - (12 - 2) = 4 - 10 → clamped to 0. Idle close is fine.
+    await _register_thermostat(client, total_vents_count=12, min_open_vents_fraction=1.0 / 3.0)
+
+    await _heating_room(
+        client, fake_ha, "Active", "sensor.active", "cover.active", target=68.0, room_temp=60.0
+    )
+    await _heating_room(
+        client, fake_ha, "Idle", "sensor.idle", "cover.idle", target=None, room_temp=72.0
+    )
+
+    await tick()
+
+    assert fake_ha.get_state("cover.active")["state"] == "open"
+    assert fake_ha.get_state("cover.idle")["state"] == "closed", (
+        "idle vent should close when passive vents already satisfy the floor"
+    )
+
+
+# ===========================================================================
+# Stability — the brief bypass window must not produce phantom activity on
+# the next tick (the "reconciler does not fight the engine" guard)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_post_bypass_tick_is_quiet(client, fake_ha, tick) -> None:
+    """Once the bypass-close + terminate-reopen sequence has run, the next
+    tick must not produce any new vent or setpoint commands. This guards
+    against the reconciler (or any other late observer) seeing the brief
+    closed-vent state and fighting the engine."""
+    _seed_heating_thermostat(fake_ha)
+    await _register_thermostat(
+        client,
+        total_vents_count=1,
+        min_open_vents_fraction=1.0,
+        reconciliation_interval_min=1,
+    )
+    await _heating_room(
+        client, fake_ha, "Bedroom", "sensor.bed", "cover.bed", target=68.0, room_temp=60.0
+    )
+
+    await tick()
+    await fake_ha.set_entity_state("sensor.bed", "68.0", {"unit_of_measurement": "°F"})
+    await tick()  # bypass-close + terminate-reopen
+
+    # Reset the call recorder, then tick again. The engine is IDLE; the
+    # reconciler runs but finds nothing to do.
+    fake_ha.reset_calls()
+    # Force a reconcile on the next tick by clearing the last-run timestamp.
+    engine = client.app["scheduler"]._engines[THERMO]
+    engine._last_reconciled_at = None
+
+    await tick()
+
+    # No further vent commands — the bypass closed-vent state must not be
+    # observed by anything that would try to re-open or re-close it.  Setpoint
+    # writes are allowed: the engine idempotently re-asserts ambient while
+    # IDLE, which keeps the thermostat aligned but does not fight the bypass.
+    assert fake_ha.calls_for("close_cover") == [], fake_ha.calls_for("close_cover")
+    assert fake_ha.calls_for("open_cover") == [], fake_ha.calls_for("open_cover")
+    # And the engine is still settled.
+    assert engine.cycle_state.value == "idle"
+    assert fake_ha.get_state("cover.bed")["state"] == "open"

--- a/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
+++ b/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
@@ -232,6 +232,88 @@ async def test_idle_room_close_proceeds_when_passive_vents_satisfy_the_floor(
 
 
 # ===========================================================================
+# Removed-room close path — the mid-cycle ``removed`` loop in
+# ``_start_or_update_cycle`` must respect the airflow floor too.  Issue #210
+# explicitly asked for both _close_idle_room_vents AND this path to be tested.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_removed_room_close_uses_airflow_floor(client, fake_ha, tick) -> None:
+    """A room that becomes inactive mid-cycle should have its vents closed —
+    when the floor permits it. ``total=12 / fraction=1/3`` means the airflow
+    floor is already carried by the 10 passive registers, so the engine is
+    free to close the deactivated room's smart vent."""
+    _seed_heating_thermostat(fake_ha)
+    await _register_thermostat(client, total_vents_count=12, min_open_vents_fraction=1.0 / 3.0)
+
+    # Both rooms scheduled → both active when the cycle starts.
+    room_a = await _heating_room(
+        client, fake_ha, "RoomA", "sensor.a", "cover.a", target=68.0, room_temp=60.0
+    )
+    room_b = await _heating_room(
+        client, fake_ha, "RoomB", "sensor.b", "cover.b", target=68.0, room_temp=60.0
+    )
+    # Capture RoomB's schedule id for deletion below.
+    schedules_b = await (await client.get(f"/api/rooms/{room_b}/schedules")).json()
+    sched_b = schedules_b[0]["id"]
+
+    await tick()
+    # Both vents open, cycle running.
+    assert fake_ha.get_state("cover.a")["state"] == "open"
+    assert fake_ha.get_state("cover.b")["state"] == "open"
+
+    # Deactivate RoomB by removing its schedule. The next tick should remove
+    # it from the active set and close its vent (required=0).
+    await client.delete(f"/api/rooms/{room_b}/schedules/{sched_b}")
+    await tick()
+
+    # RoomA's vent stays open (still active). RoomB's vent must close because
+    # the airflow floor permits it.
+    assert fake_ha.get_state("cover.a")["state"] == "open"
+    assert fake_ha.get_state("cover.b")["state"] == "closed", (
+        "removed room's vent should close — passive vents carry the airflow floor"
+    )
+    # Quiet assertion against the silent-no-op bug: a close was actually issued.
+    close_calls = fake_ha.calls_for("close_cover")
+    assert any(c.data.get("entity_id") == "cover.b" for c in close_calls), close_calls
+    # Sanity: RoomA is still in the active set.
+    _ = room_a  # keep helper return for readability
+
+
+@pytest.mark.asyncio
+async def test_removed_room_close_deferred_when_would_drop_below_floor(
+    client, fake_ha, tick
+) -> None:
+    """Mirror of the above: when the floor *would* be violated by closing the
+    deactivated room's vents, the close is deferred and the vent stays open."""
+    _seed_heating_thermostat(fake_ha)
+    # 2 smart vents, fraction=1.0 → required=2.  Closing the removed room's
+    # vent would leave only 1 open → below the floor.
+    await _register_thermostat(client, total_vents_count=2, min_open_vents_fraction=1.0)
+
+    await _heating_room(
+        client, fake_ha, "RoomA", "sensor.a", "cover.a", target=68.0, room_temp=60.0
+    )
+    room_b = await _heating_room(
+        client, fake_ha, "RoomB", "sensor.b", "cover.b", target=68.0, room_temp=60.0
+    )
+    schedules_b = await (await client.get(f"/api/rooms/{room_b}/schedules")).json()
+    sched_b = schedules_b[0]["id"]
+
+    await tick()
+    assert fake_ha.get_state("cover.b")["state"] == "open"
+
+    await client.delete(f"/api/rooms/{room_b}/schedules/{sched_b}")
+    await tick()
+
+    # RoomB's vent stays open because the floor blocks the close.
+    assert fake_ha.get_state("cover.b")["state"] == "open"
+    close_calls = fake_ha.calls_for("close_cover")
+    assert not any(c.data.get("entity_id") == "cover.b" for c in close_calls), close_calls
+
+
+# ===========================================================================
 # Stability — the brief bypass window must not produce phantom activity on
 # the next tick (the "reconciler does not fight the engine" guard)
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes #210. Pins the engine-side invariants around the airflow floor's last-vent bypass, the whole-zone enforcement in both idle- and removed-room close paths, and the stability guarantee that the brief bypass window doesn't trigger phantom activity.

Audit-during-implementation surfaced **a real bug**: the removed-room close path was a silent no-op (see below).

## What's tested

Seven integration tests in `test_airflow_floor_bypass.py`:

- **Last-vent bypass** (×2) — single smart vent / fraction 1.0 → required 1. Room reaches target, the floor would block the close, the last-vent bypass closes it anyway, `_terminate_cycle` re-opens it in the same tick. The vent ends *open*; the bypass surfaces as a warning event in the UI Live Feed.
- **`_close_idle_room_vents` whole-zone enforcement** (×2) — deferred-close when the floor forbids it (total=2 / fraction=1.0 → required=2) and proceeds-close when passive vents carry the floor (total=12 / smart=2 / fraction=1/3 → required=0).
- **`_start_or_update_cycle` removed-room close path** (×2 — new in commit 2) — the parallel path the issue explicitly asked for. Same matrix as idle-room: close fires when the floor permits it, deferred otherwise.
- **Post-bypass quiet tick** (×1) — the engine doesn't fight itself across the brief closed-vent window (no `open_cover` / `close_cover` issued by the reconciler).

## Real bug surfaced

While writing the removed-room test the issue called out, I found that `_start_or_update_cycle`'s removed-room close loop was reading `self._room_vents.get(removed_id, [])` — but `self._room_vents` had already been overwritten with the **new** active set on the lines above. The get returned `[]` for any room that had just left the active set, and the entire close path was a silent no-op. A room removed mid-cycle would keep its vents OPEN forever, regardless of the airflow floor.

The existing `test_room_removed_mid_cycle_continues_without_teardown` (added in the #215 work) never caught it because it only asserted the cycle stays running — it didn't check the removed room's vent state.

Fix: capture `prev_room_vents = self._room_vents` before the reassignment and pass it to the removed loop. The zone view used for the airflow-floor calculation is now (active vents) + (removed-room vents), which is what was always intended. The can't-close path also gains a `warning` event so the deferral appears in the UI Live Feed.

## Cross-PR audit (per your follow-up)

Validated that the work this PR builds on from #213 (PR #226) is actually used:

- ✅ **`total_vents_count` / `has_bypass_damper` / `min_open_vents_fraction`** config fields — every test configures them via the POST `/api/thermostats` validation that #213 added.
- ✅ **`required_open_vents` helper** — exercised through all three callsites (`close_room_vents`, `_close_idle_room_vents`, `_monitor_rooms` last-vent bypass, plus the now-fixed removed loop).
- ✅ **"airflow floor" vocabulary** — kept consistent in test names, assertions, and the new event-log messages.
- ✅ **Companion `_close_idle_room_vents` warning event** — added in the first commit to match what was already present in `close_room_vents`. The removed-room loop's warning event (commit 2) follows the same pattern.
- ➖ **`Alert` component** — not used. The new warnings surface as `warning`-level entries in the existing event-log feed (Logs page → Live Feed), which is the same channel as every other engine-side warning. A standing Dashboard Alert for "airflow floor is restricting closures" would be enhancement, not gap.

## Test plan

- [x] **637 backend tests pass**, coverage 91.80 % ≥ 91 gate (CI-style run from `smart_vent/`).
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] No frontend / docs changes needed — engine surfaces in the existing event feed.

Closes out the entire safety-cluster (#208 / #209 / #210 / #211 / #212 / #213 / #215).

https://claude.ai/code/session_01FeWMqLrVNdSQH4ntAEc3Xx