### PR TITLE
Fix #237: hold-state gate prevents vent thrashing + overflow conditioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 - **After every push to a PR**: always update the PR body with a description of what changed, why, and a test plan. Do this every time without being asked.
 - **When reviewing a PR and pushing fixes**: push directly to the PR's own branch (not to a separate review branch), so the fixes appear in the PR diff.
+- **Every backend/API feature must have a UI control.** When you add a new `ThermostatConfig` field, system setting, or any other tunable on the API write boundary, also add a form control + helper text to the matching React page (Thermostats, Rooms, Schedules, Settings, etc.). A feature exposed only in the DB/API and not the UI is an incomplete feature — the user cannot reach it. This is a 100% rule; if you find yourself adding a knob without surfacing it, stop and add the UI before considering the work done.
 
 ## What this repo is
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ High-level guide to what Plenum does and how the pieces fit together. For instal
 
 - [Rooms & zones](./rooms-and-zones.md) — how rooms map to thermostats and what gets configured per room
 - [Cycle engine](./cycle-engine.md) — the HVAC cycle state machine: what runs every 60s tick
+- [Overflow conditioning](./overflow-conditioning.md) — where surplus air goes during the minimum-runtime hold
 - [Vent control methods](./vent-control.md) — the four ways Plenum can drive a `cover.*` entity
 - [Thermostat settings](./thermostat-settings.md) — setpoint bounds, deadband, overshoot, timeouts, safety limits
 - [Safety features](./safety.md) — short-cycle protection, outdoor-temperature cooling lockout, equipment-protection limits

--- a/docs/cycle-engine.md
+++ b/docs/cycle-engine.md
@@ -29,6 +29,19 @@ If **reconciliation interval** is set on the thermostat, the engine re-reads the
 
 A cycle running longer than **cycle timeout** hours is aborted, vents are restored, and a warning is logged. This is a safety net for misconfigured overshoot, stuck HVAC equipment, or unreachable sensors.
 
+## Minimum-runtime hold
+
+A cycle that satisfies every active room in less time than the configured **minimum cycle runtime** is held open through the rest of the runtime window rather than stopped early — short-cycling a compressor is a primary equipment-failure mode. See [Safety features](./safety.md#short-cycle-protection) for the safety reasoning.
+
+During the hold:
+
+- The cycle is flagged `in_min_runtime_hold` on its cycle-log row. Every monitoring tick checks the flag and **short-circuits the per-room close-vent loop** so vents the hold just opened cannot be re-closed on the next tick (which used to produce open/close churn through the hold window).
+- Vents for the originally-active rooms stay open so the air handler has a full duct path — no dead-heading through whichever room finished last.
+- If [overflow conditioning](./overflow-conditioning.md) is enabled, non-active rooms that can absorb the surplus air (without crossing into the opposite-direction trigger) also have their vents opened for the remainder of the hold.
+- Once the runtime clock is satisfied the cycle terminates normally, all zone vents return to the open idle state, and the off-time lockout begins.
+
+The `in_min_runtime_hold` flag is persisted, so a server restart mid-hold resumes the hold rather than starting fresh.
+
 ## What gets persisted
 
 Every cycle writes a row to the cycle log with start/end timestamps, mode, rooms involved, and per-room state snapshots (reached-target time, vent-closed time, joined-mid-cycle time). Temperature samples and setpoint changes are also captured for the cycle-history drilldown. See [Observability](./observability.md).

--- a/docs/overflow-conditioning.md
+++ b/docs/overflow-conditioning.md
@@ -73,7 +73,7 @@ See also [Safety features → Opposite-cycle prevention](./safety.md#opposite-cy
 
 ## Configuration
 
-The behaviour is controlled per-thermostat by `ThermostatConfig.overflow_during_min_runtime`, default `True`. To disable it (e.g. while diagnosing duct balance), set the field to `False` — the hold will then keep only the originally-active rooms open as it did before this feature existed.
+The behaviour is controlled per-thermostat by `ThermostatConfig.overflow_during_min_runtime`, default `True`. The toggle is exposed on the **Thermostats** page as "Redirect surplus air to other rooms during the minimum-runtime hold" — it sits next to the Min cycle runtime / Min compressor off-time fields, and is auto-disabled in the UI when Min cycle runtime is `0` (no hold ever happens, so there is nothing to redirect). Untick it to keep only the cycle's originally-active rooms open during the hold, as the system did before this feature existed.
 
 | Knob | Where | Default | Effect |
 |---|---|---|---|

--- a/docs/overflow-conditioning.md
+++ b/docs/overflow-conditioning.md
@@ -1,0 +1,93 @@
+# Overflow conditioning during minimum-runtime hold
+
+When a cycle reaches its goal early (every active room is at target before the configured **minimum cycle runtime** has elapsed), the compressor must keep running until the runtime clock is satisfied — short-cycling is a primary equipment-failure mode. The leftover conditioning still has to go somewhere. Plenum routes it through up to three tiers of fallback candidates, opening additional vents in non-active rooms that can absorb the surplus without being driven into an opposite-direction cycle.
+
+> **Scope:** This logic runs **only** during the minimum-runtime hold phase. Normal cycle operation is unchanged, and after the cycle fully terminates every zone vent returns to the open idle state regardless of which vents the hold opened.
+
+## Why not just keep the active rooms' vents open?
+
+Before this feature, the hold kept only the originally-active rooms' vents open. That works, but has two failure modes:
+
+1. **Overshoot.** The active rooms continue to receive cold (or hot) air past their target, drifting well below (or above) the setpoint. If the drift is large enough, those same rooms call for the *opposite* direction on the next cycle — the kind of oscillation the cycle engine is otherwise designed to prevent.
+2. **Restricted airflow.** With only one or two rooms' vents open and no bypass damper, duct static pressure rises and the air handler dead-heads through whichever rooms finished last.
+
+Opening additional vents in rooms that can absorb the surplus addresses both: it reduces overshoot in the active rooms, gives the air handler a larger plenum, and pre-conditions rooms toward where they'd want to be when their schedule or presence next activates.
+
+## The four tiers
+
+For each non-active room on the same thermostat, Plenum computes an **effective presence setpoint** (see "Setpoint resolution" below) and tries up to three filtering tiers in order. The first tier that yields any candidates wins; every candidate in that tier has its vent opened. If all three are empty, the system falls back to today's behaviour.
+
+Throughout, `deadband` refers to the same `ThermostatConfig.deadband` (`±°F`) that gates cycle start/stop, and `active_cycle_target_f` is the most aggressive target across the cycle's active rooms — the lowest for cooling, the highest for heating.
+
+### Tier 1 — Surplus rooms (outside deadband)
+
+A non-active room qualifies if:
+
+- **Cooling:** `room.current_temp > effective_setpoint + deadband` **and** `room.current_temp > active_cycle_target_f`
+- **Heating:** `room.current_temp < effective_setpoint − deadband` **and** `room.current_temp < active_cycle_target_f`
+
+These are clear wins: the room is past its setpoint in the same direction the system is currently conditioning, by more than the deadband, and is on the right side of the active cycle target.
+
+### Tier 2 — Inside-deadband rooms
+
+Same direction check, but without the deadband margin. Used only when Tier 1 is empty (every non-active room is already within deadband of its setpoint). This lets Plenum nudge a room a little further past its setpoint when there's no better destination — the room is still moving in the right direction, just not by much.
+
+### Tier 3 — Headroom rooms (accept pushing past goal)
+
+Used only when Tiers 1 and 2 are both empty: every non-active room is at-or-past its goal in the conditioning direction. Plenum still needs somewhere to send the surplus air, so it picks the room with the most **headroom** before its temperature would trigger an opposite-direction cycle.
+
+"Headroom" is how far the room can drift in the conditioning direction before the room itself would start calling for the opposite cycle:
+
+- **Cooling:** `headroom = room.current_temp − (effective_setpoint − deadband)` — how much the room can be cooled before it crosses the "would call for heat" threshold.
+- **Heating:** `headroom = (effective_setpoint + deadband) − room.current_temp` — how much the room can be warmed before it crosses the "would call for cool" threshold.
+
+A room with zero or negative headroom is **excluded** — pushing more conditioning into it would create the very oscillation this feature is designed to prevent. The candidate(s) with the largest positive headroom win the tier.
+
+### Tier 4 — Active rooms only (current behaviour)
+
+If even Tier 3 yields nothing (every non-active room has zero or negative headroom), Plenum falls back to today's behaviour: only the originally-active cycle rooms stay open through the rest of the hold.
+
+## Setpoint resolution
+
+For each non-active room, the **effective presence setpoint** is resolved in this order:
+
+1. The room's own presence/schedule setpoint, if configured (`Room.system_wide_temp`).
+2. The thermostat's **global presence default** (`ThermostatConfig.default_temp`), used as the fallback when a room has no per-room setpoint.
+3. If neither is configured, the room has no rankable goal. Tiers 1, 2, and 3 all skip it — there is nothing to compare against.
+
+A room without a schedule and without an active presence trigger is *not* excluded from consideration: it's just an unoccupied room with no current call for conditioning. As long as it has an effective setpoint (per the resolution above), Plenum is happy to send surplus air there.
+
+## Safety reasoning
+
+The tier system is deliberately structured so that **Plenum never pushes a room past its own goal except when there is genuinely nowhere better to send the air**, and even then only into the room with the most headroom before it would itself trigger the opposite cycle. Specifically:
+
+- Tiers 1 and 2 only ever choose rooms that are still moving toward their goal — no room is over-conditioned past its setpoint while a better destination exists.
+- Tier 3 accepts pushing past goal, but excludes any room that is already across its opposite-direction trigger. So even when the system has nowhere ideal to dump the air, it cannot drive a room into a state where the room itself would call for the opposite cycle.
+- If even Tier 3 can find no safe destination, Tier 4 falls back to the originally-active rooms — the air goes where it was already going, no new rooms are conditioned in the wrong direction.
+- Vacation mode disables overflow entirely: vacation has its own hold strategy (`vacation_hvac_mode = "range" | "single"`) and we do not interfere with it.
+- The candidate set is recomputed on **every tick** of the hold, not just once at hold entry. If a Tier 1 room cools past its setpoint during the hold, its vent is closed and another candidate (or none) takes its place.
+
+These guards mean overflow conditioning cannot, by construction, create an opposite-direction cycle on the next pass.
+
+See also [Safety features → Opposite-cycle prevention](./safety.md#opposite-cycle-prevention).
+
+## Configuration
+
+The behaviour is controlled per-thermostat by `ThermostatConfig.overflow_during_min_runtime`, default `True`. To disable it (e.g. while diagnosing duct balance), set the field to `False` — the hold will then keep only the originally-active rooms open as it did before this feature existed.
+
+| Knob | Where | Default | Effect |
+|---|---|---|---|
+| `overflow_during_min_runtime` | `ThermostatConfig` | `True` | Master switch for the tiered overflow logic. |
+| `deadband` | `ThermostatConfig` | `0.5 °F` | Reused as the Tier 1 margin and the Tier 3 opposite-trigger margin. |
+| `default_temp` | `ThermostatConfig` | unset | Fallback presence setpoint used when a room has no own setpoint. |
+| `Room.system_wide_temp` | `Room` | unset | Per-room presence setpoint; takes priority over the thermostat default. |
+| `min_cycle_runtime_min` | `ThermostatConfig` | `0` (disabled) | Without this, the hold phase never starts and overflow never runs. |
+
+## Observability
+
+Every overflow open/close is recorded in the cycle vent-event stream (visible on the Logs page cycle-detail view):
+
+- `opened_overflow_hold` — reason includes the tier (`tier1`/`tier2`/`tier3`), the room's current temperature, and (for tier 3) the computed headroom.
+- `closed_overflow_hold` — reason notes that the room is no longer a candidate.
+
+An `INFO`-level event-log entry is also written when overflow first opens a non-active room, naming the tier used and the rooms involved.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -17,6 +17,19 @@ Rapidly stopping and restarting a compressor — *short-cycling* — is one of t
 
 When every room in a cycle reaches its target before the minimum runtime has elapsed, Plenum does **not** stop the HVAC. It re-opens the vents of every room that was part of the cycle so the air handler keeps a full duct path — never dead-heading airflow through a single room — and the small unavoidable overshoot is spread evenly. The cycle completes normally once the runtime clock is satisfied.
 
+The hold is tracked by a persisted flag on the cycle log (`in_min_runtime_hold`). While the flag is set, the engine's per-tick monitoring loop **does not close vents on rooms that have hit their target** — without this gate, the close loop would re-close vents the hold just re-opened on the very next 60-second tick, producing open/close churn through the entire hold window. The flag survives a server restart, so a mid-hold reboot resumes the hold rather than ending the cycle.
+
+When [overflow conditioning](./overflow-conditioning.md) is enabled (the default), the hold additionally opens vents in non-active rooms that can absorb the surplus air without crossing into the opposite-direction trigger. See the overflow doc for the tiering and the opposite-cycle prevention discussion.
+
+### Opposite-cycle prevention
+
+A room over-conditioned past its setpoint can swing far enough that it then calls for the *opposite* direction on the next pass — pushing the system into the heat/cool oscillation the cycle engine otherwise prevents. Two design rules guard against this:
+
+1. **The hold gate never closes a satisfied room's vent while the hold is active.** Combined with the existing "vent re-opened on hold entry" behaviour, this means the conditioning is always distributed across all originally-active rooms, never dumped into one and dead-heading the duct system.
+2. **Overflow conditioning excludes any candidate room whose temperature is already across its opposite-direction trigger.** A room that's already across `setpoint − deadband` (cooling) or `setpoint + deadband` (heating) is denied surplus air — pushing into it is exactly what creates an opposite cycle. The tier-3 fallback only runs when at least one non-active room still has positive headroom; if none do, the hold reverts to today's behaviour (active rooms only).
+
+Together these mean Plenum cannot, by construction, create an opposite-direction cycle as a *side effect* of holding a cycle open. (A genuine opposite call from a room that legitimately needs the other direction is still detected on the next tick — that's the cycle engine's primary job and is unchanged.)
+
 ### Off-time lockout
 
 While the off-time lockout is active, the engine refuses to start a new cycle and writes a warning to the event log noting how long remains. An already-running cycle is never interrupted by the lockout.

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -757,6 +757,7 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "total_vents_count",
         "has_bypass_damper",
         "min_open_vents_fraction",
+        "overflow_during_min_runtime",
     ):
         if field in body:
             if field in ("min_setpoint", "max_setpoint"):
@@ -794,6 +795,8 @@ async def create_thermostat(request: web.Request) -> web.Response:
                 if not isinstance(val, (int, float)) or not (0 < val <= 1):
                     return error("min_open_vents_fraction must be > 0 and ≤ 1")
                 setattr(tc, field, float(val))
+            elif field == "overflow_during_min_runtime":
+                setattr(tc, field, bool(body[field]))
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -860,6 +863,7 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "total_vents_count",
         "has_bypass_damper",
         "min_open_vents_fraction",
+        "overflow_during_min_runtime",
     ):
         if field in body:
             if field in ("min_setpoint", "max_setpoint"):
@@ -897,6 +901,8 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
                 if not isinstance(val, (int, float)) or not (0 < val <= 1):
                     return error("min_open_vents_fraction must be > 0 and ≤ 1")
                 setattr(tc, field, float(val))
+            elif field == "overflow_during_min_runtime":
+                setattr(tc, field, bool(body[field]))
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -99,7 +99,8 @@ CREATE TABLE IF NOT EXISTS thermostat_configs (
     -- "≥1 open" default and the Thermostats-page banner nudges the user.
     total_vents_count INTEGER,
     has_bypass_damper INTEGER NOT NULL DEFAULT 0,
-    min_open_vents_fraction REAL NOT NULL DEFAULT 0.333
+    min_open_vents_fraction REAL NOT NULL DEFAULT 0.333,
+    overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS room_overrides (
@@ -129,7 +130,8 @@ CREATE TABLE IF NOT EXISTS cycle_logs (
     vents_at_start TEXT,
     vents_at_end TEXT,
     outside_temp_at_start REAL,
-    outside_temp_at_end REAL
+    outside_temp_at_end REAL,
+    in_min_runtime_hold INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS room_cycle_states (
@@ -379,6 +381,12 @@ _MIGRATIONS = [
     # had ``min_open_vents`` defaulting to 1, which matches the transitional
     # fallback the engine uses when ``total_vents_count`` is NULL.
     "ALTER TABLE thermostat_configs DROP COLUMN min_open_vents",
+    # Vent-thrashing / overflow conditioning (Issue #237). The hold flag lets
+    # the engine remember across ticks that a cycle is past its goal but
+    # waiting for min_cycle_runtime_min to elapse — the per-room close-vent
+    # loop gates on this to stop reopened vents from flapping back closed.
+    "ALTER TABLE cycle_logs ADD COLUMN in_min_runtime_hold INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE thermostat_configs ADD COLUMN overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1",
 ]
 
 
@@ -691,6 +699,9 @@ def _row_to_tc(row) -> ThermostatConfig:
         min_open_vents_fraction=row["min_open_vents_fraction"]
         if "min_open_vents_fraction" in keys
         else 0.333,
+        overflow_during_min_runtime=bool(row["overflow_during_min_runtime"])
+        if "overflow_during_min_runtime" in keys
+        else True,
     )
 
 
@@ -701,8 +712,9 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             max_vent_closed_min,overshoot_delta,cycle_timeout_hours,
             reconciliation_interval_min,vacation_hvac_mode,
             min_cycle_runtime_min,min_cycle_offtime_min,cooling_lockout_below_f,
-            total_vents_count,has_bypass_damper,min_open_vents_fraction)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            total_vents_count,has_bypass_damper,min_open_vents_fraction,
+            overflow_during_min_runtime)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -719,7 +731,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              cooling_lockout_below_f=excluded.cooling_lockout_below_f,
              total_vents_count=excluded.total_vents_count,
              has_bypass_damper=excluded.has_bypass_damper,
-             min_open_vents_fraction=excluded.min_open_vents_fraction
+             min_open_vents_fraction=excluded.min_open_vents_fraction,
+             overflow_during_min_runtime=excluded.overflow_during_min_runtime
         """,
         (
             tc.thermostat_entity_id,
@@ -739,6 +752,7 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             tc.total_vents_count,
             int(tc.has_bypass_damper),
             tc.min_open_vents_fraction,
+            int(tc.overflow_during_min_runtime),
         ),
     )
     await conn.commit()
@@ -942,7 +956,19 @@ def _row_to_cycle_log(r) -> CycleLog:
         vents_at_end=_get("vents_at_end"),
         outside_temp_at_start=_get("outside_temp_at_start"),
         outside_temp_at_end=_get("outside_temp_at_end"),
+        in_min_runtime_hold=bool(_get("in_min_runtime_hold") or 0),
     )
+
+
+async def set_cycle_log_min_runtime_hold(
+    conn: aiosqlite.Connection, cycle_id: str, in_hold: bool
+) -> None:
+    """Persist the minimum-runtime hold flag on a running cycle (Issue #237)."""
+    await conn.execute(
+        "UPDATE cycle_logs SET in_min_runtime_hold=? WHERE id=?",
+        (1 if in_hold else 0, cycle_id),
+    )
+    await conn.commit()
 
 
 async def get_open_cycle_logs(

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -106,6 +106,13 @@ class CycleEngine:
         # from the Settings page take effect on the next tick.
         self._stale_after_min: float = SENSOR_STALE_AFTER_MIN
 
+        # Overflow-conditioning room set (Issue #237): non-active rooms whose
+        # vents we opened during the current minimum-runtime hold so the
+        # surplus conditioned air can be absorbed somewhere other than the
+        # already-satisfied cycle rooms. Recomputed every tick during the hold;
+        # cleared at cycle termination.
+        self._overflow_room_ids: set[str] = set()
+
     # ------------------------------------------------------------------
     # Public
     # ------------------------------------------------------------------
@@ -997,6 +1004,23 @@ class CycleEngine:
             and self._all_active_rooms_satisfied(hvac_mode)
         ):
             await self._enter_min_runtime_hold(conn)
+            await self._apply_overflow_during_hold(conn, hvac_mode, tc)
+            return
+
+        # Issue #237: once a cycle is in the minimum-runtime hold, the per-room
+        # close-vent loop below must NOT run. The hold has just re-opened those
+        # vents (and possibly opened overflow-destination vents in non-active
+        # rooms); the close loop sees the satisfied active rooms as "at target,
+        # vent_closed_at is None" and would close them again next tick,
+        # producing open/close churn until the hold expires.
+        if self._cycle_log is not None and self._cycle_log.in_min_runtime_hold:
+            if self._cycle_runtime_satisfied(tc):
+                # Hold satisfied — terminate even if one of the rooms has
+                # drifted off target during the hold (the cycle has done its
+                # minimum runtime; equilibrium will settle out idle).
+                await self._terminate_cycle(conn)
+                return
+            await self._apply_overflow_during_hold(conn, hvac_mode, tc)
             return
 
         all_at_target = True
@@ -1203,6 +1227,9 @@ class CycleEngine:
         self._active_rooms = {}
         self._room_cycle_states = {}
         self._room_vents = {}
+        # Clear the in-memory overflow set (Issue #237). All zone vents are
+        # re-opened on termination so any per-room overflow state is moot.
+        self._overflow_room_ids = set()
         # Start the compressor off-time lockout clock (Issue #208). Both normal
         # termination and abort stop the HVAC, so both arm the lockout.
         self._last_cycle_ended_at = datetime.now(UTC)
@@ -1341,6 +1368,9 @@ class CycleEngine:
         self._active_rooms = {}
         self._room_cycle_states = {}
         self._room_vents = {}
+        # Clear the in-memory overflow set (Issue #237). All zone vents are
+        # re-opened on termination so any per-room overflow state is moot.
+        self._overflow_room_ids = set()
         # Start the compressor off-time lockout clock (Issue #208). Both normal
         # termination and abort stop the HVAC, so both arm the lockout.
         self._last_cycle_ended_at = datetime.now(UTC)
@@ -2591,12 +2621,26 @@ class CycleEngine:
         cycle — rather than dumped into whichever room finished last, which
         would dead-head the system through a single vent.
 
-        Idempotent: once every cycle vent is open again this is a no-op until
-        the runtime clock expires and the cycle terminates normally. Idle and
-        opposite-direction rooms are deliberately left closed — the HVAC is
-        still running, so opening them would waste conditioning or drive a
-        room the wrong way.
+        Persists ``CycleLog.in_min_runtime_hold = True`` (Issue #237) so the
+        per-room close-vent loop on later ticks skips the rooms whose vents
+        the hold just opened — without the flag the close loop re-closes them
+        on the next tick, producing open/close churn through the hold window.
+
+        Idle and opposite-direction rooms are deliberately left closed by this
+        method — the actual overflow-conditioning decision (which idle rooms
+        can absorb the surplus air without crossing into an opposite cycle)
+        runs through ``_apply_overflow_during_hold`` on every tick of the hold.
         """
+        # Mark the cycle as held even if no vents need re-opening (the flag
+        # still gates close-vent behaviour on later ticks). Idempotent — the
+        # cycle stays in hold until termination.
+        if self._cycle_log is not None and not self._cycle_log.in_min_runtime_hold:
+            self._cycle_log.in_min_runtime_hold = True
+            try:
+                await db.set_cycle_log_min_runtime_hold(conn, self._cycle_log.id, True)
+            except Exception as exc:
+                log.warning("Failed to persist in_min_runtime_hold flag: %s", exc)
+
         reopened: list[str] = []
         for room_id in self._active_rooms:
             rcs = self._room_cycle_states.get(room_id)
@@ -2644,6 +2688,148 @@ class CycleEngine:
                         "reopened_rooms": room_names,
                     },
                 )
+
+    async def _apply_overflow_during_hold(
+        self,
+        conn: aiosqlite.Connection,
+        hvac_mode: str,
+        tc: ThermostatConfig,
+    ) -> None:
+        """Open non-active rooms' vents during the minimum-runtime hold to
+        absorb surplus conditioned air without overshooting the active rooms
+        (Issue #237).
+
+        Runs on every tick of the hold so a candidate that drifts past its
+        goal gets its vent closed and a different room takes its place. The
+        candidate selection (tiered) is in ``room_manager.get_overflow_candidates``.
+
+        No-op when the feature is disabled, vacation mode is active, or the
+        candidate algorithm finds no suitable destination — in which case the
+        previously-active cycle rooms continue to absorb the surplus on their
+        own, which is the pre-#237 behaviour.
+        """
+        if not tc.overflow_during_min_runtime:
+            return
+        in_vacation = bool(self._get_vacation_mode and self._get_vacation_mode())
+        if in_vacation:
+            # Vacation hold is a separate state machine; do not change vents.
+            return
+
+        # "Active cycle target" = the most aggressive target across active
+        # rooms (lowest for cooling, highest for heating). That's the
+        # temperature the thermostat is currently driving toward and the
+        # closest proxy we have for the direction the supply air will push a
+        # candidate room.
+        active_targets = [
+            rcs.target_temp
+            for rid, rcs in self._room_cycle_states.items()
+            if rid in self._active_rooms
+        ]
+        if not active_targets:
+            return
+        active_cycle_target = min(active_targets) if hvac_mode == "cooling" else max(active_targets)
+
+        try:
+            from .room_manager import get_overflow_candidates
+        except Exception as exc:
+            log.debug("Failed to import get_overflow_candidates: %s", exc)
+            return
+
+        candidates = await get_overflow_candidates(
+            conn,
+            self.thermostat_entity_id,
+            hvac_mode=hvac_mode,
+            active_room_ids=set(self._active_rooms.keys()),
+            active_cycle_target_f=active_cycle_target,
+            deadband_f=tc.deadband,
+            in_vacation=in_vacation,
+            get_avg_temp=self._get_avg_temp,
+        )
+        desired_ids = {c.room.id for c in candidates}
+
+        # Close any previously-opened overflow vents that are no longer
+        # candidates (they crossed their setpoint, or another room won the
+        # tier on this tick).
+        to_close = self._overflow_room_ids - desired_ids
+        for room_id in to_close:
+            vents = await db.get_room_vents(conn, room_id)
+            if not vents:
+                continue
+            for v in vents:
+                try:
+                    await self._vent._invoke_close(v)
+                except Exception as exc:
+                    log.debug("Failed to close overflow vent %s: %s", v.entity_id, exc)
+            if self._cycle_log:
+                ts = datetime.now(UTC)
+                for v in vents:
+                    try:
+                        await db.insert_cycle_vent_event(
+                            conn,
+                            self._cycle_log.id,
+                            ts,
+                            v.entity_id,
+                            room_id,
+                            "closed_overflow_hold",
+                            "overflow room no longer a candidate",
+                        )
+                    except Exception as exc:
+                        log.debug("Failed to record closed_overflow_hold event: %s", exc)
+
+        # Open vents for newly-selected overflow candidates.
+        to_open = desired_ids - self._overflow_room_ids
+        for c in candidates:
+            if c.room.id not in to_open:
+                continue
+            vents = await db.get_room_vents(conn, c.room.id)
+            if not vents:
+                continue
+            await self._vent.open_room_vents(vents)
+            if self._cycle_log:
+                ts = datetime.now(UTC)
+                tier_label = f"tier{c.tier}"
+                reason_extra = f", headroom={c.headroom:.1f}°F" if c.headroom is not None else ""
+                for v in vents:
+                    try:
+                        await db.insert_cycle_vent_event(
+                            conn,
+                            self._cycle_log.id,
+                            ts,
+                            v.entity_id,
+                            c.room.id,
+                            "opened_overflow_hold",
+                            f"{tier_label}: cur={c.current_temp:.1f}°F{reason_extra}",
+                        )
+                    except Exception as exc:
+                        log.debug("Failed to record opened_overflow_hold event: %s", exc)
+
+        self._overflow_room_ids = desired_ids
+
+        if to_open or to_close:
+            tier_used = candidates[0].tier if candidates else None
+            log.info(
+                "Overflow hold for %s: tier=%s, open=%s, close=%s",
+                self.thermostat_entity_id,
+                tier_used,
+                sorted(to_open),
+                sorted(to_close),
+            )
+            if self._logger and candidates:
+                opened_names = [c.room.name for c in candidates if c.room.id in to_open]
+                if opened_names:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Overflow conditioning (tier {tier_used}) opened "
+                        f"{opened_names} during minimum-runtime hold to absorb surplus "
+                        f"{'cooling' if hvac_mode == 'cooling' else 'heating'}",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "tier": tier_used,
+                            "rooms": opened_names,
+                            "active_cycle_target": active_cycle_target,
+                        },
+                    )
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -11,6 +11,7 @@ and at what target temperature, applying priority order:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 
@@ -347,6 +348,141 @@ async def handle_presence_event(
         expires_at.isoformat(),
     )
     return not was_active
+
+
+@dataclass
+class OverflowCandidate:
+    """A non-active room evaluated as a possible dumping ground for surplus
+    conditioned air during a cycle's minimum-runtime hold (Issue #237)."""
+
+    room: Room
+    current_temp: float
+    effective_setpoint: float | None  # None when neither room nor thermostat default is set
+    tier: int  # 1=surplus, 2=inside deadband, 3=headroom
+    headroom: float | None = None  # populated only for tier 3
+
+
+async def get_overflow_candidates(
+    conn: aiosqlite.Connection,
+    thermostat_entity_id: str,
+    *,
+    hvac_mode: str,
+    active_room_ids: set[str],
+    active_cycle_target_f: float,
+    deadband_f: float,
+    in_vacation: bool,
+    get_avg_temp: Callable[[Room], float | None],
+) -> list[OverflowCandidate]:
+    """Return non-active rooms whose vents should be opened to absorb the
+    surplus conditioned air during the minimum-runtime hold (Issue #237).
+
+    Tries up to three tiers and returns the first non-empty result:
+      1. Rooms past their effective presence setpoint by more than ``deadband_f``.
+      2. Rooms past their effective presence setpoint but within the deadband.
+      3. Rooms already at-or-past goal: pick the one with the largest headroom
+         before triggering an opposite-direction cycle.
+
+    Returns ``[]`` in vacation mode or when no tier yields a candidate — the
+    caller falls back to today's behaviour (hold only the active-cycle rooms).
+    """
+    if in_vacation:
+        return []
+    if hvac_mode not in ("cooling", "heating"):
+        return []
+
+    rooms = await db.get_rooms_for_thermostat(conn, thermostat_entity_id)
+    tc = await db.get_thermostat_config(conn, thermostat_entity_id)
+
+    pool: list[OverflowCandidate] = []
+    for room in rooms:
+        if room.id in active_room_ids:
+            continue
+        avg = get_avg_temp(room)
+        if avg is None:
+            continue
+        eff = room.system_wide_temp if room.system_wide_temp is not None else tc.default_temp
+        pool.append(
+            OverflowCandidate(
+                room=room,
+                current_temp=avg,
+                effective_setpoint=eff,
+                tier=0,
+            )
+        )
+
+    if not pool:
+        return []
+
+    # Tier 1: room is past its setpoint by more than the deadband AND the
+    # supply air is still moving it the right way.
+    tier1: list[OverflowCandidate] = []
+    for c in pool:
+        if c.effective_setpoint is None:
+            continue
+        if hvac_mode == "cooling":
+            if (
+                c.current_temp > c.effective_setpoint + deadband_f
+                and c.current_temp > active_cycle_target_f
+            ):
+                tier1.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 1))
+        else:  # heating
+            if (
+                c.current_temp < c.effective_setpoint - deadband_f
+                and c.current_temp < active_cycle_target_f
+            ):
+                tier1.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 1))
+    if tier1:
+        return tier1
+
+    # Tier 2: same direction check but inside the deadband.
+    tier2: list[OverflowCandidate] = []
+    for c in pool:
+        if c.effective_setpoint is None:
+            continue
+        if hvac_mode == "cooling":
+            if c.current_temp > c.effective_setpoint and c.current_temp > active_cycle_target_f:
+                tier2.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 2))
+        else:
+            if c.current_temp < c.effective_setpoint and c.current_temp < active_cycle_target_f:
+                tier2.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 2))
+    if tier2:
+        return tier2
+
+    # Tier 3: nothing qualifies in the conditioning direction — accept pushing
+    # past goal, but only into the room with the most headroom before it would
+    # trigger the OPPOSITE cycle. Rooms with no ranking signal (no per-room and
+    # no thermostat default) are not eligible because we cannot compute their
+    # opposite-direction trigger.
+    headroom_pool: list[OverflowCandidate] = []
+    for c in pool:
+        if c.effective_setpoint is None:
+            continue
+        if hvac_mode == "cooling":
+            # In cooling we are pushing the room cooler; the opposite trigger
+            # is its "would call for heat" threshold = setpoint - deadband.
+            opposite_trigger = c.effective_setpoint - deadband_f
+            headroom = c.current_temp - opposite_trigger
+        else:
+            # In heating we are pushing the room warmer; the opposite trigger
+            # is its "would call for cool" threshold = setpoint + deadband.
+            opposite_trigger = c.effective_setpoint + deadband_f
+            headroom = opposite_trigger - c.current_temp
+        if headroom > 0:
+            headroom_pool.append(
+                OverflowCandidate(
+                    room=c.room,
+                    current_temp=c.current_temp,
+                    effective_setpoint=c.effective_setpoint,
+                    tier=3,
+                    headroom=headroom,
+                )
+            )
+    if headroom_pool:
+        max_hr = max(c.headroom for c in headroom_pool if c.headroom is not None)
+        # Floating-point tie tolerance keeps near-equal headrooms grouped.
+        return [c for c in headroom_pool if c.headroom is not None and c.headroom >= max_hr - 1e-9]
+
+    return []
 
 
 async def expire_holdovers(

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -176,6 +176,12 @@ class ThermostatConfig:
     # None = disabled. NOTE: heat pumps are not supported, so there is no
     # corresponding heating lockout.
     cooling_lockout_below_f: float | None = None
+    # Overflow conditioning during minimum-runtime hold (Issue #237). When True
+    # and a cycle is held open past its goal to satisfy min_cycle_runtime_min,
+    # also open vents in non-active rooms that can absorb the surplus air
+    # without crossing into their opposite-direction trigger. Disabled in
+    # vacation mode regardless of this setting. See docs/overflow-conditioning.md.
+    overflow_during_min_runtime: bool = True
 
 
 @dataclass
@@ -219,6 +225,12 @@ class CycleLog:
     vents_at_end: str | None = None
     outside_temp_at_start: float | None = None  # °F, NULL if entity unset/unreadable
     outside_temp_at_end: float | None = None
+    # Minimum-runtime hold state (Issue #237). Set True once a cycle has hit
+    # its goal but is being held open to satisfy min_cycle_runtime_min. While
+    # True the per-room close-vent loop is short-circuited so vents the hold
+    # opened do not flap back closed on the next tick. Cleared implicitly when
+    # the cycle ends.
+    in_min_runtime_hold: bool = False
 
     @classmethod
     def create(cls, thermostat_entity_id: str, mode: str, rooms_json: str) -> CycleLog:

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1322,6 +1322,235 @@ class TestEnterMinRuntimeHold:
         engine._ha.open_cover.assert_not_awaited()
         await conn.close()
 
+    @pytest.mark.asyncio
+    async def test_persists_in_min_runtime_hold_flag(self):
+        """Issue #237: the hold flag must be persisted on the cycle log so the
+        next tick recognises we are in hold and skips the close-vent loop."""
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        assert engine._cycle_log is not None
+        assert engine._cycle_log.in_min_runtime_hold is False
+
+        await engine._enter_min_runtime_hold(conn)
+
+        # In-memory flag
+        assert engine._cycle_log.in_min_runtime_hold is True
+        # Persisted to DB
+        reloaded = await db.get_cycle_log(conn, cycle.id)
+        assert reloaded is not None
+        assert reloaded.in_min_runtime_hold is True
+        await conn.close()
+
+
+class TestMinRuntimeHoldGate:
+    """Issue #237: while a cycle is in the min-runtime hold the per-room
+    close-vent loop must be short-circuited, otherwise vents the hold has just
+    re-opened are re-closed on the next tick (the original thrashing bug)."""
+
+    @pytest.mark.asyncio
+    async def test_hold_gate_skips_close_loop(self):
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        # Force the hold state directly: cycle is satisfied but min runtime
+        # has not elapsed.
+        engine._cycle_log.in_min_runtime_hold = True
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        rcs = RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=74.0)
+        engine._room_cycle_states = {"r1": rcs}
+        # Active room reads at-or-below target (would normally close the vent).
+        engine._sensor_map = {"r1": ["s_r1"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            73.5 if eid == "s_r1" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        # Cycle just started a moment ago so runtime is NOT satisfied.
+        engine._cycle_log.started_at = datetime.now(UTC) - timedelta(seconds=30)
+        from backend import db as _db
+
+        await _db.upsert_thermostat_config(conn, tc)
+
+        engine._ha.close_cover.reset_mock()
+        await engine._monitor_rooms(conn, "cooling")
+
+        # The hold gate must prevent any close calls.
+        engine._ha.close_cover.assert_not_awaited()
+        # Vent state untouched.
+        assert rcs.vent_closed_at is None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_hold_terminates_cycle_once_runtime_satisfied(self):
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._cycle_log.in_min_runtime_hold = True
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=74.0)
+        }
+        engine._sensor_map = {"r1": ["s_r1"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            73.5 if eid == "s_r1" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        # Cycle started 15 min ago so the hold has now satisfied min runtime.
+        engine._cycle_log.started_at = datetime.now(UTC) - timedelta(minutes=15)
+        from backend import db as _db
+
+        await _db.upsert_thermostat_config(conn, tc)
+
+        await engine._monitor_rooms(conn, "cooling")
+
+        # Cycle should now be terminated (state IDLE, cycle_log cleared).
+        assert engine._state == CycleState.IDLE
+        assert engine._cycle_log is None
+        await conn.close()
+
+
+class TestOverflowDuringHold:
+    """Issue #237: during the min-runtime hold, non-active rooms that can
+    absorb the surplus conditioning have their vents opened by
+    ``_apply_overflow_during_hold``."""
+
+    @pytest.mark.asyncio
+    async def test_overflow_opens_tier1_candidate_vent(self):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        # Add an idle (non-active) candidate room: Office.
+        office = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        office.id = "r_office"
+        office.system_wide_temp = 70.0
+        await db.upsert_room(conn, office)
+        office_vent = RoomVent.create("r_office", "cover.vent_office")
+        await db.add_room_vent(conn, office_vent)
+        # Engine still treats only r1 as active.
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=68.0)
+        }
+        engine._sensor_map = {"r_office": ["s_office"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            75.0 if eid == "s_office" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        opened = [c.args[0] for c in engine._ha.open_cover.await_args_list]
+        assert "cover.vent_office" in opened
+        assert "r_office" in engine._overflow_room_ids
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_overflow_disabled_skips_open(self):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        office = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        office.id = "r_office"
+        office.system_wide_temp = 70.0
+        await db.upsert_room(conn, office)
+        await db.add_room_vent(conn, RoomVent.create("r_office", "cover.vent_office"))
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=68.0)
+        }
+        engine._sensor_map = {"r_office": ["s_office"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            75.0 if eid == "s_office" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10, overflow_during_min_runtime=False)
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        engine._ha.open_cover.assert_not_awaited()
+        assert engine._overflow_room_ids == set()
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_overflow_closes_room_that_is_no_longer_a_candidate(self):
+        """A room previously opened as overflow must be closed when it drifts
+        past its setpoint or another room outranks it."""
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        office = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        office.id = "r_office"
+        office.system_wide_temp = 70.0
+        await db.upsert_room(conn, office)
+        await db.add_room_vent(conn, RoomVent.create("r_office", "cover.vent_office"))
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=68.0)
+        }
+        engine._sensor_map = {"r_office": ["s_office"]}
+        # First tick: office at 75 — qualifies for Tier 1.
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            75.0 if eid == "s_office" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        await db.upsert_thermostat_config(conn, tc)
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+        assert "r_office" in engine._overflow_room_ids
+
+        # Next tick: office cooled below its opposite trigger — no longer qualifies.
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            65.0 if eid == "s_office" else None
+        )
+        engine._ha.close_cover.reset_mock()
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        # The overflow vent must be closed and removed from the tracking set.
+        closed_args = [c.args[0] for c in engine._ha.close_cover.await_args_list]
+        assert "cover.vent_office" in closed_args
+        assert "r_office" not in engine._overflow_room_ids
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_overflow_skipped_in_vacation_mode(self):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._get_vacation_mode = lambda: True
+        office = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        office.id = "r_office"
+        office.system_wide_temp = 70.0
+        await db.upsert_room(conn, office)
+        await db.add_room_vent(conn, RoomVent.create("r_office", "cover.vent_office"))
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=68.0)
+        }
+        engine._sensor_map = {"r_office": ["s_office"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            75.0 if eid == "s_office" else None
+        )
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        engine._ha.open_cover.assert_not_awaited()
+        assert engine._overflow_room_ids == set()
+        await conn.close()
+
 
 class TestCoolingLockoutState:
     """_cooling_lockout_state — outdoor-temperature cooling lockout (Issue #209)."""

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -23,6 +23,7 @@ from backend.engine.room_manager import (
     _schedule_active,
     expire_holdovers,
     get_active_rooms,
+    get_overflow_candidates,
     get_room_active_status,
     handle_presence_event,
     schedules_overlap,
@@ -563,4 +564,296 @@ class TestGetRoomActiveStatus:
         # holdover_hours=2.0, 30 min in → ~90 min left (± tick jitter)
         assert status["ends_in_seconds"] is not None
         assert 5000 < status["ends_in_seconds"] < 5500
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# get_overflow_candidates: tiered selection for min-runtime hold (Issue #237)
+# ---------------------------------------------------------------------------
+
+
+class TestGetOverflowCandidates:
+    """Surplus-conditioning candidate selection during a cycle's minimum-
+    runtime hold. Up to three tiers are tried; the first non-empty wins."""
+
+    async def _setup(
+        self,
+        *,
+        rooms: list[tuple[str, str, float | None]],  # (id, name, system_wide_temp)
+        thermostat_default_temp: float | None = None,
+    ) -> aiosqlite.Connection:
+        conn = await _setup_db()
+        # Persist a thermostat config so default_temp fallback works.
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_ID,
+            default_temp=thermostat_default_temp,
+            deadband=0.5,
+        )
+        await db.upsert_thermostat_config(conn, tc)
+        for rid, name, swt in rooms:
+            r = Room(
+                id=rid,
+                name=name,
+                thermostat_entity_id=THERMO_ID,
+                system_wide_temp=swt,
+            )
+            await db.upsert_room(conn, r)
+        return conn
+
+    @staticmethod
+    def _temp_map(mapping: dict[str, float | None]):
+        def _get(room: Room) -> float | None:
+            return mapping.get(room.id)
+
+        return _get
+
+    @pytest.mark.asyncio
+    async def test_vacation_short_circuits_to_empty(self):
+        conn = await self._setup(
+            rooms=[("r1", "Office", 70.0)],
+            thermostat_default_temp=None,
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=True,
+            get_avg_temp=self._temp_map({"r1": 75.0}),
+        )
+        assert out == []
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_active_rooms_excluded_from_pool(self):
+        conn = await self._setup(rooms=[("r1", "Office", 70.0)])
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids={"r1"},
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 75.0}),
+        )
+        # r1 was active in the cycle — must not appear as overflow.
+        assert out == []
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tier1_cooling_outside_deadband(self):
+        conn = await self._setup(
+            rooms=[("r1", "Office", 70.0), ("r2", "Gym", 72.0)],
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # r1 is at 71.0 (> 70.0 + 0.5), r2 at 73.0 (> 72.0 + 0.5).
+            get_avg_temp=self._temp_map({"r1": 71.0, "r2": 73.0}),
+        )
+        assert sorted(c.room.id for c in out) == ["r1", "r2"]
+        assert all(c.tier == 1 for c in out)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tier1_heating_mirror(self):
+        conn = await self._setup(
+            rooms=[("r1", "Office", 70.0)],
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="heating",
+            active_room_ids=set(),
+            active_cycle_target_f=72.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # r1 at 68.0 (< 70.0 - 0.5) and < active_cycle_target 72.
+            get_avg_temp=self._temp_map({"r1": 68.0}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 1
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tier2_when_no_tier1_qualifier(self):
+        conn = await self._setup(
+            rooms=[("r1", "Office", 70.0)],
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # 70.2: > setpoint 70 but inside deadband (≤ 70 + 0.5). > active target.
+            get_avg_temp=self._temp_map({"r1": 70.2}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 2
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tier3_picks_room_with_most_headroom(self):
+        """Tiers 1 & 2 empty: every non-active room is already at-or-past goal
+        in the conditioning direction. Tier 3 picks the room with the most
+        headroom before it would trigger the opposite cycle."""
+        conn = await self._setup(
+            rooms=[
+                ("r1", "Office", 70.0),  # at 69.5, headroom = 69.5 - (70 - 0.5) = 0
+                ("r2", "Gym", 72.0),  # at 71.6, headroom = 71.6 - 71.5 = 0.1
+                ("r3", "Den", 74.0),  # at 73.9, headroom = 73.9 - 73.5 = 0.4
+            ],
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            # active_cycle_target > all room temps, so Tiers 1 & 2 yield nothing.
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 69.5, "r2": 71.6, "r3": 73.9}),
+        )
+        assert [c.room.id for c in out] == ["r3"]
+        assert out[0].tier == 3
+        assert out[0].headroom is not None
+        assert out[0].headroom == pytest.approx(0.4)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_tier3_excludes_rooms_past_opposite_trigger(self):
+        """A room already at-or-past its opposite-direction trigger must not
+        receive more conditioning (would force an opposite cycle)."""
+        conn = await self._setup(
+            rooms=[
+                ("r1", "Office", 70.0),  # at 69.0 — already below heat trigger (69.5)
+            ],
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 69.0}),
+        )
+        # 69.0 < 70 - 0.5 = 69.5 — no headroom in cooling direction.
+        # Tier 4 falls back to empty (caller keeps only active-cycle rooms).
+        assert out == []
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_room_falls_back_to_thermostat_default_temp(self):
+        """Room with no per-room setpoint uses the thermostat's global one."""
+        conn = await self._setup(
+            rooms=[("r1", "Bedroom", None)],
+            thermostat_default_temp=70.0,
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 72.0}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 1
+        assert out[0].effective_setpoint == 70.0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_room_with_no_setpoint_excluded_from_rankable_tiers(self):
+        """Room with no per-room AND no thermostat default cannot rank in
+        Tiers 1/2/3 (no setpoint → no goal to compare against)."""
+        conn = await self._setup(
+            rooms=[("r1", "Mystery", None)],
+            thermostat_default_temp=None,
+        )
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 78.0}),
+        )
+        assert out == []
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_sensor_room_skipped(self):
+        """Rooms with no temperature reading cannot be evaluated."""
+        conn = await self._setup(rooms=[("r1", "Office", 70.0)])
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": None}),
+        )
+        assert out == []
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_room_cooler_than_active_target_falls_through_to_tier3(self):
+        """Tier 1/2 require ``room.current_temp > active_cycle_target`` (cooling)
+        as a conservative supply-direction proxy. A room that's past its own
+        setpoint but already cooler than the active cycle target fails that
+        check, but Tier 3 may still pick it via headroom — when nothing
+        better exists Tier 3 accepts pushing past goal."""
+        conn = await self._setup(rooms=[("r1", "Bedroom", 70.0)])
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=72.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # 71 > 70+0.5 (Tier 1 setpoint check passes) BUT 71 < 72
+            # (Tier 1 active-target gate fails) — falls through to Tier 3,
+            # where headroom = 71 - (70 - 0.5) = 1.5.
+            get_avg_temp=self._temp_map({"r1": 71.0}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 3
+        assert out[0].headroom == pytest.approx(1.5)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_unknown_hvac_mode_returns_empty(self):
+        conn = await self._setup(rooms=[("r1", "Office", 70.0)])
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="off",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            get_avg_temp=self._temp_map({"r1": 75.0}),
+        )
+        assert out == []
         await conn.close()

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.11.2",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.11.2",
+      "version": "0.12.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -90,6 +90,11 @@ export interface ThermostatConfig {
   // min_open_vents_fraction: share of total_vents_count that must stay open.
   //   Default 0.333 (one third).  Configurable per thermostat.
   min_open_vents_fraction: number;
+  // Overflow conditioning during the minimum-runtime hold (Issue #237). When
+  // true, the hold also opens vents in non-active rooms that can absorb the
+  // surplus conditioned air without crossing into the opposite-direction
+  // trigger. Disabled in vacation mode regardless of this flag.
+  overflow_during_min_runtime: boolean;
 }
 
 export interface VacationMode {

--- a/smart_vent/frontend/src/components/AirflowConfigBanner.test.tsx
+++ b/smart_vent/frontend/src/components/AirflowConfigBanner.test.tsx
@@ -24,6 +24,7 @@ function tc(over: Partial<api.ThermostatConfig> = {}): api.ThermostatConfig {
     total_vents_count: null,
     has_bypass_damper: false,
     min_open_vents_fraction: 0.333,
+    overflow_during_min_runtime: true,
     ...over,
   };
 }

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -71,6 +71,7 @@ describe("Dashboard Page", () => {
         min_cycle_runtime_min: 0,
         min_cycle_offtime_min: 0,
         cooling_lockout_below_f: null,
+        overflow_during_min_runtime: true,
       },
     ]);
   });

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -47,6 +47,7 @@ describe("Metrics Page", () => {
         min_cycle_runtime_min: 0,
         min_cycle_offtime_min: 0,
         cooling_lockout_below_f: null,
+        overflow_during_min_runtime: true,
       },
     ]);
     vi.mocked(api.getMetricsHomeSummary).mockResolvedValue(mockSummary);

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -27,6 +27,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     min_cycle_runtime_min: 0,
     min_cycle_offtime_min: 0,
     cooling_lockout_below_f: null,
+    overflow_during_min_runtime: true,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -27,6 +27,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     min_cycle_runtime_min: 0,
     min_cycle_offtime_min: 0,
     cooling_lockout_below_f: null,
+    overflow_during_min_runtime: true,
   },
 ];
 
@@ -206,6 +207,45 @@ describe("Thermostats Page", () => {
         expect.objectContaining({
           min_cycle_runtime_min: 10,
           min_cycle_offtime_min: 5,
+        })
+      );
+    });
+  });
+
+  it("disables the overflow-conditioning checkbox when Min cycle runtime is 0 (Issue #237)", async () => {
+    // Default mock has min_cycle_runtime_min = 0 — the toggle has nothing
+    // to hook into (no hold ever happens), so it is disabled with a hint.
+    render(<Thermostats />);
+    const overflowToggle = (await screen.findByLabelText(
+      /Redirect surplus air to other rooms/i
+    )) as HTMLInputElement;
+    expect(overflowToggle).toBeDisabled();
+  });
+
+  it("enables and saves the overflow-conditioning toggle (Issue #237)", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    render(<Thermostats />);
+
+    // First, give the min-runtime hold a non-zero value so the toggle is enabled.
+    const runtimeInput = await screen.findByLabelText(/Min cycle runtime/i);
+    fireEvent.change(runtimeInput, { target: { value: "10" } });
+
+    const overflowToggle = (await screen.findByLabelText(
+      /Redirect surplus air to other rooms/i
+    )) as HTMLInputElement;
+    expect(overflowToggle).not.toBeDisabled();
+    expect(overflowToggle.checked).toBe(true); // default true from mock
+    fireEvent.click(overflowToggle);
+    expect(overflowToggle.checked).toBe(false);
+
+    const card = runtimeInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({
+          overflow_during_min_runtime: false,
         })
       );
     });

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -442,6 +442,50 @@ function ThermostatCard({
         })}
       </div>
 
+      {/* Overflow conditioning during the minimum-runtime hold (Issue #237).
+          Boolean — rendered outside the SAFETY_FIELDS loop, which only
+          handles numeric inputs. Only meaningful when min_cycle_runtime_min
+          > 0; the helper text says so. Disabled in vacation mode regardless. */}
+      <div className="form-group" style={{ maxWidth: 480, marginTop: "1rem" }}>
+        <label
+          htmlFor={`thermo-${config.thermostat_entity_id}-overflow`}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: ".5rem",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            id={`thermo-${config.thermostat_entity_id}-overflow`}
+            type="checkbox"
+            checked={form.overflow_during_min_runtime ?? true}
+            disabled={(form.min_cycle_runtime_min ?? 0) <= 0}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, overflow_during_min_runtime: e.target.checked }))
+            }
+          />
+          <span>Redirect surplus air to other rooms during the minimum-runtime hold</span>
+        </label>
+        <div className="form-hint">
+          When a cycle hits its target before the minimum runtime has elapsed, the HVAC keeps
+          running. With this on (default), the engine opens vents in non-active rooms that can
+          absorb the surplus air without crossing into the opposite-direction trigger, so the
+          satisfied rooms do not overshoot and the air handler has a larger plenum. Turn off if you
+          would rather keep only the cycle's original rooms open during the hold. No effect unless{" "}
+          <strong>Min cycle runtime</strong> above is &gt; 0; disabled automatically in vacation
+          mode. See the{" "}
+          <a
+            href="https://github.com/dhruvb14/smart-thermostat-with-vents/blob/main/docs/overflow-conditioning.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            overflow conditioning docs
+          </a>{" "}
+          for the tier-by-tier candidate selection.
+        </div>
+      </div>
+
       {/* Outdoor-temperature cooling lockout (Issue #209). Nullable (blank =
           disabled), so it is rendered outside the SAFETY_FIELDS loop. */}
       <div className="form-group" style={{ maxWidth: 280, marginTop: "1rem" }}>


### PR DESCRIPTION
Closes #237.

## What changed

**Bug fix.** `CycleLog.in_min_runtime_hold` is now a persisted flag set by `_enter_min_runtime_hold` and checked by `_monitor_rooms`. While the flag is set, the per-room close-vent loop is skipped — that's the gate that stops the original open/close churn through the hold window.

**Feature.** During the hold, `room_manager.get_overflow_candidates()` picks non-active rooms to absorb surplus conditioning via a four-tier filter (outside-deadband → inside-deadband → most opposite-trigger headroom → fallback to active rooms only). Recomputed every tick. Disabled in vacation mode and via the new `ThermostatConfig.overflow_during_min_runtime` knob (default on).

**UI.** New "Redirect surplus air to other rooms during the minimum-runtime hold" checkbox on the Thermostats page, with helper text linking to the docs. Auto-disabled when Min cycle runtime is 0 (no hold ever happens, so the toggle has no effect). The flag is wired through the POST/PUT thermostat routes and the `ThermostatConfig` TS type. Four other test mocks updated so `tsc --noEmit` passes — the Docker production build runs that as a build step.

## Docs

- **`docs/overflow-conditioning.md`** (new) — motivation, full tier-by-tier description with cooling/heating examples, "effective presence setpoint" resolution, headroom calculation, safety reasoning (why we never push past goal except in Tier 3 and why Tier 3 still excludes rooms past their opposite-direction trigger), config knob (reachable from the Thermostats page), observability.
- **`docs/cycle-engine.md`** — new "Minimum-runtime hold" section: the `in_min_runtime_hold` flag, the close-loop gate, restart survival, and a link to overflow conditioning.
- **`docs/safety.md`** — hold-flag explanation + new "Opposite-cycle prevention" subsection covering how the design rules out the overflow feature creating an opposite cycle as a side effect.
- **`docs/README.md`** — link to the new doc.

## Convention added

`CLAUDE.md` gets a new workflow rule: every backend/API feature must expose a UI control. This PR caught itself violating that rule (the overflow knob was reachable only via direct DB write); the rule now makes the requirement explicit for future work.

## Test plan

- [x] `backend/tests/test_room_manager.py` — 11 new unit tests covering all four tiers, mode mirroring, setpoint fallback, vacation skip, missing readings, unknown HVAC mode.
- [x] `backend/tests/test_cycle_engine.py` — new classes `TestMinRuntimeHoldGate` (close-loop short-circuit, termination on runtime expiry) and `TestOverflowDuringHold` (tier-1 open, knob-disabled, candidate dropout, vacation skip); extended `TestEnterMinRuntimeHold` with flag-persistence test.
- [x] `frontend/src/pages/Thermostats.test.tsx` — 2 new tests: toggle auto-disables when Min cycle runtime is 0, and edit-then-save propagates `overflow_during_min_runtime: false` through `updateThermostat`.
- [x] Full backend suite passes (`pytest backend/tests/` — 424 unit + 238 integration).
- [x] Full frontend suite passes (`vitest run` — 156 tests).
- [x] `tsc --noEmit` clean and `vite build` succeeds — Docker build step now passes.
- [x] `ruff check backend/` and `ruff format --check backend/` clean.
- [x] `npm run lint` and `npm run format:check` clean.