### PR TITLE
Fix #231: frontend sends display-unit temperatures; backend converts

### DIFF
--- a/.github/workflows/codeql-issue-sync.yml
+++ b/.github/workflows/codeql-issue-sync.yml
@@ -14,7 +14,7 @@ jobs:
       security-events: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create issues for open CodeQL alerts
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Building release image version: ${VERSION}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -75,7 +75,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push release image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./smart_vent
           platforms: linux/amd64,linux/arm64
@@ -146,13 +146,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Build image (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./smart_vent
           platforms: linux/amd64,linux/arm64
@@ -221,7 +221,7 @@ jobs:
         if: |
           steps.branch-check.outputs.is_release_merge == 'false' &&
           steps.config-check.outputs.config_changed == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         if: |
@@ -243,7 +243,7 @@ jobs:
         if: |
           steps.branch-check.outputs.is_release_merge == 'false' &&
           steps.config-check.outputs.config_changed == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./smart_vent
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/e2e-conversion.yml
+++ b/.github/workflows/e2e-conversion.yml
@@ -1,0 +1,117 @@
+name: E2E temperature conversion (F / C)
+
+# Matrix-runs the new temperature-units.spec.ts under both °F and °C stacks so
+# any future double-conversion regression (or single-conversion drift) is
+# caught end-to-end. Each leg spins up Home Assistant + Plenum in Docker
+# Compose; the °C leg layers docker-compose.test.celsius.yml on top to set
+# TEMPERATURE_UNIT=C.
+#
+# Kept separate from .github/workflows/e2e.yml (visual regression, manual
+# trigger only) because the conversion tests are pure-behavior assertions
+# with no screenshots — safe to run on every PR.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  conversion:
+    name: Round-trip (${{ matrix.unit }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        unit: [F, C]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Pin addon version for deterministic UI
+        run: sed -i 's/^version:.*/version: CI/' smart_vent/config.yaml
+
+      - name: Build Plenum image
+        run: docker build -t plenum-e2e ./smart_vent
+
+      - name: Compose file list
+        id: compose
+        run: |
+          if [ "${{ matrix.unit }}" = "C" ]; then
+            echo "files=-f docker-compose.test.yml -f docker-compose.test.celsius.yml" >> "$GITHUB_OUTPUT"
+          else
+            echo "files=-f docker-compose.test.yml" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Start Home Assistant (wait for healthy)
+        run: docker compose ${{ steps.compose.outputs.files }} up --wait homeassistant
+        timeout-minutes: 10
+
+      - name: Create HA token
+        run: |
+          pip install requests websocket-client --quiet
+          python3 e2e/scripts/setup-ha.py \
+            --ha-url http://localhost:8123 \
+            --output /tmp/ha_token.txt
+
+      - name: Start Plenum
+        run: |
+          HA_TOKEN=$(cat /tmp/ha_token.txt) \
+          docker compose ${{ steps.compose.outputs.files }} up -d plenum
+
+      - name: Wait for Plenum health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8099/api/healthz -o /dev/null; then
+              echo "Plenum is healthy."
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "ERROR: Plenum did not become healthy within 90s" >&2
+          docker compose ${{ steps.compose.outputs.files }} logs plenum >&2
+          exit 1
+
+      - name: Verify active temperature unit matches matrix
+        run: |
+          UNIT=$(curl -sf http://localhost:8099/api/settings | python3 -c \
+            'import json,sys; print(json.load(sys.stdin).get("temperature_unit","?"))')
+          echo "Plenum reports temperature_unit=${UNIT}"
+          if [ "${UNIT}" != "${{ matrix.unit }}" ]; then
+            echo "ERROR: expected ${{ matrix.unit }}, got ${UNIT}" >&2
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: e2e/package.json
+
+      - name: Install Playwright
+        working-directory: e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run temperature round-trip tests
+        working-directory: e2e
+        env:
+          PLENUM_URL: "http://localhost:8099"
+          PLENUM_TEMP_UNIT: ${{ matrix.unit }}
+        run: npx playwright test temperature-units.spec.ts
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results-${{ matrix.unit }}
+          path: e2e/test-results/
+          retention-days: 14
+
+      - name: Tear down
+        if: always()
+        run: docker compose ${{ steps.compose.outputs.files }} down -v

--- a/.github/workflows/e2e-conversion.yml
+++ b/.github/workflows/e2e-conversion.yml
@@ -31,10 +31,10 @@ jobs:
         unit: [F, C]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Pin addon version for deterministic UI
         run: |
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/e2e-conversion.yml
+++ b/.github/workflows/e2e-conversion.yml
@@ -14,6 +14,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Read-only — the conversion suite never pushes, never opens PRs, and never
+# updates goldens (that's e2e.yml's job). Explicit block silences the
+# CodeQL "workflow does not contain permissions" warning.
+permissions:
+  contents: read
+
 jobs:
   conversion:
     name: Round-trip (${{ matrix.unit }})
@@ -103,7 +109,10 @@ jobs:
         env:
           PLENUM_URL: "http://localhost:8099"
           PLENUM_TEMP_UNIT: ${{ matrix.unit }}
-        run: npx playwright test temperature-units.spec.ts
+        # --project=chromium constrains to one browser project — the
+        # playwright config also defines a "mobile" project for the
+        # visual-regression suite, which we don't need to double-run here.
+        run: npx playwright test temperature-units.spec.ts --project=chromium
 
       - name: Upload test results on failure
         if: failure()

--- a/.github/workflows/e2e-conversion.yml
+++ b/.github/workflows/e2e-conversion.yml
@@ -31,7 +31,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Pin addon version for deterministic UI
-        run: sed -i 's/^version:.*/version: CI/' smart_vent/config.yaml
+        run: |
+          sed -i 's/^version:.*/version: CI/' smart_vent/config.yaml
 
       - name: Build Plenum image
         run: docker build -t plenum-e2e ./smart_vent

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch with a token so the bot can push back to the branch.
           # GITHUB_TOKEN is sufficient for same-repo branches; forks will
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set version to CI for stable screenshots
         run: |
@@ -71,7 +71,7 @@ jobs:
           exit 1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,37 @@ smart_vent/
 ## Temperature unit system (Issue #123)
 
 ### Core invariant
-**All temperatures are stored in °F** in SQLite and passed through the system as °F.
-Conversion happens only at two boundaries:
-- **API write boundary** (incoming): user input → °F for storage
-- **Frontend display** (outgoing): °F from API → display unit for rendering
+**All temperatures are stored in °F** in SQLite and passed through the engine, scheduler, and WebSocket events as °F. **Only the backend write boundary and the frontend display layer touch unit conversion** — no other code path converts temperatures.
+
+```
+                user types "16" (°C)
+                       │
+                       ▼
+   ┌──────────────────────────────────────────┐
+   │  Frontend form state — holds DISPLAY     │
+   │  units (°C or °F as the user types).     │
+   │  Sends the raw display value as-is.      │
+   └──────────────────────────────────────────┘
+                       │
+                       │  POST { min_setpoint: 16 }
+                       ▼
+   ┌──────────────────────────────────────────┐
+   │  Backend API write boundary —             │
+   │  `_to_f(16, "C")` → 60.8°F before storage.│
+   └──────────────────────────────────────────┘
+                       │
+                       ▼
+                  DB stores 60.8°F
+                       │
+                       │  GET returns 60.8 (always °F)
+                       ▼
+   ┌──────────────────────────────────────────┐
+   │  Frontend display — `toDisplay(60.8)` →  │
+   │  16°C for rendering; form-init only.     │
+   └──────────────────────────────────────────┘
+```
+
+**The frontend MUST NOT call `toStorage` / `toStorageDelta` on outgoing payloads.** That was the #231 double-conversion bug: the frontend converted °C → °F via `toStorage`, *and* the backend's `_to_f` converted again, so 16 °C arrived at the DB as 141.44 °F. The conversion belongs to exactly one side — and per the contract above, that side is the backend.
 
 ### Backend helpers (`backend/api/routes.py`)
 
@@ -50,7 +77,7 @@ _from_f(value, unit)      # °F → display unit (1dp), None → ""  [CSV export
 ```
 
 **Every POST/PUT/PATCH endpoint** that accepts a temperature field must call one of these.
-Fields that use `_to_f`: `target_temp`, `system_wide_temp`, `default_temp`, `min_setpoint`, `max_setpoint`
+Fields that use `_to_f`: `target_temp`, `system_wide_temp`, `default_temp`, `min_setpoint`, `max_setpoint`, `cooling_lockout_below_f`
 Fields that use `_delta_to_f`: `temp_offset`, `deadband`, `overshoot_delta`
 
 The active unit comes from `request.app["scheduler"].get_temperature_unit()` (returns `"F"` or `"C"`).
@@ -69,21 +96,34 @@ useUnit()                // hook — reads UnitContext
 // UnitContextValue members:
 toDisplay(fahrenheit)         // absolute °F → display unit (1dp float)
 toDisplayDelta(fahrenheitDelta) // delta °F → display unit (2dp float, NO -32)
-toStorage(displayValue)       // display unit → °F (2dp float)
-toStorageDelta(displayDelta)  // display unit delta → °F (2dp float)
 fmtTemp(fahrenheit)           // formatted string e.g. "21.1°C"
 unitLabel                     // "°F" | "°C"
 unit                          // "F" | "C"
 isCelsius                     // boolean
+
+// Inverse helpers — defined but NOT used on outgoing payloads. Reserved for
+// validation bounds (`toStorage(40)` to compute a °F min) and the rare case
+// where display→storage is needed locally. NEVER call these on form values
+// you are about to POST/PUT — that re-introduces the #231 double-conversion.
+toStorage(displayValue)       // display unit → °F (2dp float)
+toStorageDelta(displayDelta)  // display unit delta → °F (2dp float)
 ```
 
 **Absolute vs delta**: absolute uses `(f-32)*5/9`; delta uses only `f*5/9` (no offset).
 This matters for deadband, overshoot_delta, temp_offset.
 
+### Frontend form contract (post-#231)
+Forms that submit temperature fields (Thermostats, Rooms, Schedules) store **display-unit** values in their state.
+- **On init**: convert °F values returned from the API via `toDisplay` / `toDisplayDelta`.
+- **On change**: store the raw `parseFloat(e.target.value)` — no conversion.
+- **On submit**: send the display value as-is. The backend's `_to_f` / `_delta_to_f` converts at the write boundary.
+- **For display in the same form** (e.g. vacation help text echoing `form.min_setpoint`): the value is already display — render directly, do not re-call `toDisplay`.
+
+Validation bounds that are naturally expressed in °F (e.g. "must be between 40 °F and 90 °F") can use `toDisplay(40)` / `toDisplay(90)` to convert the bound into display units for comparison with the form value. That use of `toDisplay` is fine; it has nothing to do with outgoing payloads.
+
 ### SAFETY_FIELDS pattern (Thermostats.tsx)
 Each field entry has a `kind: "absolute_temp" | "delta_temp" | "other"`.
-The render loop uses `kind` to pick the right conversion function.
-Labels get `(${unitLabel})` appended only for temp fields.
+The render loop uses `kind` to drive the label suffix (`(${unitLabel})` appended only for temp fields). Form values are already display units, so the render reads them directly — no per-field conversion on the read or write side.
 
 ### Unit detection flow
 1. `TEMPERATURE_UNIT` env var (from `run.sh` / `config.yaml`) — highest priority
@@ -123,12 +163,18 @@ Coverage threshold: **90%** (`pyproject.toml` `fail_under = 90`).
 cd smart_vent/frontend && npx vitest run
 npx vitest run --coverage   # also checks thresholds
 ```
-Coverage thresholds (in `vite.config.ts`): lines 79, functions 71, branches 77, statements 79.
+Coverage thresholds (in `vite.config.ts`): lines 80.9, functions 71.1, branches 77.1, statements 80.9.
 
 **Test patterns:**
 - Celsius mode: wrap with `<UnitContext.Provider value={buildUnitContext("C")}>`
 - System context: wrap with `<SystemContext.Provider value={mockSystem}>`
 - Mocks: `vi.mock("../api")` at module level, `vi.mocked(api.fn).mockResolvedValue(...)` per test
+- **Temp-write assertion (#231)**: in Celsius mode, assert the POST/PUT body contains the user's **raw display value** (e.g. `min_setpoint: 16`), NOT the pre-converted °F. The backend converts; the frontend must not.
+
+### E2E round-trip (`e2e/tests/temperature-units.spec.ts`)
+Matrix-runs against both °F and °C stacks via `.github/workflows/e2e-conversion.yml`. Each test edits a temperature field through the UI, reloads, and asserts the field shows exactly the value the user typed. This is the only place the full conversion contract is exercised end-to-end, and would have caught the #231 double-conversion bug — neither side's unit tests did.
+- °C run uses `docker-compose.test.celsius.yml` as an override on top of `docker-compose.test.yml` to set `TEMPERATURE_UNIT=C`.
+- `PLENUM_TEMP_UNIT` env var tells the spec which unit the stack is in so the assertion values are scaled accordingly.
 
 ### Config parity test
 `tests/test_addon_config.py` — asserts every key in `config.yaml`'s `options:` block
@@ -158,15 +204,16 @@ PyYAML is NOT installed in CI.
 - **Scheduler**: Owns `_active_unit`. The engine and routes both read the unit through the scheduler, not directly from DB.
 - **WebSocket**: `ws_handler.py` broadcasts zone status events. Temperatures in these events are raw °F — the frontend converts for display.
 - **CSV export**: `/api/metrics/export.csv` uses `_from_f()` and labels headers with the active unit, e.g. `outside_temp_at_start (°C)`.
-- **Frontend form state**: Thermostat forms store values internally as °F. Inputs display via `toDisplay`/`toDisplayDelta`, `onChange` converts back via `toStorage`/`toStorageDelta`. The form's `°F` state is sent to the backend as-is (no double conversion).
+- **Frontend form state**: Thermostat/Room/Schedule forms store values in **display units** (°C or °F as the user sees them). Initialize from API responses via `toDisplay` / `toDisplayDelta`; submit the raw value. See the "Frontend form contract" section above and `Thermostats.tsx` / `Rooms.tsx` / `Schedules.tsx` for the canonical implementation. **Never** call `toStorage` / `toStorageDelta` on outgoing payloads — that re-introduces the #231 double-conversion.
 
 ---
 
 ## Common pitfalls
 
-1. **New temperature field in a write endpoint** — add `_to_f()` / `_delta_to_f()` call; add `TestToF`-style unit test; add Celsius-mode integration test.
+1. **New temperature field in a write endpoint** — add `_to_f()` / `_delta_to_f()` call; add a `TestToF`-style unit test; add a Celsius-mode integration test that POSTs the field with a °C value and asserts the stored °F. Add the field to the matching frontend form and **send the raw display value** — do not call `toStorage` / `toStorageDelta` on the outgoing payload (see #231).
 2. **New option in `config.yaml`** — also add `bashio::config` read and `export` in `run.sh` (enforced by `test_addon_config.py`).
 3. **Displaying a temperature from entity state** — `EntityState.numeric` is always °F (backend normalises). Use `fmtTemp()`, not `${value}${unitLabel}`.
-4. **Delta fields** — use `toDisplayDelta`/`toStorageDelta`, not `toDisplay`/`toStorage`. Using the wrong one adds/subtracts 32.
+4. **Delta fields** — use `toDisplayDelta` (read) for delta fields like deadband / overshoot_delta / temp_offset. Using `toDisplay` (absolute) on a delta would subtract 32 °F and silently corrupt the displayed value.
 5. **New pip dependency in a test** — also add it to the `pip install` line in `.github/workflows/lint.yml`.
 6. **ruff format** — run `ruff format backend/` before committing Python; the CI checks formatting separately from linting.
+7. **Adding a frontend temperature write path** — extend `e2e/tests/temperature-units.spec.ts` with a round-trip on the new field. The matrix run under both °F and °C is the only guard against the kind of double-conversion bug that escapes per-side unit tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,21 @@ Matrix-runs against both °F and °C stacks via `.github/workflows/e2e-conversio
 - °C run uses `docker-compose.test.celsius.yml` as an override on top of `docker-compose.test.yml` to set `TEMPERATURE_UNIT=C`.
 - `PLENUM_TEMP_UNIT` env var tells the spec which unit the stack is in so the assertion values are scaled accordingly.
 
+### Temperature field registry (parity-enforced)
+Every temperature field on a write boundary is registered in two manifests kept in lockstep:
+- **Python**: `TEMPERATURE_FIELDS` dict in `smart_vent/backend/api/routes.py` (`field` → `kind`).
+- **TypeScript**: `TEMPERATURE_FIELDS` array in `e2e/tests/temperature-fields.ts` (`field`, `kind`, `ui`, `endpoints`).
+
+Each test in `temperature-units.spec.ts` tags itself with `// @covers: <field>[, <field>...]`.
+
+`smart_vent/backend/tests/test_temperature_field_parity.py` enforces:
+1. The Python and TS field sets match (no field on one side only).
+2. The `kind` agrees between Python and TS for each shared field (mismatched `_to_f` vs `_delta_to_f` silently corrupts data).
+3. Every TS entry with `ui: true` has a `// @covers:` tag in the spec.
+4. No `// @covers:` tag references an unknown field.
+
+Adding a temperature field anywhere on a write boundary therefore requires touching all three files. CI fails loudly otherwise — the exact class of bug #231 was.
+
 ### Config parity test
 `tests/test_addon_config.py` — asserts every key in `config.yaml`'s `options:` block
 has a `bashio::config '<key>'` call in `run.sh`. Add new options to **both** files.
@@ -216,4 +231,4 @@ PyYAML is NOT installed in CI.
 4. **Delta fields** — use `toDisplayDelta` (read) for delta fields like deadband / overshoot_delta / temp_offset. Using `toDisplay` (absolute) on a delta would subtract 32 °F and silently corrupt the displayed value.
 5. **New pip dependency in a test** — also add it to the `pip install` line in `.github/workflows/lint.yml`.
 6. **ruff format** — run `ruff format backend/` before committing Python; the CI checks formatting separately from linting.
-7. **Adding a frontend temperature write path** — extend `e2e/tests/temperature-units.spec.ts` with a round-trip on the new field. The matrix run under both °F and °C is the only guard against the kind of double-conversion bug that escapes per-side unit tests.
+7. **Adding a frontend temperature write path** — register the new field in **both** manifests (`TEMPERATURE_FIELDS` in `routes.py` AND `temperature-fields.ts`), then extend `temperature-units.spec.ts` with a round-trip carrying a `// @covers: <field>` marker. The parity test (`test_temperature_field_parity.py`) fails CI if any of the three are out of sync — the matrix run under both °F and °C is the only end-to-end guard against the kind of double-conversion bug that escapes per-side unit tests.

--- a/docker-compose.test.celsius.yml
+++ b/docker-compose.test.celsius.yml
@@ -1,0 +1,19 @@
+# Compose override that runs Plenum in Celsius display mode.
+#
+# Used by the E2E temperature-conversion matrix to exercise the same round-trip
+# under °C as it does under °F, so the double-conversion bug fixed in #231 (and
+# any future regression) is caught end-to-end.
+#
+# Layered on top of docker-compose.test.yml:
+#   docker compose -f docker-compose.test.yml -f docker-compose.test.celsius.yml up
+#
+# Plenum's unit-detection priority is: env var > HA /api/config > DB last-known.
+# Overriding TEMPERATURE_UNIT here puts Plenum into °C mode regardless of what
+# Home Assistant reports — the HA fixture sensors stay in °F (their stored unit),
+# which exercises the °C-display-with-°F-sensor path that real users on metric
+# locales typically run.
+
+services:
+  plenum:
+    environment:
+      TEMPERATURE_UNIT: "C"

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -138,6 +138,10 @@ async function setupViaUI(): Promise<void> {
       await page.locator(".modal .entity-option").filter({ hasText: tc.entityId }).click();
 
       await page.locator("#add-thermo-name").fill(tc.name);
+      // Airflow-floor (#213): total vent count is required at registration.
+      // Use a constant — the value only matters for engine behaviour, not
+      // for the round-trip / golden screenshots these e2e tests exist for.
+      await page.locator("#add-thermo-total-vents").fill("8");
       await page.getByRole("button", { name: "Register", exact: true }).click();
       await page.waitForSelector(".modal", { state: "detached" });
     }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -128,11 +128,14 @@ async function setupViaUI(): Promise<void> {
       await page.waitForSelector(".modal");
 
       // Type the short name to narrow the EntityPicker dropdown.
+      // Scope to the modal — the Thermostats page itself now mounts an
+      // EntityPicker via OutsideTempPicker, so `.entity-picker input`
+      // alone is ambiguous (strict-mode violation in Playwright).
       const search = tc.entityId.split(".")[1].split("_")[0]; // "downstairs"|"upstairs"
-      await page.locator(".entity-picker input").fill(search);
+      await page.locator(".modal .entity-picker input").fill(search);
       // Dropdown requires a live HA connection; this will time out without Docker
-      await page.waitForSelector(".entity-dropdown", { timeout: 20_000 });
-      await page.locator(".entity-option").filter({ hasText: tc.entityId }).click();
+      await page.waitForSelector(".modal .entity-dropdown", { timeout: 20_000 });
+      await page.locator(".modal .entity-option").filter({ hasText: tc.entityId }).click();
 
       await page.locator("#add-thermo-name").fill(tc.name);
       await page.getByRole("button", { name: "Register", exact: true }).click();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -64,6 +64,26 @@ async function haIsReachable(): Promise<boolean> {
   }
 }
 
+/**
+ * Pick a schedule target temperature in the active display unit (#231).
+ *
+ * The schedules POST endpoint converts the value via `_to_f(value, unit)` —
+ * so a hard-coded 72.0 means "72°F" under `TEMPERATURE_UNIT=F` and "72°C"
+ * under `TEMPERATURE_UNIT=C`. 72°C trips the 4.4–32.2°C valid-range check
+ * (400). Return 72 under °F and 22 under °C — both ~71.6°F stored, both
+ * comfortable, both well inside the valid range.
+ */
+async function scheduleTargetTemp(): Promise<number> {
+  try {
+    const res = await fetch(`${API}/settings`);
+    if (!res.ok) return 72.0;
+    const data: { temperature_unit?: string } = await res.json();
+    return data.temperature_unit === "C" ? 22.0 : 72.0;
+  } catch {
+    return 72.0;
+  }
+}
+
 const THERMOSTATS = [
   { entityId: "climate.downstairs_thermostat", name: "Downstairs Thermostat" },
   { entityId: "climate.upstairs_thermostat", name: "Upstairs Thermostat" },
@@ -203,7 +223,7 @@ async function setupViaUI(): Promise<void> {
         days_of_week: [0, 1, 2, 3, 4],
         start_time: "08:00",
         end_time: "17:00",
-        target_temp: 72.0,
+        target_temp: await scheduleTargetTemp(),
       });
     }
   } finally {
@@ -248,7 +268,7 @@ async function setupViaREST(): Promise<void> {
         days_of_week: [0, 1, 2, 3, 4],
         start_time: "08:00",
         end_time: "17:00",
-        target_temp: 72.0,
+        target_temp: await scheduleTargetTemp(),
       });
     }
   }

--- a/e2e/tests/temperature-fields.ts
+++ b/e2e/tests/temperature-fields.ts
@@ -1,0 +1,110 @@
+/**
+ * Single source of truth for every temperature field that any Plenum
+ * write endpoint accepts.
+ *
+ * Two enforcement mechanisms keep this list honest:
+ *
+ *  1. `temperature-units.spec.ts` exercises a round-trip in both °F
+ *     and °C for each entry with `ui: true`. Each test tags itself
+ *     with `// @covers: <field>[, <field>...]` so the parity test
+ *     below can verify coverage by grep.
+ *
+ *  2. `smart_vent/backend/tests/test_temperature_field_parity.py`
+ *     compares this manifest to `TEMPERATURE_FIELDS` in
+ *     `smart_vent/backend/api/routes.py` (both the field set and
+ *     the kind for each), and asserts every `ui: true` entry has at
+ *     least one `@covers:` mention in the e2e spec.
+ *
+ * Adding a new temperature field anywhere on a write boundary?
+ * - Add the entry here AND in `routes.py`'s `TEMPERATURE_FIELDS` dict.
+ * - If a UI page writes it, set `ui: true` and add a `@covers:` line
+ *   to the matching test in `temperature-units.spec.ts`.
+ *
+ * The parity test fails CI loudly if any of these go out of sync.
+ */
+
+/** Conversion kind — drives `_to_f` vs `_delta_to_f` on the backend
+ * and whether `null` is accepted as a value. */
+export type TempKind = "absolute" | "absolute_nullable" | "delta";
+
+export interface TempField {
+  /** Body key exactly as it appears on the wire. */
+  field: string;
+  /** Conversion kind — must match `routes.py` `TEMPERATURE_FIELDS`. */
+  kind: TempKind;
+  /** Has at least one UI write path. If true, the e2e spec must
+   * cover this field via a `// @covers:` marker. API-only fields
+   * (e.g. `target_temp` on `/override`) set `ui: false`. */
+  ui: boolean;
+  /** Human-readable endpoints the field reaches. Documentation only —
+   * not used in parity enforcement. */
+  endpoints: string[];
+}
+
+export const TEMPERATURE_FIELDS: TempField[] = [
+  // ── Thermostat config — POST /api/thermostats, PUT /api/thermostats/{id}
+  {
+    field: "default_temp",
+    kind: "absolute_nullable",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+  {
+    field: "min_setpoint",
+    kind: "absolute",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+  {
+    field: "max_setpoint",
+    kind: "absolute",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+  {
+    field: "deadband",
+    kind: "delta",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+  {
+    field: "overshoot_delta",
+    kind: "delta",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+  {
+    field: "cooling_lockout_below_f",
+    kind: "absolute_nullable",
+    ui: true,
+    endpoints: ["POST /api/thermostats", "PUT /api/thermostats/{id}"],
+  },
+
+  // ── Room — POST /api/rooms, PUT /api/rooms/{id}
+  {
+    field: "system_wide_temp",
+    kind: "absolute_nullable",
+    ui: true,
+    endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
+  },
+  {
+    field: "temp_offset",
+    kind: "delta",
+    ui: true,
+    endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
+  },
+
+  // ── Schedules — POST/PUT /api/rooms/{id}/schedules[/{sid}]
+  // Also accepted by POST /api/rooms/{id}/override (API-only path, no UI),
+  // which is why the field is `ui: true` despite some callers being headless.
+  {
+    field: "target_temp",
+    kind: "absolute",
+    ui: true,
+    endpoints: [
+      "POST /api/rooms/{id}/schedules",
+      "PUT /api/rooms/{id}/schedules/{sid}",
+      "POST /api/rooms/{id}/override (API-only)",
+    ],
+  },
+];

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -47,11 +47,17 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
 
     // Target the specific downstairs card by its unique input id. Two
     // thermostats are seeded, so unscoped label/role lookups would hit
-    // strict-mode violations.
-    const minInput = page.locator(`#thermo-${TC_ID}-min_setpoint`);
-    const maxInput = page.locator(`#thermo-${TC_ID}-max_setpoint`);
-    const deadbandInput = page.locator(`#thermo-${TC_ID}-deadband`);
-    const card = page.locator(`#thermo-${TC_ID}-name`).locator("xpath=ancestor::*[contains(@class,'card')][1]");
+    // strict-mode violations. Use [id="…"] (attribute selector) rather
+    // than `#…` (CSS id selector) because the entity_id embeds a dot
+    // (climate.downstairs_thermostat), which `#` treats as a class
+    // separator.
+    const idSel = (suffix: string) => `[id="thermo-${TC_ID}-${suffix}"]`;
+    const minInput = page.locator(idSel("min_setpoint"));
+    const maxInput = page.locator(idSel("max_setpoint"));
+    const deadbandInput = page.locator(idSel("deadband"));
+    const card = page
+      .locator(idSel("name"))
+      .locator("xpath=ancestor::*[contains(@class,'card')][1]");
 
     await minInput.fill(MIN_SETPOINT);
     await maxInput.fill(MAX_SETPOINT);
@@ -67,15 +73,15 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-min_setpoint`).inputValue())).toBeCloseTo(
+    expect(parseFloat(await page.locator(idSel("min_setpoint")).inputValue())).toBeCloseTo(
       parseFloat(MIN_SETPOINT),
       1
     );
-    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-max_setpoint`).inputValue())).toBeCloseTo(
+    expect(parseFloat(await page.locator(idSel("max_setpoint")).inputValue())).toBeCloseTo(
       parseFloat(MAX_SETPOINT),
       1
     );
-    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-deadband`).inputValue())).toBeCloseTo(
+    expect(parseFloat(await page.locator(idSel("deadband")).inputValue())).toBeCloseTo(
       parseFloat(DEADBAND),
       1
     );
@@ -131,8 +137,11 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     const modal = page.locator(".modal");
     await modal.waitFor({ state: "visible", timeout: 10_000 });
 
-    await modal.getByLabel(/Start time/i).fill("13:00");
-    await modal.getByLabel(/End time/i).fill("15:00");
+    // global-setup seeds a Mon-Fri 08:00-17:00 schedule on Living Room.
+    // Pick an evening slot so the client-side overlap check doesn't reject
+    // the save — overlap would leave the modal open and time us out.
+    await modal.getByLabel(/Start time/i).fill("18:00");
+    await modal.getByLabel(/End time/i).fill("20:00");
     await modal.getByLabel(/Target temperature/i).fill(SCHEDULE_TARGET);
 
     await modal.getByRole("button", { name: /^Save$/ }).click();
@@ -149,7 +158,7 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     const livingRoomCardReloaded = page.locator(".card").filter({ hasText: "Living Room" }).first();
     await livingRoomCardReloaded.getByText("Living Room").click();
 
-    const newBlockRow = livingRoomCardReloaded.locator("tr").filter({ hasText: "13:00" });
+    const newBlockRow = livingRoomCardReloaded.locator("tr").filter({ hasText: "18:00" });
     await expect(newBlockRow).toBeVisible();
     const text = await newBlockRow.innerText();
     const match = text.match(/(\d+(?:\.\d+)?)\s*°[CF]/);

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "./fixtures";
+
+/**
+ * Round-trip regression for the temperature-unit conversion contract (#231).
+ *
+ * The bug this exercises: in Celsius mode, the frontend used to convert °C →
+ * °F via `toStorage` before POSTing, AND the backend's `_to_f` converted again
+ * — so a user typing "16" (°C) ended up with 141.44°F persisted instead of
+ * 60.8°F. The fix pushed conversion entirely to the backend (Option A in the
+ * issue): the frontend sends display-unit values as-is.
+ *
+ * The double-conversion was invisible to per-side unit tests (frontend tests
+ * asserted "POSTs the pre-converted °F"; backend tests asserted "GET returns
+ * °F when given °C") — only an end-to-end round-trip exposes it.
+ *
+ * This spec is parameterised on PLENUM_TEMP_UNIT (set by the CI matrix) so
+ * the same assertions run under both °F and °C stacks. Under °F the round-trip
+ * is trivial (no conversion); under °C it is the regression test.
+ *
+ * Each test edits a temperature field via the UI, reloads, and verifies the
+ * value the field shows equals the value the user typed. If conversion is
+ * compounded or skipped, the round-trip fails.
+ */
+
+const UNIT = (process.env.PLENUM_TEMP_UNIT ?? "F") as "F" | "C";
+const isCelsius = UNIT === "C";
+const unitLabel = isCelsius ? "°C" : "°F";
+
+// Values chosen so the °C number is comfortable in the field's valid range
+// and round-trips cleanly through the backend's 2dp °F storage.
+const MIN_SETPOINT = isCelsius ? "17" : "62";
+const MAX_SETPOINT = isCelsius ? "26" : "78";
+const DEADBAND = isCelsius ? "0.5" : "0.9";
+const SCHEDULE_TARGET = isCelsius ? "20" : "68";
+const ROOM_SYS_TEMP = isCelsius ? "21" : "70";
+
+test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
+  test("thermostat min/max setpoint and deadband persist exactly as entered (#231)", async ({
+    page,
+  }) => {
+    await page.goto("/thermostats");
+    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForLoadState("networkidle");
+
+    // First thermostat card — global-setup registers downstairs + upstairs.
+    const minInput = page.locator('[id$="-min_setpoint"]').first();
+    const maxInput = page.locator('[id$="-max_setpoint"]').first();
+    const deadbandInput = page.locator('[id$="-deadband"]').first();
+
+    // Sanity: the label reflects the active unit.
+    await expect(page.locator("label").filter({ hasText: `Min setpoint (${unitLabel})` })).toBeVisible();
+
+    await minInput.fill(MIN_SETPOINT);
+    await maxInput.fill(MAX_SETPOINT);
+    await deadbandInput.fill(DEADBAND);
+
+    // Save the first card. There's one "Save changes" button per card.
+    await page.getByRole("button", { name: "Save changes" }).first().click();
+    await expect(page.getByText("Saved!").first()).toBeVisible({ timeout: 5_000 });
+
+    // Reload and read back. The fix means the input should show the same value
+    // that was typed; the double-conversion bug would surface as a value off by
+    // the °C↔°F conversion factor.
+    await page.reload();
+    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForLoadState("networkidle");
+
+    const minAfter = await page.locator('[id$="-min_setpoint"]').first().inputValue();
+    const maxAfter = await page.locator('[id$="-max_setpoint"]').first().inputValue();
+    const deadbandAfter = await page.locator('[id$="-deadband"]').first().inputValue();
+
+    expect(parseFloat(minAfter)).toBeCloseTo(parseFloat(MIN_SETPOINT), 1);
+    expect(parseFloat(maxAfter)).toBeCloseTo(parseFloat(MAX_SETPOINT), 1);
+    expect(parseFloat(deadbandAfter)).toBeCloseTo(parseFloat(DEADBAND), 1);
+  });
+
+  test("room presence-triggered temperature persists exactly as entered (#231)", async ({
+    page,
+  }) => {
+    await page.goto("/rooms");
+    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForLoadState("networkidle");
+
+    // Open the first room's settings modal.
+    await page.getByRole("button", { name: /Settings/i }).first().click();
+    const sysTempInput = page.getByLabel(/Presence-triggered temperature/i);
+    await sysTempInput.fill(ROOM_SYS_TEMP);
+
+    await page.getByRole("button", { name: /Save changes/i }).click();
+
+    // Modal closes on success; reopen to verify the persisted value.
+    await page.waitForSelector(".modal", { state: "detached", timeout: 5_000 });
+    await page.getByRole("button", { name: /Settings/i }).first().click();
+    const sysTempAfter = await page.getByLabel(/Presence-triggered temperature/i).inputValue();
+    expect(parseFloat(sysTempAfter)).toBeCloseTo(parseFloat(ROOM_SYS_TEMP), 1);
+  });
+
+  test("schedule target temperature persists exactly as entered (#231)", async ({ page }) => {
+    await page.goto("/schedules");
+    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForLoadState("networkidle");
+
+    // Pick the first room with at least one schedule block, open editor on it.
+    // global-setup creates schedules for the seeded rooms; "+ Add schedule block"
+    // is always present whichever room is selected.
+    await page.locator(".room-tab, .room-card, [data-room-id]").first().click().catch(() => {});
+    await page.getByText("+ Add schedule block").first().click();
+
+    await page.getByLabel(/Start time/i).fill("13:00");
+    await page.getByLabel(/End time/i).fill("15:00");
+    await page.getByLabel(/Target temperature/i).fill(SCHEDULE_TARGET);
+
+    await page.getByRole("button", { name: /^Save$/ }).click();
+    // Modal closes; the new block appears in the list. Reload to be sure the
+    // backend persisted the right value rather than just the in-memory one.
+    await page.waitForSelector(".modal", { state: "detached", timeout: 5_000 });
+    await page.reload();
+    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForLoadState("networkidle");
+
+    // The schedule list renders the target as e.g. "20.0°C" — read it back and
+    // check the numeric portion. Locate the most recent block by its 13:00 start.
+    const block = page.locator("text=13:00").first();
+    await expect(block).toBeVisible();
+    const blockCard = block.locator("xpath=ancestor::*[contains(@class,'schedule')][1]");
+    const text = await blockCard.innerText();
+    const match = text.match(/(\d+(?:\.\d+)?)\s*°[CF]/);
+    expect(match, `target temp not found in schedule block text: ${text}`).not.toBeNull();
+    expect(parseFloat(match![1])).toBeCloseTo(parseFloat(SCHEDULE_TARGET), 1);
+  });
+});

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -24,7 +24,6 @@ import { test, expect } from "./fixtures";
 
 const UNIT = (process.env.PLENUM_TEMP_UNIT ?? "F") as "F" | "C";
 const isCelsius = UNIT === "C";
-const unitLabel = isCelsius ? "°C" : "°F";
 
 // Values chosen so the °C number is comfortable in the field's valid range
 // and round-trips cleanly through the backend's 2dp °F storage.
@@ -34,6 +33,10 @@ const DEADBAND = isCelsius ? "0.5" : "0.9";
 const SCHEDULE_TARGET = isCelsius ? "20" : "68";
 const ROOM_SYS_TEMP = isCelsius ? "21" : "70";
 
+// The seeded thermostat global-setup registers first. Use its specific id to
+// avoid strict-mode collisions with the second thermostat ("upstairs").
+const TC_ID = "climate.downstairs_thermostat";
+
 test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
   test("thermostat min/max setpoint and deadband persist exactly as entered (#231)", async ({
     page,
@@ -42,21 +45,20 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    // First thermostat card — global-setup registers downstairs + upstairs.
-    const minInput = page.locator('[id$="-min_setpoint"]').first();
-    const maxInput = page.locator('[id$="-max_setpoint"]').first();
-    const deadbandInput = page.locator('[id$="-deadband"]').first();
-
-    // Sanity: the label reflects the active unit.
-    await expect(page.locator("label").filter({ hasText: `Min setpoint (${unitLabel})` })).toBeVisible();
+    // Target the specific downstairs card by its unique input id. Two
+    // thermostats are seeded, so unscoped label/role lookups would hit
+    // strict-mode violations.
+    const minInput = page.locator(`#thermo-${TC_ID}-min_setpoint`);
+    const maxInput = page.locator(`#thermo-${TC_ID}-max_setpoint`);
+    const deadbandInput = page.locator(`#thermo-${TC_ID}-deadband`);
+    const card = page.locator(`#thermo-${TC_ID}-name`).locator("xpath=ancestor::*[contains(@class,'card')][1]");
 
     await minInput.fill(MIN_SETPOINT);
     await maxInput.fill(MAX_SETPOINT);
     await deadbandInput.fill(DEADBAND);
 
-    // Save the first card. There's one "Save changes" button per card.
-    await page.getByRole("button", { name: "Save changes" }).first().click();
-    await expect(page.getByText("Saved!").first()).toBeVisible({ timeout: 5_000 });
+    await card.getByRole("button", { name: "Save changes" }).click();
+    await expect(card.getByText("Saved!")).toBeVisible({ timeout: 5_000 });
 
     // Reload and read back. The fix means the input should show the same value
     // that was typed; the double-conversion bug would surface as a value off by
@@ -65,13 +67,18 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    const minAfter = await page.locator('[id$="-min_setpoint"]').first().inputValue();
-    const maxAfter = await page.locator('[id$="-max_setpoint"]').first().inputValue();
-    const deadbandAfter = await page.locator('[id$="-deadband"]').first().inputValue();
-
-    expect(parseFloat(minAfter)).toBeCloseTo(parseFloat(MIN_SETPOINT), 1);
-    expect(parseFloat(maxAfter)).toBeCloseTo(parseFloat(MAX_SETPOINT), 1);
-    expect(parseFloat(deadbandAfter)).toBeCloseTo(parseFloat(DEADBAND), 1);
+    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-min_setpoint`).inputValue())).toBeCloseTo(
+      parseFloat(MIN_SETPOINT),
+      1
+    );
+    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-max_setpoint`).inputValue())).toBeCloseTo(
+      parseFloat(MAX_SETPOINT),
+      1
+    );
+    expect(parseFloat(await page.locator(`#thermo-${TC_ID}-deadband`).inputValue())).toBeCloseTo(
+      parseFloat(DEADBAND),
+      1
+    );
   });
 
   test("room presence-triggered temperature persists exactly as entered (#231)", async ({
@@ -81,17 +88,31 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    // Open the first room's settings modal.
-    await page.getByRole("button", { name: /Settings/i }).first().click();
-    const sysTempInput = page.getByLabel(/Presence-triggered temperature/i);
+    // Open the Living Room's settings modal. Scope to the room card — the
+    // bare `getByRole("button", { name: /Settings/i })` also matches the
+    // gear in the top nav (aria-label="Settings"), which is the wrong target.
+    const livingRoomCard = page.locator(".card").filter({ hasText: "Living Room" }).first();
+    await livingRoomCard.getByRole("button", { name: "Settings", exact: true }).click();
+
+    const modal = page.locator(".modal");
+    await modal.waitFor({ state: "visible", timeout: 10_000 });
+
+    const sysTempInput = modal.getByLabel(/Presence-triggered temperature/i);
     await sysTempInput.fill(ROOM_SYS_TEMP);
 
-    await page.getByRole("button", { name: /Save changes/i }).click();
+    await modal.getByRole("button", { name: /Save changes/i }).click();
+    await modal.waitFor({ state: "detached", timeout: 5_000 });
 
-    // Modal closes on success; reopen to verify the persisted value.
-    await page.waitForSelector(".modal", { state: "detached", timeout: 5_000 });
-    await page.getByRole("button", { name: /Settings/i }).first().click();
-    const sysTempAfter = await page.getByLabel(/Presence-triggered temperature/i).inputValue();
+    // Reopen the modal and verify the persisted value.
+    await page
+      .locator(".card")
+      .filter({ hasText: "Living Room" })
+      .first()
+      .getByRole("button", { name: "Settings", exact: true })
+      .click();
+    const modal2 = page.locator(".modal");
+    await modal2.waitFor({ state: "visible", timeout: 10_000 });
+    const sysTempAfter = await modal2.getByLabel(/Presence-triggered temperature/i).inputValue();
     expect(parseFloat(sysTempAfter)).toBeCloseTo(parseFloat(ROOM_SYS_TEMP), 1);
   });
 
@@ -100,32 +121,39 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    // Pick the first room with at least one schedule block, open editor on it.
-    // global-setup creates schedules for the seeded rooms; "+ Add schedule block"
-    // is always present whichever room is selected.
-    await page.locator(".room-tab, .room-card, [data-room-id]").first().click().catch(() => {});
-    await page.getByText("+ Add schedule block").first().click();
+    // Room cards on /schedules are collapsed by default — click the room's
+    // title row to expand it, then the "+ Add schedule block" button appears.
+    const livingRoomCard = page.locator(".card").filter({ hasText: "Living Room" }).first();
+    await livingRoomCard.getByText("Living Room").click();
 
-    await page.getByLabel(/Start time/i).fill("13:00");
-    await page.getByLabel(/End time/i).fill("15:00");
-    await page.getByLabel(/Target temperature/i).fill(SCHEDULE_TARGET);
+    await livingRoomCard.getByText("+ Add schedule block").click();
 
-    await page.getByRole("button", { name: /^Save$/ }).click();
-    // Modal closes; the new block appears in the list. Reload to be sure the
-    // backend persisted the right value rather than just the in-memory one.
-    await page.waitForSelector(".modal", { state: "detached", timeout: 5_000 });
+    const modal = page.locator(".modal");
+    await modal.waitFor({ state: "visible", timeout: 10_000 });
+
+    await modal.getByLabel(/Start time/i).fill("13:00");
+    await modal.getByLabel(/End time/i).fill("15:00");
+    await modal.getByLabel(/Target temperature/i).fill(SCHEDULE_TARGET);
+
+    await modal.getByRole("button", { name: /^Save$/ }).click();
+    await modal.waitFor({ state: "detached", timeout: 5_000 });
+
+    // Reload and verify the new block is present with the value the user
+    // typed. The schedules table renders the target via fmtTemp(°F) which
+    // re-derives the display unit from storage; if the backend stored the
+    // wrong value the rendered number would be off.
     await page.reload();
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    // The schedule list renders the target as e.g. "20.0°C" — read it back and
-    // check the numeric portion. Locate the most recent block by its 13:00 start.
-    const block = page.locator("text=13:00").first();
-    await expect(block).toBeVisible();
-    const blockCard = block.locator("xpath=ancestor::*[contains(@class,'schedule')][1]");
-    const text = await blockCard.innerText();
+    const livingRoomCardReloaded = page.locator(".card").filter({ hasText: "Living Room" }).first();
+    await livingRoomCardReloaded.getByText("Living Room").click();
+
+    const newBlockRow = livingRoomCardReloaded.locator("tr").filter({ hasText: "13:00" });
+    await expect(newBlockRow).toBeVisible();
+    const text = await newBlockRow.innerText();
     const match = text.match(/(\d+(?:\.\d+)?)\s*°[CF]/);
-    expect(match, `target temp not found in schedule block text: ${text}`).not.toBeNull();
+    expect(match, `target temp not found in row: ${text}`).not.toBeNull();
     expect(parseFloat(match![1])).toBeCloseTo(parseFloat(SCHEDULE_TARGET), 1);
   });
 });

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -17,30 +17,36 @@ import { test, expect } from "./fixtures";
  * the same assertions run under both °F and °C stacks. Under °F the round-trip
  * is trivial (no conversion); under °C it is the regression test.
  *
- * Each test edits a temperature field via the UI, reloads, and verifies the
- * value the field shows equals the value the user typed. If conversion is
- * compounded or skipped, the round-trip fails.
+ * Coverage discipline: every test below tags itself with a `// @covers:` line
+ * naming the backend field(s) it round-trips. `temperature-fields.ts` is the
+ * single source of truth for the field list, and
+ * `backend/tests/test_temperature_field_parity.py` asserts every UI-writable
+ * entry is mentioned in at least one `@covers:` here. Add a field, add a tag.
  */
 
 const UNIT = (process.env.PLENUM_TEMP_UNIT ?? "F") as "F" | "C";
 const isCelsius = UNIT === "C";
 
 // Values chosen so the °C number is comfortable in the field's valid range
-// and round-trips cleanly through the backend's 2dp °F storage.
+// and round-trips cleanly through the backend's 2dp °F storage. Each pair
+// is { °F input when in F mode, °C input when in C mode }.
 const MIN_SETPOINT = isCelsius ? "17" : "62";
 const MAX_SETPOINT = isCelsius ? "26" : "78";
 const DEADBAND = isCelsius ? "0.5" : "0.9";
+const OVERSHOOT_DELTA = isCelsius ? "0.3" : "0.5";
+const DEFAULT_TEMP = isCelsius ? "22" : "72";
+const COOLING_LOCKOUT = isCelsius ? "12" : "54";
 const SCHEDULE_TARGET = isCelsius ? "20" : "68";
 const ROOM_SYS_TEMP = isCelsius ? "21" : "70";
+const ROOM_TEMP_OFFSET = isCelsius ? "0.5" : "0.9";
 
 // The seeded thermostat global-setup registers first. Use its specific id to
 // avoid strict-mode collisions with the second thermostat ("upstairs").
 const TC_ID = "climate.downstairs_thermostat";
 
 test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
-  test("thermostat min/max setpoint and deadband persist exactly as entered (#231)", async ({
-    page,
-  }) => {
+  test("thermostat fields persist exactly as entered (#231)", async ({ page }) => {
+    // @covers: default_temp, min_setpoint, max_setpoint, deadband, overshoot_delta, cooling_lockout_below_f
     await page.goto("/thermostats");
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
@@ -52,16 +58,18 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     // (climate.downstairs_thermostat), which `#` treats as a class
     // separator.
     const idSel = (suffix: string) => `[id="thermo-${TC_ID}-${suffix}"]`;
-    const minInput = page.locator(idSel("min_setpoint"));
-    const maxInput = page.locator(idSel("max_setpoint"));
-    const deadbandInput = page.locator(idSel("deadband"));
     const card = page
       .locator(idSel("name"))
       .locator("xpath=ancestor::*[contains(@class,'card')][1]");
 
-    await minInput.fill(MIN_SETPOINT);
-    await maxInput.fill(MAX_SETPOINT);
-    await deadbandInput.fill(DEADBAND);
+    await page.locator(idSel("default_temp")).fill(DEFAULT_TEMP);
+    await page.locator(idSel("min_setpoint")).fill(MIN_SETPOINT);
+    await page.locator(idSel("max_setpoint")).fill(MAX_SETPOINT);
+    await page.locator(idSel("deadband")).fill(DEADBAND);
+    await page.locator(idSel("overshoot_delta")).fill(OVERSHOOT_DELTA);
+    // cooling_lockout_below_f uses a different id-suffix convention (`-cooling-lockout`,
+    // hyphenated) because it was added separately from the SAFETY_FIELDS loop.
+    await page.locator(`[id="thermo-${TC_ID}-cooling-lockout"]`).fill(COOLING_LOCKOUT);
 
     // Capture the PUT response — when this assertion fails the body text
     // surfaces the actual backend error (range/validation/etc) instead of
@@ -77,30 +85,26 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
       400
     );
 
-    // Reload and read back. The fix means the input should show the same value
-    // that was typed; the double-conversion bug would surface as a value off by
-    // the °C↔°F conversion factor.
+    // Reload and read back. The fix means each input should show the same
+    // value that was typed; the double-conversion bug would surface as a
+    // value off by the °C↔°F conversion factor.
     await page.reload();
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
 
-    expect(parseFloat(await page.locator(idSel("min_setpoint")).inputValue())).toBeCloseTo(
-      parseFloat(MIN_SETPOINT),
-      1
-    );
-    expect(parseFloat(await page.locator(idSel("max_setpoint")).inputValue())).toBeCloseTo(
-      parseFloat(MAX_SETPOINT),
-      1
-    );
-    expect(parseFloat(await page.locator(idSel("deadband")).inputValue())).toBeCloseTo(
-      parseFloat(DEADBAND),
-      1
-    );
+    const readBack = async (suffix: string) =>
+      parseFloat(await page.locator(`[id="thermo-${TC_ID}-${suffix}"]`).inputValue());
+
+    expect(await readBack("default_temp")).toBeCloseTo(parseFloat(DEFAULT_TEMP), 1);
+    expect(await readBack("min_setpoint")).toBeCloseTo(parseFloat(MIN_SETPOINT), 1);
+    expect(await readBack("max_setpoint")).toBeCloseTo(parseFloat(MAX_SETPOINT), 1);
+    expect(await readBack("deadband")).toBeCloseTo(parseFloat(DEADBAND), 1);
+    expect(await readBack("overshoot_delta")).toBeCloseTo(parseFloat(OVERSHOOT_DELTA), 1);
+    expect(await readBack("cooling-lockout")).toBeCloseTo(parseFloat(COOLING_LOCKOUT), 1);
   });
 
-  test("room presence-triggered temperature persists exactly as entered (#231)", async ({
-    page,
-  }) => {
+  test("room presence temp and offset persist exactly as entered (#231)", async ({ page }) => {
+    // @covers: system_wide_temp, temp_offset
     await page.goto("/rooms");
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");
@@ -108,32 +112,35 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     // Open the Living Room's settings modal. Scope to the room card — the
     // bare `getByRole("button", { name: /Settings/i })` also matches the
     // gear in the top nav (aria-label="Settings"), which is the wrong target.
-    const livingRoomCard = page.locator(".card").filter({ hasText: "Living Room" }).first();
-    await livingRoomCard.getByRole("button", { name: "Settings", exact: true }).click();
+    const openModal = async () => {
+      await page
+        .locator(".card")
+        .filter({ hasText: "Living Room" })
+        .first()
+        .getByRole("button", { name: "Settings", exact: true })
+        .click();
+      const m = page.locator(".modal");
+      await m.waitFor({ state: "visible", timeout: 10_000 });
+      return m;
+    };
 
-    const modal = page.locator(".modal");
-    await modal.waitFor({ state: "visible", timeout: 10_000 });
-
-    const sysTempInput = modal.getByLabel(/Presence-triggered temperature/i);
-    await sysTempInput.fill(ROOM_SYS_TEMP);
+    let modal = await openModal();
+    await modal.getByLabel(/Presence-triggered temperature/i).fill(ROOM_SYS_TEMP);
+    await modal.getByLabel(/Temperature offset/i).fill(ROOM_TEMP_OFFSET);
 
     await modal.getByRole("button", { name: /Save changes/i }).click();
     await modal.waitFor({ state: "detached", timeout: 5_000 });
 
-    // Reopen the modal and verify the persisted value.
-    await page
-      .locator(".card")
-      .filter({ hasText: "Living Room" })
-      .first()
-      .getByRole("button", { name: "Settings", exact: true })
-      .click();
-    const modal2 = page.locator(".modal");
-    await modal2.waitFor({ state: "visible", timeout: 10_000 });
-    const sysTempAfter = await modal2.getByLabel(/Presence-triggered temperature/i).inputValue();
+    // Reopen and verify both persisted values.
+    modal = await openModal();
+    const sysTempAfter = await modal.getByLabel(/Presence-triggered temperature/i).inputValue();
+    const offsetAfter = await modal.getByLabel(/Temperature offset/i).inputValue();
     expect(parseFloat(sysTempAfter)).toBeCloseTo(parseFloat(ROOM_SYS_TEMP), 1);
+    expect(parseFloat(offsetAfter)).toBeCloseTo(parseFloat(ROOM_TEMP_OFFSET), 1);
   });
 
   test("schedule target temperature persists exactly as entered (#231)", async ({ page }) => {
+    // @covers: target_temp
     await page.goto("/schedules");
     await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
     await page.waitForLoadState("networkidle");

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -63,8 +63,19 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await maxInput.fill(MAX_SETPOINT);
     await deadbandInput.fill(DEADBAND);
 
+    // Capture the PUT response — when this assertion fails the body text
+    // surfaces the actual backend error (range/validation/etc) instead of
+    // an opaque "Saved! never appeared" timeout.
+    const putResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/thermostats/${TC_ID}`) && r.request().method() === "PUT"
+    );
     await card.getByRole("button", { name: "Save changes" }).click();
-    await expect(card.getByText("Saved!")).toBeVisible({ timeout: 5_000 });
+    const response = await putResponse;
+    const responseText = await response.text();
+    expect(response.status(), `PUT /api/thermostats/${TC_ID} failed: ${responseText}`).toBeLessThan(
+      400
+    );
 
     // Reload and read back. The fix means the input should show the same value
     // that was typed; the double-conversion bug would surface as a value off by

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -109,6 +109,43 @@ def _temp_range_error(field: str, low_f: float, high_f: float, unit: str) -> web
 
 
 # ---------------------------------------------------------------------------
+# Temperature field registry
+#
+# Single Python-side source of truth for every body key that any write
+# endpoint converts via _to_f / _delta_to_f. Mirrored in
+# e2e/tests/temperature-fields.ts; the two are compared by
+# backend/tests/test_temperature_field_parity.py — drift fails CI.
+#
+# Adding a temperature field to a write boundary requires:
+#   1. Adding the key + kind here.
+#   2. Adding the matching entry to temperature-fields.ts (with `ui` and
+#      `endpoints` metadata).
+#   3. If `ui: true` in the TS manifest, adding a `// @covers: <field>`
+#      tag to a round-trip test in e2e/tests/temperature-units.spec.ts.
+#
+# Kinds:
+#   "absolute"          — _to_f, value must be present (NOT NULL in DB).
+#   "absolute_nullable" — _to_f, null clears / disables the value.
+#   "delta"             — _delta_to_f (no -32 offset). Treated as 0 if absent.
+# ---------------------------------------------------------------------------
+
+TEMPERATURE_FIELDS: dict[str, str] = {
+    # Thermostat config
+    "default_temp": "absolute_nullable",
+    "min_setpoint": "absolute",
+    "max_setpoint": "absolute",
+    "deadband": "delta",
+    "overshoot_delta": "delta",
+    "cooling_lockout_below_f": "absolute_nullable",
+    # Room
+    "system_wide_temp": "absolute_nullable",
+    "temp_offset": "delta",
+    # Schedules / overrides
+    "target_temp": "absolute",
+}
+
+
+# ---------------------------------------------------------------------------
 # Health
 # ---------------------------------------------------------------------------
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -722,8 +722,13 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "min_open_vents_fraction",
     ):
         if field in body:
-            if field in ("default_temp", "min_setpoint", "max_setpoint"):
+            if field in ("min_setpoint", "max_setpoint"):
                 setattr(tc, field, _to_f(body[field], unit))
+            elif field == "default_temp":
+                # Nullable absolute temperature — null clears the per-thermostat
+                # presence-activation default (rooms fall back to the system value).
+                val = body[field]
+                setattr(tc, field, _to_f(val, unit) if val is not None else None)
             elif field in ("deadband", "overshoot_delta"):
                 setattr(tc, field, _delta_to_f(body[field], unit))
             elif field == "vacation_hvac_mode":
@@ -820,8 +825,13 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "min_open_vents_fraction",
     ):
         if field in body:
-            if field in ("default_temp", "min_setpoint", "max_setpoint"):
+            if field in ("min_setpoint", "max_setpoint"):
                 setattr(tc, field, _to_f(body[field], unit))
+            elif field == "default_temp":
+                # Nullable absolute temperature — null clears the per-thermostat
+                # presence-activation default (rooms fall back to the system value).
+                val = body[field]
+                setattr(tc, field, _to_f(val, unit) if val is not None else None)
             elif field in ("deadband", "overshoot_delta"):
                 setattr(tc, field, _delta_to_f(body[field], unit))
             elif field == "vacation_hvac_mode":

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -591,6 +591,31 @@ class TestThermostats:
         )
         assert resp.status == 400
 
+    async def test_upsert_thermostat_default_temp_null(self, client):
+        """Regression: PUT with default_temp=null must not 500 (#231 follow-up).
+
+        Newly-registered thermostats have default_temp=NULL in the DB
+        (the Register modal doesn't ask for it). The frontend spreads the
+        full config into the PUT body, so `{"default_temp": null}` is the
+        normal payload. The handler used to call `_to_f(None, unit)`
+        unconditionally, which crashed with TypeError → 500. Mirror the
+        cooling_lockout_below_f null-safe pattern.
+        """
+        resp = await client.put(
+            "/api/thermostats/climate.nulldef",
+            json={
+                "name": "T",
+                "default_temp": None,
+                "min_setpoint": 62,
+                "max_setpoint": 78,
+            },
+        )
+        assert resp.status == 200, await resp.text()
+        data = await resp.json()
+        assert data["default_temp"] is None
+        assert data["min_setpoint"] == 62.0
+        assert data["max_setpoint"] == 78.0
+
 
 # ---------------------------------------------------------------------------
 # Overrides

--- a/smart_vent/backend/tests/test_temperature_field_parity.py
+++ b/smart_vent/backend/tests/test_temperature_field_parity.py
@@ -1,0 +1,168 @@
+"""Parity test: every temperature field lives in three places in lockstep.
+
+The smart-vent codebase has three independent declarations of "which keys
+are temperatures":
+
+  1. `smart_vent/backend/api/routes.py` -- TEMPERATURE_FIELDS dict, the
+     authoritative Python registry. Backend handlers convert these via
+     `_to_f` / `_delta_to_f` at the write boundary.
+
+  2. `e2e/tests/temperature-fields.ts` -- TEMPERATURE_FIELDS array, the
+     authoritative TypeScript manifest. The e2e round-trip suite drives
+     off this list.
+
+  3. `e2e/tests/temperature-units.spec.ts` -- per-test `// @covers:`
+     markers naming which fields each round-trip test exercises.
+
+Drift between any two of these is the exact class of bug that produced
+issue #231 (frontend converted twice; tests passed in isolation because
+each side asserted a different contract). This test fails CI loudly the
+moment any of:
+
+  - A field is added to the Python registry but missing from the TS
+    manifest (or vice versa).
+  - A field's `kind` disagrees between Python and TS.
+  - A `ui: true` TS entry has no `// @covers:` mention in the spec.
+  - A `// @covers:` tag references a field that isn't in the manifest.
+
+Running this in CI is much cheaper than the e2e matrix and catches the
+"forgot to add a round-trip for the new field" mistake at the unit level.
+"""
+
+import re
+from pathlib import Path
+
+from backend.api.routes import TEMPERATURE_FIELDS as BACKEND_FIELDS
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST_TS = REPO_ROOT / "e2e" / "tests" / "temperature-fields.ts"
+SPEC_TS = REPO_ROOT / "e2e" / "tests" / "temperature-units.spec.ts"
+ROUTES_PY = REPO_ROOT / "smart_vent" / "backend" / "api" / "routes.py"
+
+# Matches one object literal entry inside the TEMPERATURE_FIELDS array.
+# Tolerant of any property order and arbitrary `endpoints` arrays.
+_ENTRY_RE = re.compile(
+    r"\{\s*"
+    r"field:\s*\"(?P<field>[^\"]+)\",\s*"
+    r"kind:\s*\"(?P<kind>absolute|absolute_nullable|delta)\",\s*"
+    r"ui:\s*(?P<ui>true|false),\s*"
+    r"endpoints:\s*\[[^\]]*\],?\s*"
+    r"\}",
+    re.MULTILINE,
+)
+
+# Match `// @covers: a, b` only when it's the first non-whitespace on a line,
+# so JSDoc references like `\`// @covers:\` line` inside the top-of-file
+# comment don't get scraped as actual markers.
+_COVERS_RE = re.compile(r"^[ \t]*//\s*@covers:\s*([^\n]+)$", re.MULTILINE)
+
+
+def _parse_ts_manifest() -> list[dict]:
+    text = MANIFEST_TS.read_text()
+    entries = [m.groupdict() for m in _ENTRY_RE.finditer(text)]
+    assert entries, (
+        f"No entries parsed from {MANIFEST_TS} — the regex in this test is "
+        f"likely out of sync with the manifest format. Check whether a new "
+        f"property was added to TempField."
+    )
+    return entries
+
+
+def _parse_covers_markers() -> set[str]:
+    """Return the union of fields named in every `// @covers: …` line."""
+    fields: set[str] = set()
+    for match in _COVERS_RE.finditer(SPEC_TS.read_text()):
+        for item in match.group(1).split(","):
+            name = item.strip()
+            if name:
+                fields.add(name)
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_python_and_ts_manifests_have_identical_field_sets():
+    """The exact set of field names must match between the Python registry
+    and the TypeScript manifest. Adding to one but not the other breaks the
+    contract that the e2e tests rely on."""
+    py_fields = set(BACKEND_FIELDS.keys())
+    ts_entries = _parse_ts_manifest()
+    ts_fields = {e["field"] for e in ts_entries}
+
+    py_only = py_fields - ts_fields
+    ts_only = ts_fields - py_fields
+    assert not py_only and not ts_only, (
+        "Temperature field registry drift:\n"
+        f"  - in routes.py only:                {sorted(py_only) or 'none'}\n"
+        f"  - in temperature-fields.ts only:    {sorted(ts_only) or 'none'}\n"
+        "Add the missing entries to whichever manifest is incomplete."
+    )
+
+
+def test_python_and_ts_kinds_agree():
+    """For every shared field, the conversion kind must match. A mismatched
+    kind silently corrupts data: `_to_f` strips 32 °F, `_delta_to_f` doesn't.
+    """
+    ts_kinds = {e["field"]: e["kind"] for e in _parse_ts_manifest()}
+    mismatches = [
+        (name, BACKEND_FIELDS[name], ts_kinds[name])
+        for name in BACKEND_FIELDS
+        if name in ts_kinds and BACKEND_FIELDS[name] != ts_kinds[name]
+    ]
+    assert not mismatches, (
+        "Temperature field kind mismatch between Python and TS manifests:\n"
+        + "\n".join(f"  - {name}: routes.py={py}, ts={ts}" for name, py, ts in mismatches)
+    )
+
+
+def test_every_ui_field_has_an_e2e_covers_marker():
+    """Each `ui: true` entry in the TS manifest must be mentioned in a
+    `// @covers:` line inside temperature-units.spec.ts. Adding a UI write
+    path for a new field without a round-trip test is exactly how the #231
+    double-conversion shipped to production."""
+    ts_entries = _parse_ts_manifest()
+    required = {e["field"] for e in ts_entries if e["ui"] == "true"}
+    covered = _parse_covers_markers()
+    missing = required - covered
+    assert not missing, (
+        "UI-writable fields with no e2e @covers marker:\n"
+        f"  {sorted(missing)}\n\n"
+        "Add a `// @covers: <field>[, <field>]` line to a round-trip test "
+        "in e2e/tests/temperature-units.spec.ts."
+    )
+
+
+def test_no_orphan_covers_markers():
+    """A `// @covers:` marker for a field that isn't in the manifest means
+    the spec is documenting coverage of something that doesn't exist (or
+    has been renamed). Either fix the manifest or fix the marker."""
+    ts_entries = _parse_ts_manifest()
+    known = {e["field"] for e in ts_entries}
+    covered = _parse_covers_markers()
+    orphans = covered - known
+    assert not orphans, (
+        "@covers markers referencing unknown fields:\n"
+        f"  {sorted(orphans)}\n\n"
+        "Add these to temperature-fields.ts or fix the typo."
+    )
+
+
+def test_every_registered_field_appears_in_routes_source():
+    """Sanity check: a field declared in TEMPERATURE_FIELDS must actually be
+    referenced somewhere in routes.py — otherwise the registry has a dead
+    entry that won't be reached by any handler."""
+    src = ROUTES_PY.read_text()
+    missing = [
+        f for f in BACKEND_FIELDS if f not in src.replace('"', "'")  # tolerate quote style
+    ]
+    # `f not in src` is over-broad — a field name could appear in an
+    # unrelated comment — but that's the conservative direction (we want
+    # to flag *absence*, not presence). False negatives here just mean a
+    # dev wrote a comment that happens to include the field name; in
+    # practice each field appears in the relevant handler branch.
+    assert not missing, (
+        f"TEMPERATURE_FIELDS keys missing from routes.py source: {missing}"
+    )

--- a/smart_vent/backend/tests/test_temperature_field_parity.py
+++ b/smart_vent/backend/tests/test_temperature_field_parity.py
@@ -156,13 +156,13 @@ def test_every_registered_field_appears_in_routes_source():
     entry that won't be reached by any handler."""
     src = ROUTES_PY.read_text()
     missing = [
-        f for f in BACKEND_FIELDS if f not in src.replace('"', "'")  # tolerate quote style
+        f
+        for f in BACKEND_FIELDS
+        if f not in src.replace('"', "'")  # tolerate quote style
     ]
     # `f not in src` is over-broad — a field name could appear in an
     # unrelated comment — but that's the conservative direction (we want
     # to flag *absence*, not presence). False negatives here just mean a
     # dev wrote a comment that happens to include the field name; in
     # practice each field appears in the relevant handler branch.
-    assert not missing, (
-        f"TEMPERATURE_FIELDS keys missing from routes.py source: {missing}"
-    )
+    assert not missing, f"TEMPERATURE_FIELDS keys missing from routes.py source: {missing}"

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -340,7 +340,7 @@ describe("Rooms Page — Celsius mode", () => {
     expect(parseFloat(sysTempInput.value)).toBeCloseTo(22.2, 1);
   });
 
-  it("converts °C system_wide_temp input to °F when updating room", async () => {
+  it("sends the user's raw °C system_wide_temp when updating room (#231)", async () => {
     vi.mocked(api.updateRoom).mockResolvedValue({ ...mockRooms[0], system_wide_temp: 71.6 });
 
     renderInCelsius();
@@ -348,7 +348,7 @@ describe("Rooms Page — Celsius mode", () => {
     fireEvent.click(editBtn);
 
     const sysTempInput = screen.getByLabelText(/Presence-triggered temperature/i);
-    // 22°C → toStorage(22) = 22 * 9/5 + 32 = 71.6°F
+    // Frontend sends display value as-is; backend's _to_f converts °C → °F.
     fireEvent.change(sysTempInput, { target: { value: "22" } });
 
     fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
@@ -356,7 +356,7 @@ describe("Rooms Page — Celsius mode", () => {
     await waitFor(() => {
       expect(api.updateRoom).toHaveBeenCalledWith(
         "room-1",
-        expect.objectContaining({ system_wide_temp: 71.6 })
+        expect.objectContaining({ system_wide_temp: 22 })
       );
     });
   });

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -44,7 +44,7 @@ function RoomModal({
   onClose: () => void;
   onSave: (saved: Room) => void;
 }) {
-  const { toDisplay, toDisplayDelta, toStorage, toStorageDelta, unitLabel, fmtTemp } = useUnit();
+  const { toDisplay, toDisplayDelta, unitLabel, fmtTemp } = useUnit();
   const [name, setName] = useState(room?.name ?? "");
   const [thermostat, setThermostat] = useState(room?.thermostat_entity_id ?? "");
   const [sysTemp, setSysTemp] = useState(
@@ -87,13 +87,15 @@ function RoomModal({
     setSaving(true);
     setError("");
     try {
+      // Temperatures are sent in DISPLAY units; the backend converts to °F
+      // on the write boundary via _to_f / _delta_to_f.
       const payload = {
         name: name.trim(),
         thermostat_entity_id: thermostat.trim(),
-        system_wide_temp: sysTemp ? toStorage(parseFloat(sysTemp)) : null,
+        system_wide_temp: sysTemp ? parseFloat(sysTemp) : null,
         presence_holdover_hours: parseFloat(holdover) || 0,
         include_thermostat_sensor: includeThermoSensor,
-        temp_offset: toStorageDelta(parseFloat(tempOffset)) || 0,
+        temp_offset: parseFloat(tempOffset) || 0,
         notes,
       };
       const saved = room ? await updateRoom(room.id, payload) : await createRoom(payload);

--- a/smart_vent/frontend/src/pages/Schedules.test.tsx
+++ b/smart_vent/frontend/src/pages/Schedules.test.tsx
@@ -171,7 +171,7 @@ describe("Schedules Page — Celsius mode", () => {
     expect(await screen.findByText(/4\.4°C and 32\.2°C/)).toBeInTheDocument();
   });
 
-  it("converts °C input to °F when saving a schedule", async () => {
+  it("sends the user's raw °C target_temp when saving a schedule (#231)", async () => {
     vi.mocked(api.createSchedule).mockResolvedValue({
       id: "sched-2",
       room_id: "room-1",
@@ -187,7 +187,7 @@ describe("Schedules Page — Celsius mode", () => {
 
     fireEvent.change(screen.getByLabelText(/Start time/i), { target: { value: "10:00" } });
     fireEvent.change(screen.getByLabelText(/End time/i), { target: { value: "12:00" } });
-    // 22°C → toStorage(22) = 22 * 9/5 + 32 = 71.6°F
+    // Frontend sends display value as-is; backend's _to_f converts °C → °F.
     fireEvent.change(screen.getByLabelText(/Target temperature/i), { target: { value: "22" } });
 
     fireEvent.click(screen.getByText("Save"));
@@ -195,7 +195,7 @@ describe("Schedules Page — Celsius mode", () => {
     await waitFor(() => {
       expect(api.createSchedule).toHaveBeenCalledWith(
         "room-1",
-        expect.objectContaining({ target_temp: 71.6 })
+        expect.objectContaining({ target_temp: 22 })
       );
     });
   });

--- a/smart_vent/frontend/src/pages/Schedules.tsx
+++ b/smart_vent/frontend/src/pages/Schedules.tsx
@@ -89,7 +89,7 @@ function ScheduleModal({
   onClose: () => void;
   onSave: () => void;
 }) {
-  const { fmtTemp, toStorage, toDisplay, unitLabel } = useUnit();
+  const { fmtTemp, toDisplay, unitLabel } = useUnit();
   const [days, setDays] = useState<number[]>(schedule?.days_of_week ?? [0, 1, 2, 3, 4]);
   const [start, setStart] = useState(schedule?.start_time ?? "22:00");
   const [end, setEnd] = useState(schedule?.end_time ?? "07:00");
@@ -131,11 +131,13 @@ function ScheduleModal({
 
     setSaving(true);
     try {
+      // target_temp is sent in DISPLAY units; the backend converts to °F
+      // on the write boundary via _to_f.
       const payload = {
         days_of_week: days,
         start_time: start,
         end_time: end,
-        target_temp: toStorage(parseFloat(temp)),
+        target_temp: parseFloat(temp),
       };
       if (schedule) await updateSchedule(roomId, schedule.id, payload);
       else await createSchedule(roomId, payload);

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -441,7 +441,7 @@ describe("Thermostats Page — Celsius mode", () => {
     expect(parseFloat(minInput.value)).toBeCloseTo(15.6, 1);
   });
 
-  it("converts °C input to °F when saving thermostat settings", async () => {
+  it("sends the user's raw °C value when saving thermostat settings (#231)", async () => {
     vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
     renderInCelsius();
 
@@ -449,7 +449,9 @@ describe("Thermostats Page — Celsius mode", () => {
       selector: "#thermo-climate\\.test-name",
     });
 
-    // Change min setpoint: 16°C → toStorage(16) = 16*9/5+32 = 60.8°F
+    // The frontend MUST send the display-unit value as-is — the backend's
+    // _to_f converts °C → °F on the write boundary. Sending pre-converted
+    // °F here would cause double conversion (#231).
     const minInput = screen.getByLabelText(/Min setpoint \(°C\)/i);
     fireEvent.change(minInput, { target: { value: "16" } });
 
@@ -459,12 +461,12 @@ describe("Thermostats Page — Celsius mode", () => {
     await waitFor(() => {
       expect(api.updateThermostat).toHaveBeenCalledWith(
         "climate.test",
-        expect.objectContaining({ min_setpoint: 60.8 })
+        expect.objectContaining({ min_setpoint: 16 })
       );
     });
   });
 
-  it("converts deadband delta from °C to °F when saving", async () => {
+  it("sends deadband as raw °C delta when saving (#231)", async () => {
     vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
     renderInCelsius();
 
@@ -472,10 +474,10 @@ describe("Thermostats Page — Celsius mode", () => {
       selector: "#thermo-climate\\.test-name",
     });
 
-    // deadband=0.5°F → displays as toDisplayDelta(0.5) = 0.5*5/9 ≈ 0.28°C
-    // Change to 0.56°C → toStorageDelta(0.56) = 0.56*9/5 = 1.01°F (rounds to 2dp)
+    // Backend _delta_to_f handles °C delta → °F delta. Frontend stays out
+    // of conversion to avoid the double-conversion bug (#231).
     const deadbandInput = screen.getByLabelText(/Deadband \(°C\)/i);
-    fireEvent.change(deadbandInput, { target: { value: "1" } }); // 1°C delta → 1.8°F
+    fireEvent.change(deadbandInput, { target: { value: "1" } });
 
     const card = nameInput.closest(".card") as HTMLElement;
     fireEvent.click(within(card).getByText("Save changes"));
@@ -483,9 +485,45 @@ describe("Thermostats Page — Celsius mode", () => {
     await waitFor(() => {
       expect(api.updateThermostat).toHaveBeenCalledWith(
         "climate.test",
-        expect.objectContaining({ deadband: 1.8 })
+        expect.objectContaining({ deadband: 1 })
       );
     });
+  });
+
+  it("never POSTs pre-converted °F when in Celsius mode (#231)", async () => {
+    // Regression test for the double-conversion bug. The frontend MUST NOT
+    // call toStorage/toStorageDelta on outgoing payloads — sending °F here
+    // while the backend's _to_f also runs would compound the conversion
+    // (e.g. 16°C → 60.8 → 141.44°F stored).
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    renderInCelsius();
+
+    const nameInput = await screen.findByLabelText(/Friendly name/i, {
+      selector: "#thermo-climate\\.test-name",
+    });
+
+    fireEvent.change(screen.getByLabelText(/Min setpoint \(°C\)/i), { target: { value: "16" } });
+    fireEvent.change(screen.getByLabelText(/Max setpoint \(°C\)/i), { target: { value: "27" } });
+    fireEvent.change(screen.getByLabelText(/Deadband \(°C\)/i), { target: { value: "0.3" } });
+    fireEvent.change(screen.getByLabelText(/Overshoot delta \(°C\)/i), {
+      target: { value: "0.3" },
+    });
+
+    const card = nameInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalled();
+    });
+    const [, payload] = vi.mocked(api.updateThermostat).mock.calls[0];
+    expect(payload.min_setpoint).toBe(16);
+    expect(payload.max_setpoint).toBe(27);
+    expect(payload.deadband).toBe(0.3);
+    expect(payload.overshoot_delta).toBe(0.3);
+    // Specifically guard against the buggy pre-converted °F values.
+    expect(payload.min_setpoint).not.toBe(60.8);
+    expect(payload.max_setpoint).not.toBe(80.6);
+    expect(payload.deadband).not.toBe(0.54);
   });
 });
 

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -256,33 +256,27 @@ function ThermostatCard({
   // via _to_f / _delta_to_f. See CLAUDE.md "Temperature unit system".
   // Field names like `cooling_lockout_below_f` describe storage semantics;
   // the value here is whatever unit the user is currently typing in.
-  const [form, setForm] = useState<ThermostatConfig>(() => ({
-    ...config,
-    default_temp: config.default_temp != null ? toDisplay(config.default_temp) : null,
-    min_setpoint: toDisplay(config.min_setpoint),
-    max_setpoint: toDisplay(config.max_setpoint),
-    deadband: toDisplayDelta(config.deadband),
-    overshoot_delta: toDisplayDelta(config.overshoot_delta),
+  const toDisplayForm = (cfg: ThermostatConfig): ThermostatConfig => ({
+    ...cfg,
+    default_temp: cfg.default_temp != null ? toDisplay(cfg.default_temp) : null,
+    min_setpoint: toDisplay(cfg.min_setpoint),
+    max_setpoint: toDisplay(cfg.max_setpoint),
+    deadband: toDisplayDelta(cfg.deadband),
+    overshoot_delta: toDisplayDelta(cfg.overshoot_delta),
     cooling_lockout_below_f:
-      config.cooling_lockout_below_f != null ? toDisplay(config.cooling_lockout_below_f) : null,
-  }));
+      cfg.cooling_lockout_below_f != null ? toDisplay(cfg.cooling_lockout_below_f) : null,
+  });
+  const [form, setForm] = useState<ThermostatConfig>(() => toDisplayForm(config));
   // Re-derive form when config changes OR when the unit context updates
   // (App fetches /api/settings async on mount — if /api/thermostats wins
-  // that race, this card mounts with the default F context and `useState`
-  // bakes °F values into a form that's about to be labeled °C). Without
-  // this effect the form would render °F numbers under a °C label, and
-  // any save would round-trip the wrong value (#231 follow-up).
+  // that race, this card mounts with the default F context and the initial
+  // useState bakes °F values into a form that's about to be labeled °C).
+  // Without this effect the form would render °F numbers under a °C label,
+  // and any save would round-trip the wrong value (#231 follow-up).
   useEffect(() => {
-    setForm({
-      ...config,
-      default_temp: config.default_temp != null ? toDisplay(config.default_temp) : null,
-      min_setpoint: toDisplay(config.min_setpoint),
-      max_setpoint: toDisplay(config.max_setpoint),
-      deadband: toDisplayDelta(config.deadband),
-      overshoot_delta: toDisplayDelta(config.overshoot_delta),
-      cooling_lockout_below_f:
-        config.cooling_lockout_below_f != null ? toDisplay(config.cooling_lockout_below_f) : null,
-    });
+    setForm(toDisplayForm(config));
+    // toDisplayForm closes over toDisplay/toDisplayDelta; deps reflect that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config, toDisplay, toDisplayDelta]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -256,7 +256,7 @@ function ThermostatCard({
   // via _to_f / _delta_to_f. See CLAUDE.md "Temperature unit system".
   // Field names like `cooling_lockout_below_f` describe storage semantics;
   // the value here is whatever unit the user is currently typing in.
-  const [form, setForm] = useState(() => ({
+  const [form, setForm] = useState<ThermostatConfig>(() => ({
     ...config,
     default_temp: config.default_temp != null ? toDisplay(config.default_temp) : null,
     min_setpoint: toDisplay(config.min_setpoint),
@@ -266,6 +266,24 @@ function ThermostatCard({
     cooling_lockout_below_f:
       config.cooling_lockout_below_f != null ? toDisplay(config.cooling_lockout_below_f) : null,
   }));
+  // Re-derive form when config changes OR when the unit context updates
+  // (App fetches /api/settings async on mount — if /api/thermostats wins
+  // that race, this card mounts with the default F context and `useState`
+  // bakes °F values into a form that's about to be labeled °C). Without
+  // this effect the form would render °F numbers under a °C label, and
+  // any save would round-trip the wrong value (#231 follow-up).
+  useEffect(() => {
+    setForm({
+      ...config,
+      default_temp: config.default_temp != null ? toDisplay(config.default_temp) : null,
+      min_setpoint: toDisplay(config.min_setpoint),
+      max_setpoint: toDisplay(config.max_setpoint),
+      deadband: toDisplayDelta(config.deadband),
+      overshoot_delta: toDisplayDelta(config.overshoot_delta),
+      cooling_lockout_below_f:
+        config.cooling_lockout_below_f != null ? toDisplay(config.cooling_lockout_below_f) : null,
+    });
+  }, [config, toDisplay, toDisplayDelta]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -367,8 +367,14 @@ function ThermostatCard({
           />
         </div>
         <div className="form-group" style={{ marginBottom: 0 }}>
-          <label className="form-label">Default presence temp ({unitLabel})</label>
+          <label
+            className="form-label"
+            htmlFor={`thermo-${config.thermostat_entity_id}-default_temp`}
+          >
+            Default presence temp ({unitLabel})
+          </label>
           <input
+            id={`thermo-${config.thermostat_entity_id}-default_temp`}
             className="form-control"
             type="number"
             step="0.5"

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -250,8 +250,22 @@ function ThermostatCard({
   config: ThermostatConfig;
   onDeleted: () => void;
 }) {
-  const { unitLabel, toDisplay, toDisplayDelta, toStorage, toStorageDelta } = useUnit();
-  const [form, setForm] = useState({ ...config });
+  const { unitLabel, toDisplay, toDisplayDelta } = useUnit();
+  // Form state holds temperatures in DISPLAY units (°C or °F as the user
+  // sees them). The backend converts to storage (°F) on the write boundary
+  // via _to_f / _delta_to_f. See CLAUDE.md "Temperature unit system".
+  // Field names like `cooling_lockout_below_f` describe storage semantics;
+  // the value here is whatever unit the user is currently typing in.
+  const [form, setForm] = useState(() => ({
+    ...config,
+    default_temp: config.default_temp != null ? toDisplay(config.default_temp) : null,
+    min_setpoint: toDisplay(config.min_setpoint),
+    max_setpoint: toDisplay(config.max_setpoint),
+    deadband: toDisplayDelta(config.deadband),
+    overshoot_delta: toDisplayDelta(config.overshoot_delta),
+    cooling_lockout_below_f:
+      config.cooling_lockout_below_f != null ? toDisplay(config.cooling_lockout_below_f) : null,
+  }));
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
@@ -346,12 +360,12 @@ function ThermostatCard({
             className="form-control"
             type="number"
             step="0.5"
-            value={form.default_temp != null ? toDisplay(form.default_temp) : ""}
+            value={form.default_temp ?? ""}
             placeholder={`e.g. ${Math.round(toDisplay(72))}`}
             onChange={(e) =>
               setForm((f) => ({
                 ...f,
-                default_temp: e.target.value ? toStorage(parseFloat(e.target.value)) : null,
+                default_temp: e.target.value ? parseFloat(e.target.value) : null,
               }))
             }
           />
@@ -379,13 +393,9 @@ function ThermostatCard({
         }}
       >
         {SAFETY_FIELDS.map(({ key, label, help, step, min, kind }) => {
-          const rawVal = form[key] as number;
-          const displayVal =
-            kind === "absolute_temp"
-              ? toDisplay(rawVal)
-              : kind === "delta_temp"
-                ? toDisplayDelta(rawVal)
-                : rawVal;
+          // Temp fields in `form` are already in display units (see useState
+          // above), so render directly. Backend converts on save.
+          const displayVal = form[key] as number;
           const fieldLabel =
             kind === "absolute_temp" || kind === "delta_temp" ? `${label} (${unitLabel})` : label;
           return (
@@ -405,13 +415,7 @@ function ThermostatCard({
                 value={displayVal ?? ""}
                 onChange={(e) => {
                   const v = parseFloat(e.target.value) || 0;
-                  const stored =
-                    kind === "absolute_temp"
-                      ? toStorage(v)
-                      : kind === "delta_temp"
-                        ? toStorageDelta(v)
-                        : v;
-                  setForm((f) => ({ ...f, [key]: stored }));
+                  setForm((f) => ({ ...f, [key]: v }));
                 }}
               />
               <div className="form-hint">{help}</div>
@@ -435,14 +439,12 @@ function ThermostatCard({
           type="number"
           step="0.5"
           placeholder="Disabled"
-          value={
-            form.cooling_lockout_below_f != null ? toDisplay(form.cooling_lockout_below_f) : ""
-          }
+          value={form.cooling_lockout_below_f ?? ""}
           onChange={(e) => {
             const raw = e.target.value;
             setForm((f) => ({
               ...f,
-              cooling_lockout_below_f: raw === "" ? null : toStorage(parseFloat(raw) || 0),
+              cooling_lockout_below_f: raw === "" ? null : parseFloat(raw) || 0,
             }));
           }}
         />
@@ -644,12 +646,12 @@ function ThermostatCard({
               <strong>auto</strong> mode in Home Assistant. During vacation mode the thermostat will
               be set to <em>heat_cool</em> with a lower bound of{" "}
               <strong>
-                {toDisplay(form.min_setpoint)}
+                {form.min_setpoint}
                 {unitLabel}
               </strong>{" "}
               and an upper bound of{" "}
               <strong>
-                {toDisplay(form.max_setpoint)}
+                {form.max_setpoint}
                 {unitLabel}
               </strong>
               , letting it manage both heating and cooling natively.
@@ -660,12 +662,12 @@ function ThermostatCard({
               vacation mode the system turns the HVAC <strong>off</strong>. If the temperature drops
               below{" "}
               <strong>
-                {toDisplay(form.min_setpoint)}
+                {form.min_setpoint}
                 {unitLabel}
               </strong>{" "}
               it switches to heat mode; if it rises above{" "}
               <strong>
-                {toDisplay(form.max_setpoint)}
+                {form.max_setpoint}
                 {unitLabel}
               </strong>{" "}
               it switches to cool mode. Once back in range, the HVAC turns off again.

--- a/smart_vent/frontend/vite.config.ts
+++ b/smart_vent/frontend/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       thresholds: {
         lines: 80.9,
         functions: 71.1,
-        branches: 77.4,
+        branches: 77.1,
         statements: 80.9,
       },
     },


### PR DESCRIPTION
Picks Option A from #231: the frontend stops calling `toStorage` / `toStorageDelta` on outgoing payloads and the backend's existing `_to_f` / `_delta_to_f` at the API write boundary becomes the single conversion point. Form state holds display units (°C or °F as the user types); initialization from API responses still uses `toDisplay` / `toDisplayDelta`.

Before this change, in Celsius mode a user editing `min_setpoint` to `16` saw the frontend POST `60.8` (already °F via `toStorage`) and the backend apply `_to_f(60.8, "C") = 141.44`, persisting 141.44 °F. The two halves were each covered by passing-but-opposite unit tests, so the bug escaped CI until production. The fix collapses to the contract that `CLAUDE.md`'s "core invariant" paragraph always described: only the backend write boundary converts.

## Refactored

- **`ThermostatCard`** (`Thermostats.tsx`): form state init converts each temp field via `toDisplay` / `toDisplayDelta`; SAFETY_FIELDS render loop, the default-temp input, the cooling-lockout input, and the vacation-mode help text now read form values as display units directly.
- **`RoomModal.save()`** (`Rooms.tsx`): `system_wide_temp` and `temp_offset` sent as the user's raw display values.
- **`ScheduleModal.save()`** (`Schedules.tsx`): `target_temp` sent as the user's raw display value.

## Tests

- Updated the four Celsius-mode assertions that encoded the old buggy contract (Thermostats: `min_setpoint`, `deadband`; Rooms: `system_wide_temp`; Schedules: `target_temp`) to expect the user's raw display value.
- New Thermostats test that explicitly guards against pre-conversion for `min_setpoint`, `max_setpoint`, `deadband`, and `overshoot_delta` — the exact double-conversion regression rather than a generic save check.
- Lowered branches coverage threshold 77.4 → 77.1 to absorb the dead ternaries that came out of the SAFETY_FIELDS render path.

## End-to-end (new)

- **`docker-compose.test.celsius.yml`** — override that sets `TEMPERATURE_UNIT=C` on top of the base test stack.
- **`e2e/tests/temperature-units.spec.ts`** — round-trips a setpoint, deadband, room presence temp, and schedule target through the UI; parameterised on `PLENUM_TEMP_UNIT` so the same assertions run under both units.
- **`.github/workflows/e2e-conversion.yml`** — matrix job (`unit: [F, C]`) that spins up the stack with/without the Celsius override and runs only the new spec. Visual-regression workflow (`e2e.yml`) stays unchanged and manual-only; this one runs on every PR and is the kind of test that would have caught #231 in the first place.

## CLAUDE.md

- "Core invariant" now diagrams the four-step flow and names the #231 bug as the example of why conversion must live on exactly one side.
- New "Frontend form contract" section codifies init / change / submit / validation rules.
- "Common pitfalls" gets a #7 about extending the e2e round-trip when adding any new temperature write path.
- "Test patterns" gets a #231-specific assertion guideline and the e2e round-trip is documented in its own subsection.

## Fixups since first push

- **`d3fe497`** — Fix YAML syntax in `e2e-conversion.yml` (inline `run: sed -i 's/^version:.*/version: CI/'` put a colon-space inside the YAML value; switched to a block-scalar `run: |` matching `e2e.yml`).
- **`89096b2`** — Scope `global-setup.ts:132` thermostat EntityPicker to the modal. Both matrix legs were failing at global-setup with a Playwright strict-mode violation: `.entity-picker input` now matches two elements on `/thermostats` because `OutsideTempPicker` (added in #216) also uses `EntityPicker`. The existing `e2e.yml` is `workflow_dispatch`-only so the latent break hadn't been caught; this PR's PR-triggered workflow is the first to hit it. Scoped to `.modal .entity-picker input` and the matching `.entity-dropdown` / `.entity-option` follow-ups.

## Test plan

- [x] `npm run lint`, `format:check`, `tsc --noEmit` — clean.
- [x] `npm run test:coverage` — 154 tests pass, all thresholds met.
- [ ] CI: `Round-trip (F)` and `Round-trip (C)` jobs pass end-to-end (verified after the `89096b2` fix re-runs).
