### PR TITLE
docs: update install section for HA add-on and Docker timezone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 - **After every push to a PR**: always update the PR body with a description of what changed, why, and a test plan. Do this every time without being asked.
 - **When reviewing a PR and pushing fixes**: push directly to the PR's own branch (not to a separate review branch), so the fixes appear in the PR diff.
+- **Never include Claude session links** in commit messages, PR titles, PR bodies, or issue comments.
+- **Never mention that code was written by Claude** (or any AI assistant) in commit messages, PR titles, PR bodies, or issue comments.
 - **Every backend/API feature must have a UI control.** When you add a new `ThermostatConfig` field, system setting, or any other tunable on the API write boundary, also add a form control + helper text to the matching React page (Thermostats, Rooms, Schedules, Settings, etc.). A feature exposed only in the DB/API and not the UI is an incomplete feature — the user cannot reach it. This is a 100% rule; if you find yourself adding a knob without surfacing it, stop and add the UI before considering the work done.
 
 ## What this repo is

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [`docs/safety.md`](./docs/safety.md) for how each protection works and how t
 1. In HA, go to **Settings → Add-ons → Add-on Store → ⋮ → Repositories**
 2. Add this repository URL
 3. Find **Plenum** and click **Install**
-4. Go to the add-on **Configuration** tab and fill in your HA URL and long-lived access token (see below)
+4. Go to the add-on **Configuration** tab and set your **`timezone`** (e.g. `America/New_York`) — no token or URL is needed when running as an HA add-on
 5. Click **Start** — the UI is available via the **Open Web UI** button (HA Ingress)
 
 ### Option B — Docker (standalone / testing)
@@ -100,6 +100,7 @@ docker run -d \
   -v /path/to/data:/data \
   -e HA_URL=https://your-ha-instance.com \
   -e HA_TOKEN=your_long_lived_token \
+  -e TZ=America/New_York \
   ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
 ```
 

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.13.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.13.0",
+      "version": "0.12.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plenum-ui",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plenum-ui",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary

- **Option A (HA add-on):** Clarify that users do not need to configure a token or URL — only the timezone field is required in the Configuration tab.
- **Option B (Docker):** Add `-e TZ=` to the `docker run` example so standalone users know they must pass their timezone to keep schedules firing at the right time.
- **CLAUDE.md:** Add conventions to never include Claude session links or AI attribution in commit messages, PR bodies, or issue comments.

## Test plan

- [x] Review Option A install steps — confirm no token/URL step remains
- [x] Review Option B `docker run` snippet — confirm `-e TZ=` is present
- [x] Verify CLAUDE.md workflow conventions look correct