### PR TITLE
Fix #244: _terminate_cycle reopens idle-room vents; clarify idle reconciler warning

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1220,10 +1220,17 @@ class CycleEngine:
         # were closed at cycle start (by _close_idle_room_vents) must also be
         # re-opened so the zone returns to a fully-open idle state (issue #244).
         all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
-        _active_ids = set(self._active_rooms.keys())
-        for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
-            if _zr.id not in _active_ids:
-                all_zone_vents.extend(await db.get_room_vents(conn, _zr.id))
+        try:
+            _active_ids = set(self._active_rooms.keys())
+            for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
+                if _zr.id not in _active_ids:
+                    all_zone_vents.extend(await db.get_room_vents(conn, _zr.id))
+        except Exception:
+            log.exception(
+                "Failed to fetch idle-room vents for %s during termination — "
+                "idle vents may remain closed until the next reconcile pass",
+                self.thermostat_entity_id,
+            )
 
         self._state = CycleState.IDLE
         self._cycle_mode = None
@@ -1322,10 +1329,17 @@ class CycleEngine:
         # path returns the zone to fully-open idle state (issue #244).
         all_vents = [v for vl in self._room_vents.values() for v in vl]
         if not safe_close:
-            _active_ids = set(self._active_rooms.keys())
-            for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
-                if _zr.id not in _active_ids:
-                    all_vents.extend(await db.get_room_vents(conn, _zr.id))
+            try:
+                _active_ids = set(self._active_rooms.keys())
+                for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
+                    if _zr.id not in _active_ids:
+                        all_vents.extend(await db.get_room_vents(conn, _zr.id))
+            except Exception:
+                log.exception(
+                    "Failed to fetch idle-room vents for %s during abort — "
+                    "idle vents may remain closed until the next reconcile pass",
+                    self.thermostat_entity_id,
+                )
         try:
             if safe_close:
                 await self._vent.close_all_zone_vents(all_vents)

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1216,9 +1216,14 @@ class CycleEngine:
                     log.error("Failed to set termination setpoint: %s", exc)
 
         # Capture all zone vents before clearing state so we can re-open them.
-        # Vents are closed as rooms hit target during the cycle; on termination
-        # they should all return to open (idle state = vents open).
+        # self._room_vents only contains active-cycle rooms; idle rooms whose vents
+        # were closed at cycle start (by _close_idle_room_vents) must also be
+        # re-opened so the zone returns to a fully-open idle state (issue #244).
         all_zone_vents = [v for vl in self._room_vents.values() for v in vl]
+        _active_ids = set(self._active_rooms.keys())
+        for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
+            if _zr.id not in _active_ids:
+                all_zone_vents.extend(await db.get_room_vents(conn, _zr.id))
 
         self._state = CycleState.IDLE
         self._cycle_mode = None
@@ -1313,7 +1318,14 @@ class CycleEngine:
                     exc,
                 )
 
+        # Include idle-room vents (closed at cycle start) so the normal abort
+        # path returns the zone to fully-open idle state (issue #244).
         all_vents = [v for vl in self._room_vents.values() for v in vl]
+        if not safe_close:
+            _active_ids = set(self._active_rooms.keys())
+            for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
+                if _zr.id not in _active_ids:
+                    all_vents.extend(await db.get_room_vents(conn, _zr.id))
         try:
             if safe_close:
                 await self._vent.close_all_zone_vents(all_vents)
@@ -2214,14 +2226,18 @@ class CycleEngine:
                     if not self._vent._is_open(vent.entity_id):
                         await self._vent.open_room_vents([vent])
                         log.warning(
-                            "Reconcile (idle): vent %s found closed while system idle — re-opening",
+                            "Reconcile (idle): vent %s was closed externally while zone is idle — re-opening "
+                            "(check for manual HA cover controls or automations acting on this entity)",
                             vent.entity_id,
                         )
                         if self._logger:
                             await self._logger.log(
                                 "warning",
                                 "reconcile",
-                                f"Drift (idle): vent {vent.entity_id} found closed while zone is idle — re-opened",
+                                f"Vent {vent.entity_id} found closed while zone is idle — re-opened. "
+                                f"This vent was closed by something outside Plenum (manual HA cover control, "
+                                f"an HA automation, or an HA restart that reset cover state). "
+                                f"Plenum does not close vents when the zone is idle.",
                                 {
                                     "entity_id": vent.entity_id,
                                     "room_id": room.id,

--- a/smart_vent/backend/tests/integration/test_idle_vent_close_dispatch.py
+++ b/smart_vent/backend/tests/integration/test_idle_vent_close_dispatch.py
@@ -265,3 +265,63 @@ async def test_reconcile_recloses_drifted_idle_vent(client, fake_ha, tick) -> No
         f"reconciler must re-close drifted idle vent; close calls: {close_calls}"
     )
     assert fake_ha.get_state("cover.idle_vent")["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_terminate_reopens_idle_room_vents(client, fake_ha, tick) -> None:
+    """Cycle termination must reopen idle-room vents that were closed at cycle
+    start, not just the active-room vents (issue #244)."""
+    thermostat = "climate.test_thermostat"
+    fake_ha.seed_state(
+        thermostat,
+        "cool",
+        {"current_temperature": 76.0, "temperature": 76.0, "hvac_action": "cooling"},
+    )
+    # Active room: warm → will drive a cooling cycle.
+    fake_ha.seed_state("sensor.active_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.active_vent", "open", {})
+    # Idle room: already comfortable → vent will be closed at cycle start.
+    fake_ha.seed_state("sensor.idle_temp", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.idle_vent", "open", {})
+
+    await _create_room_with_schedule(
+        client,
+        name="Active",
+        sensor_entity="sensor.active_temp",
+        vent_entity="cover.active_vent",
+        control_method="open_close",
+        sensor_temp=78.0,
+    )
+    await _create_idle_room(
+        client,
+        name="Idle",
+        sensor_entity="sensor.idle_temp",
+        vent_entity="cover.idle_vent",
+        control_method="open_close",
+    )
+
+    # Tick 1: cycle starts, idle vent closes.
+    await tick()
+    assert fake_ha.get_state("cover.idle_vent")["state"] == "closed", (
+        "precondition: idle vent should be closed after cycle start"
+    )
+    assert fake_ha.get_state("cover.active_vent")["state"] == "open", (
+        "precondition: active vent should be open"
+    )
+
+    # Drive active room to target so the cycle terminates on the next tick.
+    await fake_ha.set_entity_state("sensor.active_temp", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.reset_calls()
+
+    # Tick 2: active room hits target → cycle terminates → all zone vents re-open.
+    await tick()
+
+    open_calls = fake_ha.calls_for("open_cover")
+    opened_entities = {c.data.get("entity_id") for c in open_calls}
+    assert "cover.idle_vent" in opened_entities, (
+        f"_terminate_cycle must reopen idle-room vents (issue #244); "
+        f"open_cover calls: {open_calls}, all calls: {fake_ha.calls}"
+    )
+    assert fake_ha.get_state("cover.idle_vent")["state"] == "open", (
+        "idle vent must be open after cycle termination"
+    )


### PR DESCRIPTION
## What changed and why

Fixes two related issues documented in #244 that together caused misleading "Drift (idle)" log spam after every cycle.

### Bug 1 — `_terminate_cycle` / `_abort_cycle` left idle-room vents closed

When a cycle starts, `_close_idle_room_vents` closes vents for every room on the zone that isn't in the active cycle. On cycle end, `_terminate_cycle` is supposed to restore the zone to fully-open idle state, but it built its reopen list from `self._room_vents` — which only contains active-cycle rooms. Idle rooms whose vents were closed at cycle start were silently skipped, leaving them closed until the next idle-reconcile pass.

The same gap existed in the normal (non-`safe_close`) path of `_abort_cycle`.

**Fix:** both methods now fetch all zone rooms from DB and extend the vent list with idle-room vents before the reopen call. The fetch is wrapped in `try-except` so a transient DB error degrades gracefully (idle vents remain closed until the next reconciler pass, which logs a warning) rather than blocking the state transition.

### Bug 2 — Idle reconciler warning implied engine fault

The idle-reconcile log read `"Drift (idle): vent X found closed while zone is idle — re-opened"` at `WARNING` severity under the `"Drift"` prefix — language that implies a state-machine bug. In practice it fired exactly once per cycle, cleaning up Bug 1's leftover closures. After Bug 1 is fixed, the only remaining reason for the idle reconciler to fire is a genuine external actor (manual HA cover control, HA restart resetting cover state, an automation). The message now says so clearly.

## Files changed

- `smart_vent/backend/engine/cycle_engine.py` — `_terminate_cycle` and `_abort_cycle` extended to include idle-room vents in the reopen call (with try-except guard); idle reconciler warning text updated
- `smart_vent/backend/tests/integration/test_idle_vent_close_dispatch.py` — new regression test `test_terminate_reopens_idle_room_vents`

## Test plan

- New integration test `test_terminate_reopens_idle_room_vents`: starts a cooling cycle with one active room and one idle room, drives the active room sensor to target so the cycle terminates, then asserts the idle room's vent receives an `open_cover` call and ends up in state `"open"`. This would have failed before the fix.
- Existing tests `test_idle_vent_closed_via_set_position`, `test_idle_vent_closed_via_set_tilt_position`, `test_reconcile_recloses_drifted_idle_vent`, and `test_restore_closes_idle_room_vents` all continue to pass — idle-vent closure at cycle start and mid-cycle drift detection are unaffected.
- Full suite: 663 tests pass, coverage 91.37% (threshold 91%).