### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@
 - **When reviewing a PR and pushing fixes**: push directly to the PR's own branch (not to a separate review branch), so the fixes appear in the PR diff.
 - **Never include Claude session links** in commit messages, PR titles, PR bodies, or issue comments.
 - **Never mention that code was written by Claude** (or any AI assistant) in commit messages, PR titles, PR bodies, or issue comments.
+- **Never leak exception detail into API responses.** In `except` blocks inside route handlers, call `log.exception("…context…")` (or `log.error("…", exc_info=True)`) to preserve the full traceback in server logs, then return a generic user-safe message via `error("…", status=5xx)` — never embed `{exc}` or `str(exc)` in the response body. Exposing raw exception strings is an information-disclosure vulnerability (CWE-209) and was the subject of security alert #4. Pattern to follow:
+  ```python
+  except Exception:
+      log.exception("Failed to <action> for <context>=…")
+      return error("Failed to <action>", status=502)
+  ```
 - **Every backend/API feature must have a UI control.** When you add a new `ThermostatConfig` field, system setting, or any other tunable on the API write boundary, also add a form control + helper text to the matching React page (Thermostats, Rooms, Schedules, Settings, etc.). A feature exposed only in the DB/API and not the UI is an incomplete feature — the user cannot reach it. This is a 100% rule; if you find yourself adding a knob without surfacing it, stop and add the UI before considering the work done.
 
 ## What this repo is

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1589,8 +1589,9 @@ async def test_vacation_mode(request: web.Request) -> web.Response:
     ha = request.app["ha"]
     try:
         await ha.set_thermostat_temperature_range(entity_id, tc.min_setpoint, tc.max_setpoint)
-    except Exception as exc:
-        return error(f"Failed to send range command: {exc}", status=502)
+    except Exception:
+        log.exception("Failed to send thermostat range command for entity_id=%s", entity_id)
+        return error("Failed to send range command", status=502)
     # Return current HA state so the UI can surface it to the user.
     state = ha.get_state(entity_id)
     return json_response(
@@ -1614,8 +1615,9 @@ async def revert_vacation_test(request: web.Request) -> web.Response:
     ha = request.app["ha"]
     try:
         await ha.set_thermostat_hvac_mode(entity_id, "off")
-    except Exception as exc:
-        return error(f"Failed to revert thermostat mode: {exc}", status=502)
+    except Exception:
+        log.exception("Failed to revert thermostat mode for entity_id=%s", entity_id)
+        return error("Failed to revert thermostat mode", status=502)
     return json_response({"ok": True})
 
 


### PR DESCRIPTION
## Summary

Fixes security alert #4 (CWE-209 — information exposure through an exception).

Two route handlers in `test_vacation_mode` and `revert_vacation_test` were embedding raw `{exc}` strings directly in API error responses, exposing internal exception detail to callers. This pattern was fixed previously but reintroduced when these methods were added.

**Changes:**
- `test_vacation_mode`: replaced `return error(f"Failed to send range command: {exc}", status=502)` with `log.exception(...)` + generic `return error("Failed to send range command", status=502)`
- `revert_vacation_test`: same pattern fixed
- `CLAUDE.md`: added an explicit rule documenting the correct pattern for all future exception handling in route handlers — log full detail server-side via `log.exception()`, return only a generic user-safe message in the response body

## Why

Raw exception strings can leak internal implementation details (file paths, class names, query fragments, entity IDs) to API consumers. The fix preserves full diagnostics in server logs while keeping responses safe.

## Test plan

- [ ] Trigger a HA client failure in dev mode and confirm the 502 response body contains only the generic message, not the exception text
- [ ] Confirm the server log contains the full traceback via `log.exception`
- [ ] Verify no remaining `f"...{exc}"` patterns exist in route handlers (`grep 'f\".*{exc}' backend/api/routes.py` returns empty)