### PR TITLE
Ambient-aware presence suppression (pre-cool / pre-heat), per-room

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Feature-by-feature guides live in [`docs/`](./docs/README.md):
 - [Safety features](./docs/safety.md) — short-cycle protection, outdoor-temperature cooling lockout
 - [Schedules](./docs/schedules.md) — time blocks and overnight ranges
 - [Presence & motion](./docs/presence.md) — motion activation and holdover
+- [Pre-cool / pre-heat](./docs/precool-presence.md) — skip presence HVAC when the outside air will reach the target on its own
 - [System modes](./docs/system-modes.md) — System On/Off and Dev Mode
 - [Observability](./docs/observability.md) — dashboard, logs, WebSocket
 - [Metrics & analytics](./docs/metrics.md) — heating/cooling charts, outside-temp correlation, CSV export

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ High-level guide to what Plenum does and how the pieces fit together. For instal
 - [Safety features](./safety.md) — short-cycle protection, outdoor-temperature cooling lockout, equipment-protection limits
 - [Schedules](./schedules.md) — time blocks, overnight ranges, priority rules
 - [Presence & motion](./presence.md) — motion-triggered activation and holdover
+- [Pre-cool / pre-heat](./precool-presence.md) — let a room coast to target on outside air instead of running HVAC for presence
 - [System modes](./system-modes.md) — the System On/Off toggle and Dev Mode
 - [Observability](./observability.md) — dashboard, event logs, cycle history, WebSocket
 - [Metrics & analytics](./metrics.md) — `/metrics` page charts, outside-temperature correlation, CSV export, live HA sensor endpoint

--- a/docs/precool-presence.md
+++ b/docs/precool-presence.md
@@ -8,10 +8,11 @@ room **coast** to its target on ambient drift instead of conditioning — a
 software version of the "pre-cool/pre-heat" idea many smart thermostats offer.
 
 It is **off by default**, configured **per room**, and only works when an
-**outside temperature sensor** is configured (see
-[Metrics & analytics](./metrics.md) for setting `outside_temp_entity_id`).
-Without a readable outside sensor the feature is inert and presence behaves
-exactly as before — a deliberate fail-safe.
+**outside temperature sensor** is configured — the home-wide *Outside
+temperature sensor* picker at the top of the **Thermostats** page (the same
+sensor the [cooling lockout](./safety.md) uses). Without a readable outside
+sensor the feature is inert and presence behaves exactly as before — a
+deliberate fail-safe.
 
 ## The problem it solves
 

--- a/docs/precool-presence.md
+++ b/docs/precool-presence.md
@@ -1,0 +1,115 @@
+# Pre-cool / pre-heat (ambient-aware presence suppression)
+
+When someone walks into a room, presence normally drives the HVAC to the
+room's presence target. But if the **outside air** will carry the room to that
+target on its own, running the heater or AC just wastes energy (and the
+overnight "coolness" you banked). This per-room feature lets a presence-active
+room **coast** to its target on ambient drift instead of conditioning — a
+software version of the "pre-cool/pre-heat" idea many smart thermostats offer.
+
+It is **off by default**, configured **per room**, and only works when an
+**outside temperature sensor** is configured (see
+[Metrics & analytics](./metrics.md) for setting `outside_temp_entity_id`).
+Without a readable outside sensor the feature is inert and presence behaves
+exactly as before — a deliberate fail-safe.
+
+## The problem it solves
+
+> A night schedule holds the bathroom at **68°F** and ends at 7:00am. At 7:30am
+> someone walks in and presence wants **70°F**, so the heater runs to add 2°F.
+> But it is already warmer than 70°F outside — the room will drift past 70°F on
+> its own as the sun comes up. The heat (and the stored overnight coolness) is
+> wasted.
+
+With the feature enabled on that room, the morning presence event does **not**
+call for heat: the room is left to drift up to 70°F on ambient gain. A hard
+floor still protects comfort if the room somehow gets too cold.
+
+## Per-room settings
+
+All of these live in the Room settings modal (**Rooms → Settings**), under
+*"Skip presence heating/cooling when the weather will do it for me"*. The two
+temperature fields are **deltas** shown in your active unit (°F or °C).
+
+| Setting | Meaning |
+|---|---|
+| **Enable** | Master toggle. Disabled until an outside sensor is configured. |
+| **When to apply** | `Any presence` (every presence activation) or `Only after a schedule ends` (just the post-schedule window — the 7am case). |
+| **Schedule window (minutes)** | Only for *"Only after a schedule ends"*: how long after a block ends the feature still applies. Default 60. |
+| **Minimum outside difference** | How far past the target the outside temp must be before coasting (default 5°F). |
+| **Widened deadband** | The grace band used while coasting. Must be **≥ the thermostat's deadband** (default 2°F). |
+
+### Minimum outside difference
+
+Coasting only makes sense when the weather is genuinely on the helpful side of
+the target — otherwise drift is too slow and you should just run the HVAC.
+
+With a 70°F target and a 5°F minimum difference:
+
+| Outside | Decision |
+|---|---|
+| 80°F (+10) | **Skip heat** — strong push, let it drift up |
+| 71°F (+1) | **Run heat** — only 1° of push, drift would be too slow |
+
+Concretely: heating is skipped only when `outside ≥ target + difference`, and
+cooling is skipped only when `outside ≤ target − difference`. A larger value is
+more conservative (coast less often) and is always safe.
+
+### Widened deadband and the threshold-crossing rule
+
+While coasting, the room rides a **wider** deadband than normal — but only on
+the side it is coasting *from*. **The instant the room crosses its presence
+target, the far side reverts to the normal deadband.** The widened band never
+spans across the target.
+
+Example — target **70°F**, normal deadband **2°F**, widened deadband **3°F**,
+outside **80°F**:
+
+| Room temp | Decision | Why |
+|---|---|---|
+| 68°F | **no heat** | within the widened floor (70 − 3 = 67°F); coast up |
+| 66°F | **heat** | dropped below the widened floor — comfort protection |
+| 70°F | idle | at target |
+| 72°F | **cool to 70°F** | crossed the target → normal deadband: cool at 70 + 2 = **72°F**, *not* 73°F |
+
+### Hard cap
+
+Whatever the feature decides, the thermostat's **min/max setpoint** always
+wins: if the room drifts to or below `min_setpoint` it heats, and at or above
+`max_setpoint` it cools. Coasting can never push a room past those absolute
+comfort bounds. (See [Thermostat settings](./thermostat-settings.md).)
+
+## How the decision is made
+
+Each tick, for every presence-active room with the feature engaged:
+
+1. **Gate** — is the outside temp at least `min_differential` past the target on
+   the helpful side? If not, run HVAC normally.
+2. **Direction** — below target with warm outside → coast up; above target with
+   cool outside → coast down.
+3. **Widened band** — while coasting, only call for HVAC if the room leaves the
+   widened band on the coasting side. Once the room crosses the target, the
+   normal deadband governs the other side.
+4. **Hard cap** — `min_setpoint`/`max_setpoint` override everything.
+
+A suppressed room contributes **no demand**: if it is the only active room, no
+cycle starts and its vents stay at the resting (open) position, exactly as if
+presence had never fired. If another room drives a cycle, the coasting room is
+excluded from it. Schedule and manual-override targets are explicit user intent
+and are **never** suppressed — only presence-driven demand is eligible.
+
+## Trigger scope
+
+- **Any presence** — the check runs every time presence activates the room.
+- **Only after a schedule ends** — the check runs only while the room is within
+  the configured window after a schedule block ended (the night→morning case),
+  and behaves normally the rest of the day. Overnight blocks count from their
+  morning end time.
+
+## See also
+
+- [Presence & motion](./presence.md) — how presence activates a room (and how
+  this feature can intentionally skip it)
+- [Rooms & zones](./rooms-and-zones.md) — the full set of per-room settings
+- [Safety features](./safety.md) — other outside-temperature-gated behavior
+- [Thermostat settings](./thermostat-settings.md) — deadband, setpoint bounds

--- a/docs/presence.md
+++ b/docs/presence.md
@@ -20,6 +20,10 @@ Configured per room in hours (default `2.0`). A value of `0` disables presence a
 
 Presence is lower priority than a matching schedule or a manual override (see [Schedules](./schedules.md)). If a schedule block and presence both apply, the schedule wins — presence won't re-activate the room until the schedule exits.
 
+## Skipping presence when the weather will do the work
+
+A room can be configured to **ignore presence-driven heating/cooling** when the outside temperature will carry it to target on its own — for example, declining to heat at 7am because the day is already warming up. This only affects presence demand (never schedules or overrides) and needs an outside temperature sensor. See [Pre-cool / pre-heat](./precool-presence.md).
+
 ## Why holdover lives in the DB
 
 Holdover expiry is persisted, so an add-on restart or a crash doesn't lose presence state. A room active at the moment of restart stays active through the boot, assuming the holdover hasn't expired.

--- a/docs/rooms-and-zones.md
+++ b/docs/rooms-and-zones.md
@@ -12,6 +12,7 @@ Every room has:
 - Zero or more **vents** (`cover.*`). Each vent stores its own **control method** (see [Vent control methods](./vent-control.md)).
 - Zero or more **presence sensors** (`binary_sensor.*`) plus a **presence holdover** (hours) and a **presence target temp**. See [Presence & motion](./presence.md).
 - A **temperature offset** (°F) added to the measured average before comparing to target. Use this to compensate for post-vent-close drift — e.g. set `+3` if your room always ends up 3° cooler than target after the vent closes.
+- Optional **pre-cool / pre-heat** settings that let the room coast to its presence target on outside air instead of running HVAC (enable, when-to-apply, minimum outside difference, widened deadband). Requires an outside temperature sensor. See [Pre-cool / pre-heat](./precool-presence.md).
 
 ## Multiple rooms per zone
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -64,6 +64,10 @@ The lockout needs to know the outdoor temperature. The **outside-temperature sen
 
 If a lockout threshold is configured but the outdoor sensor is unset or unreadable, Plenum **fails open** — it allows the cooling cycle and logs a warning. A dropped sensor should not silently disable cooling for the whole house in summer; the warning makes the gap visible so it can be fixed.
 
+### Related: pre-cool / pre-heat
+
+[Pre-cool / pre-heat](./precool-presence.md) is another outside-temperature-gated behavior: a per-room option to skip *presence-driven* heating/cooling when the weather will carry the room to target on its own. It is comfort/energy tuning rather than equipment protection, and the thermostat's min/max setpoint always overrides it so a coasting room never drifts past those bounds. Like the lockout, it is inert without a readable outside sensor.
+
 ## Sensor-staleness guard
 
 A battery-powered Zigbee or Z-Wave temperature sensor that drops off the mesh does not always flip to `unavailable` in Home Assistant — HA keeps showing the **last numeric value it heard**. If Plenum averaged that stale value into a room temperature, it would confidently make the wrong control decision: wrong mode, vents closing on a room that hasn't actually reached target, no cycle starting on a room that's actually warm. The kind of silent failure that only shows up as a comfort complaint.

--- a/docs/thermostat-settings.md
+++ b/docs/thermostat-settings.md
@@ -23,3 +23,5 @@ Per-thermostat configuration controls how aggressively Plenum drives the HVAC an
 - **Deadband** is checked per-room at every tick to decide when to close a room's vents.
 - **Total vent count / minimum open fraction** together set the airflow floor — `ceil(total × fraction) − passive_vents_always_open` smart vents must stay open. If too many would close, the ones furthest from target stay open. Bypass-damper systems skip this enforcement.
 - **Max vent closed** and **cycle timeout** are independent safety valves that can fire mid-cycle.
+
+The per-room [pre-cool / pre-heat](./precool-presence.md) feature builds on these: while a room coasts it uses a **widened deadband** (which must be ≥ this thermostat **Deadband**) on the side it is drifting from, and the **Min / max setpoint** act as the hard floor/ceiling that always overrides coasting.

--- a/e2e/fixtures/ha-config/configuration.yaml
+++ b/e2e/fixtures/ha-config/configuration.yaml
@@ -43,6 +43,14 @@ template:
         unit_of_measurement: "°F"
         device_class: temperature
         state_class: measurement
+      # Outdoor sensor — used by the ambient pre-cool/pre-heat round-trip
+      # (Issue #248). Warm so the heating-suppression scenario is realistic.
+      - name: "Outdoor Temperature"
+        unique_id: e2e_outdoor_temp
+        state: "80.0"
+        unit_of_measurement: "°F"
+        device_class: temperature
+        state_class: measurement
 
 # Fake thermostats — generic_thermostat over dummy switches + template sensors
 climate:

--- a/e2e/tests/temperature-fields.ts
+++ b/e2e/tests/temperature-fields.ts
@@ -93,6 +93,22 @@ export const TEMPERATURE_FIELDS: TempField[] = [
     ui: true,
     endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
   },
+  // ── Ambient-aware presence suppression / pre-cool (Issue #248).
+  // ui:false for now — no Room UI write path lands until the UI phase.
+  // Flip to ui:true (and add `// @covers:` markers in
+  // temperature-units.spec.ts) when the Rooms.tsx controls ship.
+  {
+    field: "ambient_suppression_min_differential",
+    kind: "delta",
+    ui: false,
+    endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
+  },
+  {
+    field: "ambient_suppression_deadband",
+    kind: "delta",
+    ui: false,
+    endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
+  },
 
   // ── Schedules — POST/PUT /api/rooms/{id}/schedules[/{sid}]
   // Also accepted by POST /api/rooms/{id}/override (API-only path, no UI),

--- a/e2e/tests/temperature-fields.ts
+++ b/e2e/tests/temperature-fields.ts
@@ -94,19 +94,18 @@ export const TEMPERATURE_FIELDS: TempField[] = [
     endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
   },
   // ── Ambient-aware presence suppression / pre-cool (Issue #248).
-  // ui:false for now — no Room UI write path lands until the UI phase.
-  // Flip to ui:true (and add `// @covers:` markers in
-  // temperature-units.spec.ts) when the Rooms.tsx controls ship.
+  // Delta fields written by the Rooms modal; covered by the round-trip in
+  // temperature-units.spec.ts (// @covers).
   {
     field: "ambient_suppression_min_differential",
     kind: "delta",
-    ui: false,
+    ui: true,
     endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
   },
   {
     field: "ambient_suppression_deadband",
     kind: "delta",
-    ui: false,
+    ui: true,
     endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
   },
 

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -195,6 +195,14 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     // sensor is configured. Configure one via the API; skip on the no-HA stack
     // where the sensor entity does not exist (the conversion matrix that
     // actually exercises this runs against real HA).
+    //
+    // The outside-temp entity is a global setting, and later specs (e.g.
+    // thermostats.spec.ts) screenshot the page that renders it — workers:1 runs
+    // every spec sequentially against the same stack — so capture the prior
+    // value and restore it in `finally` to avoid contaminating those goldens.
+    const priorOutside = await (
+      await page.request.get("/api/settings/outside-temp-entity")
+    ).json();
     const res = await page.request.put("/api/settings/outside-temp-entity", {
       data: { entity_id: "sensor.outdoor_temperature" },
     });
@@ -203,53 +211,60 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
       "requires an outside temperature sensor (HA-backed stack)",
     );
 
-    await page.goto("/rooms");
-    await page.waitForSelector(".loading", {
-      state: "detached",
-      timeout: 15_000,
-    });
-    await page.waitForLoadState("networkidle");
+    try {
+      await page.goto("/rooms");
+      await page.waitForSelector(".loading", {
+        state: "detached",
+        timeout: 15_000,
+      });
+      await page.waitForLoadState("networkidle");
 
-    const openModal = async () => {
-      await page
-        .locator(".card")
-        .filter({ hasText: "Living Room" })
-        .first()
-        .getByRole("button", { name: "Settings", exact: true })
-        .click();
-      const m = page.locator(".modal");
-      await m.waitFor({ state: "visible", timeout: 10_000 });
-      return m;
-    };
+      const openModal = async () => {
+        await page
+          .locator(".card")
+          .filter({ hasText: "Living Room" })
+          .first()
+          .getByRole("button", { name: "Settings", exact: true })
+          .click();
+        const m = page.locator(".modal");
+        await m.waitFor({ state: "visible", timeout: 10_000 });
+        return m;
+      };
 
-    let modal = await openModal();
-    // Enable the feature (the checkbox is enabled once the outside sensor loads),
-    // then fill the two delta inputs that appear.
-    await modal.getByLabel(/pre-cool \/ pre-heat/i).check();
-    await modal
-      .getByLabel(/Minimum outside difference/i)
-      .fill(AMBIENT_MIN_DIFF);
-    await modal.getByLabel(/Widened deadband/i).fill(AMBIENT_DEADBAND);
+      let modal = await openModal();
+      // Enable the feature (the checkbox is enabled once the outside sensor loads),
+      // then fill the two delta inputs that appear.
+      await modal.getByLabel(/pre-cool \/ pre-heat/i).check();
+      await modal
+        .getByLabel(/Minimum outside difference/i)
+        .fill(AMBIENT_MIN_DIFF);
+      await modal.getByLabel(/Widened deadband/i).fill(AMBIENT_DEADBAND);
 
-    await modal.getByRole("button", { name: /Save changes/i }).click();
-    await modal.waitFor({ state: "detached", timeout: 5_000 });
+      await modal.getByRole("button", { name: /Save changes/i }).click();
+      await modal.waitFor({ state: "detached", timeout: 5_000 });
 
-    // Reopen and verify both deltas survived the °C↔°F round-trip unchanged.
-    modal = await openModal();
-    const minDiffAfter = await modal
-      .getByLabel(/Minimum outside difference/i)
-      .inputValue();
-    const deadbandAfter = await modal
-      .getByLabel(/Widened deadband/i)
-      .inputValue();
-    expect(parseFloat(minDiffAfter)).toBeCloseTo(
-      parseFloat(AMBIENT_MIN_DIFF),
-      1,
-    );
-    expect(parseFloat(deadbandAfter)).toBeCloseTo(
-      parseFloat(AMBIENT_DEADBAND),
-      1,
-    );
+      // Reopen and verify both deltas survived the °C↔°F round-trip unchanged.
+      modal = await openModal();
+      const minDiffAfter = await modal
+        .getByLabel(/Minimum outside difference/i)
+        .inputValue();
+      const deadbandAfter = await modal
+        .getByLabel(/Widened deadband/i)
+        .inputValue();
+      expect(parseFloat(minDiffAfter)).toBeCloseTo(
+        parseFloat(AMBIENT_MIN_DIFF),
+        1,
+      );
+      expect(parseFloat(deadbandAfter)).toBeCloseTo(
+        parseFloat(AMBIENT_DEADBAND),
+        1,
+      );
+    } finally {
+      // Restore the global outside-temp setting for subsequent specs.
+      await page.request.put("/api/settings/outside-temp-entity", {
+        data: { entity_id: priorOutside?.entity_id ?? null },
+      });
+    }
   });
 
   test("schedule target temperature persists exactly as entered (#231)", async ({

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -39,16 +39,26 @@ const COOLING_LOCKOUT = isCelsius ? "12" : "54";
 const SCHEDULE_TARGET = isCelsius ? "20" : "68";
 const ROOM_SYS_TEMP = isCelsius ? "21" : "70";
 const ROOM_TEMP_OFFSET = isCelsius ? "0.5" : "0.9";
+// Ambient pre-cool/pre-heat deltas (Issue #248). 5°C → 9.0°F and 3°C → 5.4°F
+// both round-trip cleanly through the backend's 2dp °F storage, and the
+// widened deadband (3) clears any thermostat deadband set earlier in this file.
+const AMBIENT_MIN_DIFF = isCelsius ? "5" : "5";
+const AMBIENT_DEADBAND = isCelsius ? "3" : "3";
 
 // The seeded thermostat global-setup registers first. Use its specific id to
 // avoid strict-mode collisions with the second thermostat ("upstairs").
 const TC_ID = "climate.downstairs_thermostat";
 
 test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
-  test("thermostat fields persist exactly as entered (#231)", async ({ page }) => {
+  test("thermostat fields persist exactly as entered (#231)", async ({
+    page,
+  }) => {
     // @covers: default_temp, min_setpoint, max_setpoint, deadband, overshoot_delta, cooling_lockout_below_f
     await page.goto("/thermostats");
-    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
     await page.waitForLoadState("networkidle");
 
     // Target the specific downstairs card by its unique input id. Two
@@ -69,44 +79,73 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     await page.locator(idSel("overshoot_delta")).fill(OVERSHOOT_DELTA);
     // cooling_lockout_below_f uses a different id-suffix convention (`-cooling-lockout`,
     // hyphenated) because it was added separately from the SAFETY_FIELDS loop.
-    await page.locator(`[id="thermo-${TC_ID}-cooling-lockout"]`).fill(COOLING_LOCKOUT);
+    await page
+      .locator(`[id="thermo-${TC_ID}-cooling-lockout"]`)
+      .fill(COOLING_LOCKOUT);
 
     // Capture the PUT response — when this assertion fails the body text
     // surfaces the actual backend error (range/validation/etc) instead of
     // an opaque "Saved! never appeared" timeout.
     const putResponse = page.waitForResponse(
       (r) =>
-        r.url().includes(`/api/thermostats/${TC_ID}`) && r.request().method() === "PUT"
+        r.url().includes(`/api/thermostats/${TC_ID}`) &&
+        r.request().method() === "PUT",
     );
     await card.getByRole("button", { name: "Save changes" }).click();
     const response = await putResponse;
     const responseText = await response.text();
-    expect(response.status(), `PUT /api/thermostats/${TC_ID} failed: ${responseText}`).toBeLessThan(
-      400
-    );
+    expect(
+      response.status(),
+      `PUT /api/thermostats/${TC_ID} failed: ${responseText}`,
+    ).toBeLessThan(400);
 
     // Reload and read back. The fix means each input should show the same
     // value that was typed; the double-conversion bug would surface as a
     // value off by the °C↔°F conversion factor.
     await page.reload();
-    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
     await page.waitForLoadState("networkidle");
 
     const readBack = async (suffix: string) =>
-      parseFloat(await page.locator(`[id="thermo-${TC_ID}-${suffix}"]`).inputValue());
+      parseFloat(
+        await page.locator(`[id="thermo-${TC_ID}-${suffix}"]`).inputValue(),
+      );
 
-    expect(await readBack("default_temp")).toBeCloseTo(parseFloat(DEFAULT_TEMP), 1);
-    expect(await readBack("min_setpoint")).toBeCloseTo(parseFloat(MIN_SETPOINT), 1);
-    expect(await readBack("max_setpoint")).toBeCloseTo(parseFloat(MAX_SETPOINT), 1);
+    expect(await readBack("default_temp")).toBeCloseTo(
+      parseFloat(DEFAULT_TEMP),
+      1,
+    );
+    expect(await readBack("min_setpoint")).toBeCloseTo(
+      parseFloat(MIN_SETPOINT),
+      1,
+    );
+    expect(await readBack("max_setpoint")).toBeCloseTo(
+      parseFloat(MAX_SETPOINT),
+      1,
+    );
     expect(await readBack("deadband")).toBeCloseTo(parseFloat(DEADBAND), 1);
-    expect(await readBack("overshoot_delta")).toBeCloseTo(parseFloat(OVERSHOOT_DELTA), 1);
-    expect(await readBack("cooling-lockout")).toBeCloseTo(parseFloat(COOLING_LOCKOUT), 1);
+    expect(await readBack("overshoot_delta")).toBeCloseTo(
+      parseFloat(OVERSHOOT_DELTA),
+      1,
+    );
+    expect(await readBack("cooling-lockout")).toBeCloseTo(
+      parseFloat(COOLING_LOCKOUT),
+      1,
+    );
   });
 
-  test("room presence temp and offset persist exactly as entered (#231)", async ({ page }) => {
+  test("room presence temp and offset persist exactly as entered (#231)", async ({
+    page,
+  }) => {
     // @covers: system_wide_temp, temp_offset
     await page.goto("/rooms");
-    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
     await page.waitForLoadState("networkidle");
 
     // Open the Living Room's settings modal. Scope to the room card — the
@@ -125,7 +164,9 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     };
 
     let modal = await openModal();
-    await modal.getByLabel(/Presence-triggered temperature/i).fill(ROOM_SYS_TEMP);
+    await modal
+      .getByLabel(/Presence-triggered temperature/i)
+      .fill(ROOM_SYS_TEMP);
     await modal.getByLabel(/Temperature offset/i).fill(ROOM_TEMP_OFFSET);
 
     await modal.getByRole("button", { name: /Save changes/i }).click();
@@ -133,21 +174,101 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
 
     // Reopen and verify both persisted values.
     modal = await openModal();
-    const sysTempAfter = await modal.getByLabel(/Presence-triggered temperature/i).inputValue();
-    const offsetAfter = await modal.getByLabel(/Temperature offset/i).inputValue();
+    const sysTempAfter = await modal
+      .getByLabel(/Presence-triggered temperature/i)
+      .inputValue();
+    const offsetAfter = await modal
+      .getByLabel(/Temperature offset/i)
+      .inputValue();
     expect(parseFloat(sysTempAfter)).toBeCloseTo(parseFloat(ROOM_SYS_TEMP), 1);
-    expect(parseFloat(offsetAfter)).toBeCloseTo(parseFloat(ROOM_TEMP_OFFSET), 1);
+    expect(parseFloat(offsetAfter)).toBeCloseTo(
+      parseFloat(ROOM_TEMP_OFFSET),
+      1,
+    );
   });
 
-  test("schedule target temperature persists exactly as entered (#231)", async ({ page }) => {
+  test("room pre-cool/pre-heat deltas persist exactly as entered (#231)", async ({
+    page,
+  }) => {
+    // @covers: ambient_suppression_min_differential, ambient_suppression_deadband
+    // The pre-cool/pre-heat controls only render once an outside temperature
+    // sensor is configured. Configure one via the API; skip on the no-HA stack
+    // where the sensor entity does not exist (the conversion matrix that
+    // actually exercises this runs against real HA).
+    const res = await page.request.put("/api/settings/outside-temp-entity", {
+      data: { entity_id: "sensor.outdoor_temperature" },
+    });
+    test.skip(
+      !res.ok(),
+      "requires an outside temperature sensor (HA-backed stack)",
+    );
+
+    await page.goto("/rooms");
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
+    await page.waitForLoadState("networkidle");
+
+    const openModal = async () => {
+      await page
+        .locator(".card")
+        .filter({ hasText: "Living Room" })
+        .first()
+        .getByRole("button", { name: "Settings", exact: true })
+        .click();
+      const m = page.locator(".modal");
+      await m.waitFor({ state: "visible", timeout: 10_000 });
+      return m;
+    };
+
+    let modal = await openModal();
+    // Enable the feature (the checkbox is enabled once the outside sensor loads),
+    // then fill the two delta inputs that appear.
+    await modal.getByLabel(/pre-cool \/ pre-heat/i).check();
+    await modal
+      .getByLabel(/Minimum outside difference/i)
+      .fill(AMBIENT_MIN_DIFF);
+    await modal.getByLabel(/Widened deadband/i).fill(AMBIENT_DEADBAND);
+
+    await modal.getByRole("button", { name: /Save changes/i }).click();
+    await modal.waitFor({ state: "detached", timeout: 5_000 });
+
+    // Reopen and verify both deltas survived the °C↔°F round-trip unchanged.
+    modal = await openModal();
+    const minDiffAfter = await modal
+      .getByLabel(/Minimum outside difference/i)
+      .inputValue();
+    const deadbandAfter = await modal
+      .getByLabel(/Widened deadband/i)
+      .inputValue();
+    expect(parseFloat(minDiffAfter)).toBeCloseTo(
+      parseFloat(AMBIENT_MIN_DIFF),
+      1,
+    );
+    expect(parseFloat(deadbandAfter)).toBeCloseTo(
+      parseFloat(AMBIENT_DEADBAND),
+      1,
+    );
+  });
+
+  test("schedule target temperature persists exactly as entered (#231)", async ({
+    page,
+  }) => {
     // @covers: target_temp
     await page.goto("/schedules");
-    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
     await page.waitForLoadState("networkidle");
 
     // Room cards on /schedules are collapsed by default — click the room's
     // title row to expand it, then the "+ Add schedule block" button appears.
-    const livingRoomCard = page.locator(".card").filter({ hasText: "Living Room" }).first();
+    const livingRoomCard = page
+      .locator(".card")
+      .filter({ hasText: "Living Room" })
+      .first();
     await livingRoomCard.getByText("Living Room").click();
 
     await livingRoomCard.getByText("+ Add schedule block").click();
@@ -170,13 +291,21 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     // re-derives the display unit from storage; if the backend stored the
     // wrong value the rendered number would be off.
     await page.reload();
-    await page.waitForSelector(".loading", { state: "detached", timeout: 15_000 });
+    await page.waitForSelector(".loading", {
+      state: "detached",
+      timeout: 15_000,
+    });
     await page.waitForLoadState("networkidle");
 
-    const livingRoomCardReloaded = page.locator(".card").filter({ hasText: "Living Room" }).first();
+    const livingRoomCardReloaded = page
+      .locator(".card")
+      .filter({ hasText: "Living Room" })
+      .first();
     await livingRoomCardReloaded.getByText("Living Room").click();
 
-    const newBlockRow = livingRoomCardReloaded.locator("tr").filter({ hasText: "18:00" });
+    const newBlockRow = livingRoomCardReloaded
+      .locator("tr")
+      .filter({ hasText: "18:00" });
     await expect(newBlockRow).toBeVisible();
     const text = await newBlockRow.innerText();
     const match = text.match(/(\d+(?:\.\d+)?)\s*°[CF]/);

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -120,13 +120,20 @@ def _temp_range_error(field: str, low_f: float, high_f: float, unit: str) -> web
 
 
 def _validate_ambient_suppression(
-    body: dict, unit: str, tc_deadband_f: float
+    body: dict, unit: str, tc_deadband_f: float, feature_enabled: bool
 ) -> tuple[web.Response | None, dict]:
     """Validate the ambient-suppression (pre-cool/pre-heat) fields in *body*.
 
     Only keys actually present in *body* are validated, so the same helper
     serves both create (full body) and update (partial body). Temperature
     fields are deltas and are converted to °F via ``_delta_to_f``.
+
+    ``feature_enabled`` is the effective enabled state for the room after this
+    write. The "widened deadband must be ≥ the thermostat deadband" rule is only
+    enforced when the feature is enabled: when it is off the value is unused
+    (and the engine clamps with ``max()`` regardless), so a default widened
+    deadband must never block an unrelated room save on a wide-deadband
+    thermostat.
 
     Returns ``(error_response | None, converted_updates)``. On the first
     validation failure the error response is returned and the updates dict is
@@ -164,7 +171,7 @@ def _validate_ambient_suppression(
         if isinstance(val, bool) or not isinstance(val, (int, float)):
             return error("ambient_suppression_deadband must be numeric"), {}
         val_f = _delta_to_f(val, unit)
-        if val_f < tc_deadband_f:
+        if feature_enabled and val_f < tc_deadband_f:
             min_display = _from_f_delta(tc_deadband_f, unit)
             return (
                 error(
@@ -289,7 +296,8 @@ async def create_room(request: web.Request) -> web.Response:
     # room's thermostat deadband. get_thermostat_config returns a default config
     # (deadband 0.5) when the thermostat has no row yet.
     tc = await db.get_thermostat_config(conn, body["thermostat_entity_id"])
-    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband)
+    ambient_enabled = bool(body.get("ambient_suppression_enabled", False))
+    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband, ambient_enabled)
     if err is not None:
         return err
 
@@ -368,7 +376,10 @@ async def update_room(request: web.Request) -> web.Response:
     # (a request can switch thermostat_entity_id in the same PUT).
     effective_thermostat = body.get("thermostat_entity_id", room.thermostat_entity_id)
     tc = await db.get_thermostat_config(conn, effective_thermostat)
-    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband)
+    ambient_enabled = bool(
+        body.get("ambient_suppression_enabled", room.ambient_suppression_enabled)
+    )
+    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband, ambient_enabled)
     if err is not None:
         return err
     for field in (

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -101,11 +101,90 @@ def _from_f(value: float | None, unit: str) -> float | str:
     return round(float(value), 1)
 
 
+def _from_f_delta(value: float, unit: str) -> float:
+    """Convert a stored °F *delta* (deadband/offset) to the active display unit (1dp).
+
+    Unlike :func:`_from_f`, this applies no -32 offset — a 2 °F deadband is a
+    1.1 °C deadband, not a negative number.
+    """
+    if unit == "C":
+        return round(value * 5 / 9, 1)
+    return round(float(value), 1)
+
+
 def _temp_range_error(field: str, low_f: float, high_f: float, unit: str) -> web.Response:
     """Generate a unit-aware temperature range error response."""
     low = _from_f(low_f, unit)
     high = _from_f(high_f, unit)
     return error(f"{field} must be between {low} and {high}°{unit}")
+
+
+def _validate_ambient_suppression(
+    body: dict, unit: str, tc_deadband_f: float
+) -> tuple[web.Response | None, dict]:
+    """Validate the ambient-suppression (pre-cool/pre-heat) fields in *body*.
+
+    Only keys actually present in *body* are validated, so the same helper
+    serves both create (full body) and update (partial body). Temperature
+    fields are deltas and are converted to °F via ``_delta_to_f``.
+
+    Returns ``(error_response | None, converted_updates)``. On the first
+    validation failure the error response is returned and the updates dict is
+    empty; otherwise the updates dict holds storage-ready (°F where relevant)
+    values keyed by Room attribute name. See Issue #248.
+    """
+    updates: dict = {}
+
+    if "ambient_suppression_enabled" in body:
+        val = body["ambient_suppression_enabled"]
+        if not isinstance(val, bool):
+            return error("ambient_suppression_enabled must be a boolean"), {}
+        updates["ambient_suppression_enabled"] = val
+
+    if "ambient_suppression_mode" in body:
+        val = body["ambient_suppression_mode"]
+        if val not in ("any_presence", "off_schedule_only"):
+            return (
+                error("ambient_suppression_mode must be 'any_presence' or 'off_schedule_only'"),
+                {},
+            )
+        updates["ambient_suppression_mode"] = val
+
+    if "ambient_suppression_min_differential" in body:
+        val = body["ambient_suppression_min_differential"]
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            return error("ambient_suppression_min_differential must be numeric"), {}
+        val_f = _delta_to_f(val, unit)
+        if val_f < 0:
+            return error("ambient_suppression_min_differential must be 0 or greater"), {}
+        updates["ambient_suppression_min_differential"] = val_f
+
+    if "ambient_suppression_deadband" in body:
+        val = body["ambient_suppression_deadband"]
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            return error("ambient_suppression_deadband must be numeric"), {}
+        val_f = _delta_to_f(val, unit)
+        if val_f < tc_deadband_f:
+            min_display = _from_f_delta(tc_deadband_f, unit)
+            return (
+                error(
+                    "ambient_suppression_deadband must be at least the thermostat's "
+                    f"deadband ({min_display}°{unit})"
+                ),
+                {},
+            )
+        updates["ambient_suppression_deadband"] = val_f
+
+    if "ambient_suppression_off_schedule_window_min" in body:
+        val = body["ambient_suppression_off_schedule_window_min"]
+        if isinstance(val, bool) or not isinstance(val, int) or val < 0:
+            return (
+                error("ambient_suppression_off_schedule_window_min must be a non-negative integer"),
+                {},
+            )
+        updates["ambient_suppression_off_schedule_window_min"] = val
+
+    return None, updates
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +219,9 @@ TEMPERATURE_FIELDS: dict[str, str] = {
     # Room
     "system_wide_temp": "absolute_nullable",
     "temp_offset": "delta",
+    # Room — ambient-aware presence suppression / pre-cool (Issue #248)
+    "ambient_suppression_min_differential": "delta",
+    "ambient_suppression_deadband": "delta",
     # Schedules / overrides
     "target_temp": "absolute",
 }
@@ -202,6 +284,15 @@ async def create_room(request: web.Request) -> web.Response:
     if not (-20 <= temp_offset_f <= 20):
         return error("temp_offset must be between -20 and 20°F (or equivalent)")
 
+    conn = await get_conn(request)
+    # Ambient suppression (Issue #248): widened deadband is validated against the
+    # room's thermostat deadband. get_thermostat_config returns a default config
+    # (deadband 0.5) when the thermostat has no row yet.
+    tc = await db.get_thermostat_config(conn, body["thermostat_entity_id"])
+    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband)
+    if err is not None:
+        return err
+
     room = Room.create(
         name=body["name"],
         thermostat_entity_id=body["thermostat_entity_id"],
@@ -210,8 +301,8 @@ async def create_room(request: web.Request) -> web.Response:
         presence_holdover_hours=holdover,
         notes=body.get("notes", ""),
         temp_offset=temp_offset_f,
+        **ambient_updates,
     )
-    conn = await get_conn(request)
     await db.upsert_room(conn, room)
     await refresh(request)
     await emit(request, "info", "api", f"Room created: {room.name}", {"room_id": room.id})
@@ -273,6 +364,13 @@ async def update_room(request: web.Request) -> web.Response:
         val_f = _delta_to_f(val, unit)
         if not (-20 <= val_f <= 20):
             return error("temp_offset must be between -20 and 20°F (or equivalent)")
+    # Ambient suppression (Issue #248): validate against the *effective* thermostat
+    # (a request can switch thermostat_entity_id in the same PUT).
+    effective_thermostat = body.get("thermostat_entity_id", room.thermostat_entity_id)
+    tc = await db.get_thermostat_config(conn, effective_thermostat)
+    err, ambient_updates = _validate_ambient_suppression(body, unit, tc.deadband)
+    if err is not None:
+        return err
     for field in (
         "name",
         "thermostat_entity_id",
@@ -287,6 +385,8 @@ async def update_room(request: web.Request) -> web.Response:
         room.system_wide_temp = _to_f(val, unit) if val is not None else None
     if "temp_offset" in body:
         room.temp_offset = _delta_to_f(body["temp_offset"], unit)
+    for attr, value in ambient_updates.items():
+        setattr(room, attr, value)
     await db.upsert_room(conn, room)
     await refresh(request)
     await emit(request, "info", "api", f"Room updated: {room.name}", {"room_id": room.id})

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -46,7 +46,12 @@ CREATE TABLE IF NOT EXISTS rooms (
     system_wide_temp REAL,
     presence_holdover_hours REAL NOT NULL DEFAULT 2.0,
     notes TEXT NOT NULL DEFAULT '',
-    temp_offset REAL NOT NULL DEFAULT 0.0
+    temp_offset REAL NOT NULL DEFAULT 0.0,
+    ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0,
+    ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence',
+    ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0,
+    ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0,
+    ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60
 );
 
 CREATE TABLE IF NOT EXISTS room_sensors (
@@ -387,6 +392,12 @@ _MIGRATIONS = [
     # loop gates on this to stop reopened vents from flapping back closed.
     "ALTER TABLE cycle_logs ADD COLUMN in_min_runtime_hold INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE thermostat_configs ADD COLUMN overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1",
+    # Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248)
+    "ALTER TABLE rooms ADD COLUMN ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE rooms ADD COLUMN ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence'",
+    "ALTER TABLE rooms ADD COLUMN ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0",
+    "ALTER TABLE rooms ADD COLUMN ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0",
+    "ALTER TABLE rooms ADD COLUMN ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60",
 ]
 
 
@@ -457,14 +468,24 @@ def _row_to_room(row) -> Room:
         presence_holdover_hours=row["presence_holdover_hours"],
         notes=row["notes"],
         temp_offset=row["temp_offset"] if row["temp_offset"] is not None else 0.0,
+        ambient_suppression_enabled=bool(row["ambient_suppression_enabled"]),
+        ambient_suppression_mode=row["ambient_suppression_mode"],
+        ambient_suppression_min_differential=row["ambient_suppression_min_differential"],
+        ambient_suppression_deadband=row["ambient_suppression_deadband"],
+        ambient_suppression_off_schedule_window_min=row[
+            "ambient_suppression_off_schedule_window_min"
+        ],
     )
 
 
 async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
     await conn.execute(
         """INSERT INTO rooms (id,name,thermostat_entity_id,include_thermostat_sensor,
-           system_wide_temp,presence_holdover_hours,notes,temp_offset)
-           VALUES (?,?,?,?,?,?,?,?)
+           system_wide_temp,presence_holdover_hours,notes,temp_offset,
+           ambient_suppression_enabled,ambient_suppression_mode,
+           ambient_suppression_min_differential,ambient_suppression_deadband,
+           ambient_suppression_off_schedule_window_min)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(id) DO UPDATE SET
              name=excluded.name,
              thermostat_entity_id=excluded.thermostat_entity_id,
@@ -472,7 +493,12 @@ async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
              system_wide_temp=excluded.system_wide_temp,
              presence_holdover_hours=excluded.presence_holdover_hours,
              notes=excluded.notes,
-             temp_offset=excluded.temp_offset
+             temp_offset=excluded.temp_offset,
+             ambient_suppression_enabled=excluded.ambient_suppression_enabled,
+             ambient_suppression_mode=excluded.ambient_suppression_mode,
+             ambient_suppression_min_differential=excluded.ambient_suppression_min_differential,
+             ambient_suppression_deadband=excluded.ambient_suppression_deadband,
+             ambient_suppression_off_schedule_window_min=excluded.ambient_suppression_off_schedule_window_min
         """,
         (
             room.id,
@@ -483,6 +509,11 @@ async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
             room.presence_holdover_hours,
             room.notes,
             room.temp_offset,
+            int(room.ambient_suppression_enabled),
+            room.ambient_suppression_mode,
+            room.ambient_suppression_min_differential,
+            room.ambient_suppression_deadband,
+            room.ambient_suppression_off_schedule_window_min,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1546,11 +1546,11 @@ class CycleEngine:
         holding the room off: it would normally call for HVAC but is being
         allowed to coast toward target on outside air.
 
-        With the feature inactive (disabled, non-presence source, no outside
-        reading, or ``tc`` unknown) this collapses to the plain normal-deadband
-        vote, so existing callers are unaffected.
+        With the feature inactive (disabled, non-presence source, or no outside
+        reading) this collapses to the plain normal-deadband vote — no widened
+        band and no hard cap — so rooms not using the feature are unaffected.
 
-        Decision:
+        Decision (only when the feature is active for this room):
         - **Minimum-differential gate** — only coast when the outside temp is at
           least ``min_differential`` °F past the target on the helpful side.
         - **Asymmetric widened deadband** — relax only the side being coasted
@@ -1558,8 +1558,8 @@ class CycleEngine:
           longer matches and ``base`` (the normal deadband) governs the far
           side, so e.g. coasting up the room cools at ``target + normal_deadband``
           rather than ``target + widened_deadband``.
-        - **Hard cap** — the thermostat min/max setpoint always wins, forcing
-          HVAC if the room drifts past the absolute comfort bounds.
+        - **Hard cap** — the thermostat min/max setpoint overrides suppression,
+          forcing HVAC if the room drifts past the absolute comfort bounds.
         """
         if effective > target + normal_deadband:
             base = "cool"
@@ -1587,12 +1587,15 @@ class CycleEngine:
             # Otherwise the differential gate is not met, or the room has crossed
             # to the far side of target — keep the normal-deadband ``base`` vote.
 
-        # Hard cap (absolute comfort protection) — always wins.
-        if tc is not None:
-            if effective <= tc.min_setpoint:
-                vote, suppressed = "heat", False
-            elif effective >= tc.max_setpoint:
-                vote, suppressed = "cool", False
+            # Hard cap (absolute comfort protection) — overrides suppression so a
+            # coasting room never drifts past the thermostat's min/max setpoint.
+            # Scoped to feature-active rooms: a room not using pre-cool/pre-heat
+            # keeps its plain deadband vote with no new comfort floor.
+            if tc is not None:
+                if effective <= tc.min_setpoint:
+                    vote, suppressed = "heat", False
+                elif effective >= tc.max_setpoint:
+                    vote, suppressed = "cool", False
 
         return vote, suppressed
 

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -287,12 +287,17 @@ class CycleEngine:
         # Fetch thermostat config (needed for mode inference and room filtering).
         tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
 
+        # Outside temperature for ambient presence-suppression / pre-cool
+        # (Issue #248). Read once per tick; None when no sensor is configured or
+        # it is unreadable, in which case the feature stays inert (fail-safe).
+        outside_temp_f = await self._read_outside_temp(conn)
+
         # Determine the effective mode for this tick:
         # - IDLE: infer from room temps (majority vote)
         # - RUNNING: use the mode locked at cycle start
         if self._state == CycleState.IDLE:
             inferred = await self._infer_mode_from_room_temps(
-                new_active_map, tc.deadband, thermo_state
+                new_active_map, tc.deadband, thermo_state, outside_temp=outside_temp_f, tc=tc
             )
             if inferred == "off":
                 # All rooms within deadband — reset setpoint to ambient so the HVAC
@@ -384,7 +389,7 @@ class CycleEngine:
         # needing heat would open those rooms' vents during cooling, driving
         # them further from target.  (Issue #48 Bug 3)
         new_active_map = await self._filter_rooms_for_mode(
-            new_active_map, effective_mode, tc.deadband, thermo_state
+            new_active_map, effective_mode, tc.deadband, thermo_state, outside_temp_f, tc
         )
 
         if not new_active_map:
@@ -1450,11 +1455,100 @@ class CycleEngine:
         # it is unknown. _cycle_mode handles monitoring direction mid-cycle.
         return "off"
 
+    def _ambient_suppression_eligible(self, room: Room, source: str) -> bool:
+        """Whether ambient presence-suppression (pre-cool/pre-heat) may engage.
+
+        Covers the gates that do not depend on temperature (Issue #248):
+        - the room opted in,
+        - the demand is presence-driven (schedule/override are explicit user
+          intent and are never suppressed),
+        - the trigger-scope mode permits it right now.
+
+        ``off_schedule_only`` needs a schedule-end window check that is wired in
+        a later phase; until then it never engages — the conservative default,
+        since wrongly suppressing is worse than conditioning normally.
+        """
+        if not room.ambient_suppression_enabled:
+            return False
+        if source != "presence":
+            return False
+        # TODO(Issue #248 Phase 3): off_schedule_only should engage only within
+        # the post-schedule window. Until that lands it never engages — the
+        # conservative default (better to condition normally than wrongly skip).
+        return room.ambient_suppression_mode != "off_schedule_only"
+
+    def _suppression_vote(
+        self,
+        room: Room,
+        effective: float,
+        target: float,
+        source: str,
+        normal_deadband: float,
+        outside_temp: float | None,
+        tc: ThermostatConfig | None,
+    ) -> tuple[str, bool]:
+        """Return ``(vote, suppressed)`` for one room (Issue #248).
+
+        ``vote`` is the room's HVAC demand — ``"cool"`` | ``"heat"`` | ``"off"``.
+        ``suppressed`` is True when ambient presence-suppression is actively
+        holding the room off: it would normally call for HVAC but is being
+        allowed to coast toward target on outside air.
+
+        With the feature inactive (disabled, non-presence source, no outside
+        reading, or ``tc`` unknown) this collapses to the plain normal-deadband
+        vote, so existing callers are unaffected.
+
+        Decision:
+        - **Minimum-differential gate** — only coast when the outside temp is at
+          least ``min_differential`` °F past the target on the helpful side.
+        - **Asymmetric widened deadband** — relax only the side being coasted
+          from. The instant the room crosses the target, the coasting branch no
+          longer matches and ``base`` (the normal deadband) governs the far
+          side, so e.g. coasting up the room cools at ``target + normal_deadband``
+          rather than ``target + widened_deadband``.
+        - **Hard cap** — the thermostat min/max setpoint always wins, forcing
+          HVAC if the room drifts past the absolute comfort bounds.
+        """
+        if effective > target + normal_deadband:
+            base = "cool"
+        elif effective < target - normal_deadband:
+            base = "heat"
+        else:
+            base = "off"
+
+        vote = base
+        suppressed = False
+
+        if outside_temp is not None and self._ambient_suppression_eligible(room, source):
+            differential = room.ambient_suppression_min_differential
+            wide = max(room.ambient_suppression_deadband, normal_deadband)
+            if effective < target and outside_temp >= target + differential:
+                # Coast up: warm enough outside to drift up — relax heating only.
+                vote = "heat" if effective < target - wide else "off"
+                suppressed = vote != base
+            elif effective > target and outside_temp <= target - differential:
+                # Coast down: cool enough outside to drift down — relax cooling only.
+                vote = "cool" if effective > target + wide else "off"
+                suppressed = vote != base
+            # Otherwise the differential gate is not met, or the room has crossed
+            # to the far side of target — keep the normal-deadband ``base`` vote.
+
+        # Hard cap (absolute comfort protection) — always wins.
+        if tc is not None:
+            if effective <= tc.min_setpoint:
+                vote, suppressed = "heat", False
+            elif effective >= tc.max_setpoint:
+                vote, suppressed = "cool", False
+
+        return vote, suppressed
+
     async def _infer_mode_from_room_temps(
         self,
         active_rooms: dict[str, ActiveRoom],
         deadband: float,
         thermo_state: dict | None = None,
+        outside_temp: float | None = None,
+        tc: ThermostatConfig | None = None,
     ) -> str:
         """Determine needed cycle direction from room temperatures vs targets.
 
@@ -1498,9 +1592,12 @@ class CycleEngine:
             if avg is None:
                 continue  # no data at all; skip room
             effective = avg + ar.room.temp_offset
-            if effective > ar.target_temp + deadband:
+            vote, _suppressed = self._suppression_vote(
+                ar.room, effective, ar.target_temp, ar.source, deadband, outside_temp, tc
+            )
+            if vote == "cool":
                 needs_cool += 1
-            elif effective < ar.target_temp - deadband:
+            elif vote == "heat":
                 needs_heat += 1
 
         if needs_cool == 0 and needs_heat == 0:
@@ -1564,11 +1661,18 @@ class CycleEngine:
         mode: str,
         deadband: float,
         thermo_state: dict | None,
+        outside_temp: float | None = None,
+        tc: ThermostatConfig | None = None,
     ) -> dict[str, ActiveRoom]:
         """Remove rooms that need the opposite direction from the cycle mode.
 
         Rooms within deadband or needing the same direction are kept.  Rooms
         with no sensor data are kept (benefit of the doubt).  (Issue #48 Bug 3)
+
+        Rooms the ambient pre-cool/pre-heat feature is actively suppressing
+        (Issue #248) are dropped here too: they carry no demand and must not be
+        pulled into another room's cycle, so they coast with their vents at the
+        resting (open) position like any idle room.
         """
         thermo_ambient: float | None = None
         if thermo_state:
@@ -1587,7 +1691,41 @@ class CycleEngine:
                 filtered[room_id] = ar
                 continue
             effective = avg + ar.room.temp_offset
-            if mode == "cooling" and effective < ar.target_temp - deadband:
+            vote, suppressed = self._suppression_vote(
+                ar.room, effective, ar.target_temp, ar.source, deadband, outside_temp, tc
+            )
+            if suppressed:
+                # Ambient pre-cool/pre-heat is holding this room off — drop it so
+                # it coasts toward target on outside air instead of riding the
+                # cycle (Issue #248). Its vents stay at the resting open position.
+                log.info(
+                    "Excluding room %s from %s cycle — ambient pre-cool/pre-heat "
+                    "is letting it coast (effective=%.1f, target=%.1f, outside=%s)",
+                    ar.room.name,
+                    mode,
+                    effective,
+                    ar.target_temp,
+                    f"{outside_temp:.1f}" if outside_temp is not None else "n/a",
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "info",
+                        "engine",
+                        f"Room {ar.room.name} left to coast — ambient pre-cool/pre-heat "
+                        f"is skipping presence {mode} (effective={effective:.1f}°F, "
+                        f"target={ar.target_temp}°F).",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room_id": room_id,
+                            "room_name": ar.room.name,
+                            "effective_temp": effective,
+                            "target_temp": ar.target_temp,
+                            "outside_temp": outside_temp,
+                            "cycle_mode": mode,
+                        },
+                    )
+                continue
+            if mode == "cooling" and vote == "heat":
                 # Room needs heating but cycle is cooling — exclude
                 log.info(
                     "Excluding room %s from cooling cycle — needs heating "
@@ -1613,7 +1751,7 @@ class CycleEngine:
                         },
                     )
                 continue
-            if mode == "heating" and effective > ar.target_temp + deadband:
+            if mode == "heating" and vote == "cool":
                 # Room needs cooling but cycle is heating — exclude
                 log.info(
                     "Excluding room %s from heating cycle — needs cooling "

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -30,7 +30,12 @@ from ..models import (
     ThermostatConfig,
     ZoneStatus,
 )
-from .room_manager import ActiveRoom, expire_holdovers, get_active_rooms
+from .room_manager import (
+    ActiveRoom,
+    _seconds_since_schedule_end,
+    expire_holdovers,
+    get_active_rooms,
+)
 from .vent_controller import VentController, required_open_vents
 
 log = logging.getLogger(__name__)
@@ -291,13 +296,21 @@ class CycleEngine:
         # (Issue #248). Read once per tick; None when no sensor is configured or
         # it is unreadable, in which case the feature stays inert (fail-safe).
         outside_temp_f = await self._read_outside_temp(conn)
+        # Per-room off_schedule_only window flags (only queried for rooms using
+        # that mode). Threaded into both inference and filtering.
+        off_schedule_ok = await self._compute_off_schedule_flags(conn, new_active_map)
 
         # Determine the effective mode for this tick:
         # - IDLE: infer from room temps (majority vote)
         # - RUNNING: use the mode locked at cycle start
         if self._state == CycleState.IDLE:
             inferred = await self._infer_mode_from_room_temps(
-                new_active_map, tc.deadband, thermo_state, outside_temp=outside_temp_f, tc=tc
+                new_active_map,
+                tc.deadband,
+                thermo_state,
+                outside_temp=outside_temp_f,
+                tc=tc,
+                off_schedule_ok=off_schedule_ok,
             )
             if inferred == "off":
                 # All rooms within deadband — reset setpoint to ambient so the HVAC
@@ -389,7 +402,13 @@ class CycleEngine:
         # needing heat would open those rooms' vents during cooling, driving
         # them further from target.  (Issue #48 Bug 3)
         new_active_map = await self._filter_rooms_for_mode(
-            new_active_map, effective_mode, tc.deadband, thermo_state, outside_temp_f, tc
+            new_active_map,
+            effective_mode,
+            tc.deadband,
+            thermo_state,
+            outside_temp_f,
+            tc,
+            off_schedule_ok,
         )
 
         if not new_active_map:
@@ -1455,7 +1474,9 @@ class CycleEngine:
         # it is unknown. _cycle_mode handles monitoring direction mid-cycle.
         return "off"
 
-    def _ambient_suppression_eligible(self, room: Room, source: str) -> bool:
+    def _ambient_suppression_eligible(
+        self, room: Room, source: str, recently_off_schedule: bool
+    ) -> bool:
         """Whether ambient presence-suppression (pre-cool/pre-heat) may engage.
 
         Covers the gates that do not depend on temperature (Issue #248):
@@ -1464,18 +1485,48 @@ class CycleEngine:
           intent and are never suppressed),
         - the trigger-scope mode permits it right now.
 
-        ``off_schedule_only`` needs a schedule-end window check that is wired in
-        a later phase; until then it never engages — the conservative default,
-        since wrongly suppressing is worse than conditioning normally.
+        For ``off_schedule_only`` the room must also have *recently* come off a
+        schedule — ``recently_off_schedule`` is precomputed by the caller from
+        the room's schedules and its configured window (see
+        ``_compute_off_schedule_flags``). ``any_presence`` ignores that flag.
         """
         if not room.ambient_suppression_enabled:
             return False
         if source != "presence":
             return False
-        # TODO(Issue #248 Phase 3): off_schedule_only should engage only within
-        # the post-schedule window. Until that lands it never engages — the
-        # conservative default (better to condition normally than wrongly skip).
-        return room.ambient_suppression_mode != "off_schedule_only"
+        if room.ambient_suppression_mode == "off_schedule_only":
+            return recently_off_schedule
+        return True
+
+    async def _compute_off_schedule_flags(
+        self,
+        conn: aiosqlite.Connection,
+        active_rooms: dict[str, ActiveRoom],
+        now: datetime | None = None,
+    ) -> dict[str, bool]:
+        """Precompute the ``off_schedule_only`` window flag per room (Issue #248).
+
+        Only rooms that actually use the mode are queried. A room qualifies when
+        a schedule block ended within the last
+        ``ambient_suppression_off_schedule_window_min`` minutes. Returns a map of
+        ``room_id -> bool``; absent rooms are treated as False by callers.
+        """
+        flags: dict[str, bool] = {}
+        if now is None:
+            now = datetime.now(UTC)
+        for ar in active_rooms.values():
+            room = ar.room
+            if (
+                room.ambient_suppression_enabled
+                and ar.source == "presence"
+                and room.ambient_suppression_mode == "off_schedule_only"
+            ):
+                schedules = await db.get_schedules_for_room(conn, room.id)
+                gap = _seconds_since_schedule_end(schedules, now)
+                flags[room.id] = (
+                    gap is not None and gap <= room.ambient_suppression_off_schedule_window_min * 60
+                )
+        return flags
 
     def _suppression_vote(
         self,
@@ -1486,6 +1537,7 @@ class CycleEngine:
         normal_deadband: float,
         outside_temp: float | None,
         tc: ThermostatConfig | None,
+        recently_off_schedule: bool = False,
     ) -> tuple[str, bool]:
         """Return ``(vote, suppressed)`` for one room (Issue #248).
 
@@ -1519,7 +1571,9 @@ class CycleEngine:
         vote = base
         suppressed = False
 
-        if outside_temp is not None and self._ambient_suppression_eligible(room, source):
+        if outside_temp is not None and self._ambient_suppression_eligible(
+            room, source, recently_off_schedule
+        ):
             differential = room.ambient_suppression_min_differential
             wide = max(room.ambient_suppression_deadband, normal_deadband)
             if effective < target and outside_temp >= target + differential:
@@ -1549,6 +1603,7 @@ class CycleEngine:
         thermo_state: dict | None = None,
         outside_temp: float | None = None,
         tc: ThermostatConfig | None = None,
+        off_schedule_ok: dict[str, bool] | None = None,
     ) -> str:
         """Determine needed cycle direction from room temperatures vs targets.
 
@@ -1592,8 +1647,16 @@ class CycleEngine:
             if avg is None:
                 continue  # no data at all; skip room
             effective = avg + ar.room.temp_offset
+            recently_off = bool(off_schedule_ok and off_schedule_ok.get(ar.room.id))
             vote, _suppressed = self._suppression_vote(
-                ar.room, effective, ar.target_temp, ar.source, deadband, outside_temp, tc
+                ar.room,
+                effective,
+                ar.target_temp,
+                ar.source,
+                deadband,
+                outside_temp,
+                tc,
+                recently_off,
             )
             if vote == "cool":
                 needs_cool += 1
@@ -1663,6 +1726,7 @@ class CycleEngine:
         thermo_state: dict | None,
         outside_temp: float | None = None,
         tc: ThermostatConfig | None = None,
+        off_schedule_ok: dict[str, bool] | None = None,
     ) -> dict[str, ActiveRoom]:
         """Remove rooms that need the opposite direction from the cycle mode.
 
@@ -1691,8 +1755,16 @@ class CycleEngine:
                 filtered[room_id] = ar
                 continue
             effective = avg + ar.room.temp_offset
+            recently_off = bool(off_schedule_ok and off_schedule_ok.get(ar.room.id))
             vote, suppressed = self._suppression_vote(
-                ar.room, effective, ar.target_temp, ar.source, deadband, outside_temp, tc
+                ar.room,
+                effective,
+                ar.target_temp,
+                ar.source,
+                deadband,
+                outside_temp,
+                tc,
+                recently_off,
             )
             if suppressed:
                 # Ambient pre-cool/pre-heat is holding this room off — drop it so

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -201,6 +201,47 @@ def _seconds_until_schedule_end(s: Schedule, now: datetime) -> float:
     return max(0.0, (end_dt - local_now).total_seconds())
 
 
+def _seconds_since_schedule_end(
+    schedules: list[Schedule],
+    now: datetime,
+) -> float | None:
+    """Seconds since the most recently ended schedule block, or None.
+
+    Used by the ambient pre-cool/pre-heat ``off_schedule_only`` mode
+    (Issue #248) to tell whether a room has *recently* come off a schedule.
+    Considers the real end instant of each block — for an overnight block
+    (``end_time <= start_time``) that is ``end_time`` on the day *after* the
+    scheduled day. Returns the smallest non-negative gap across all blocks that
+    have already ended within the past week, or None when none have.
+    """
+    if not schedules:
+        return None
+
+    # Schedules are local wall-clock; do the arithmetic in naive-local so the
+    # naive datetime.combine(...) below lines up with ``now``.
+    local_now = now.astimezone().replace(tzinfo=None) if now.tzinfo else now
+
+    best: float | None = None
+    for s in schedules:
+        is_overnight = s.end_time <= s.start_time
+        # Walk back over the last 7 days; a block whose end falls on
+        # ``candidate_date`` belongs to a scheduled day that is the same day
+        # (daytime block) or the previous day (overnight block).
+        for day_offset in range(8):
+            candidate_date = local_now.date() - timedelta(days=day_offset)
+            end_weekday = candidate_date.weekday()
+            scheduled_day = end_weekday if not is_overnight else (end_weekday - 1) % 7
+            if scheduled_day not in s.days_of_week:
+                continue
+            end_dt = datetime.combine(candidate_date, s.end_time)
+            if end_dt > local_now:
+                continue  # this occurrence hasn't ended yet
+            gap = (local_now - end_dt).total_seconds()
+            if best is None or gap < best:
+                best = gap
+    return best
+
+
 def _next_schedule_start(
     schedules: list[Schedule],
     now: datetime,

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -42,6 +42,21 @@ class Room:
     presence_holdover_hours: float = 2.0
     notes: str = ""
     temp_offset: float = 0.0  # °F added to measured avg before comparing to target
+    # Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
+    # Per-room opt-in; only active when an outside temperature sensor is
+    # configured. When the outside temp is at least
+    # ``ambient_suppression_min_differential`` °F past the presence target on the
+    # helpful side, the room is allowed to drift to target on its own instead of
+    # calling for HVAC, riding a widened deadband on the coasting side only.
+    ambient_suppression_enabled: bool = False
+    # "any_presence" | "off_schedule_only"
+    ambient_suppression_mode: str = "any_presence"
+    # °F the outside temp must be past the target before coasting (>= 0).
+    ambient_suppression_min_differential: float = 5.0
+    # °F widened deadband applied while coasting (>= thermostat deadband).
+    ambient_suppression_deadband: float = 2.0
+    # Minutes after a schedule block ends that off_schedule_only mode applies.
+    ambient_suppression_off_schedule_window_min: int = 60
 
     @classmethod
     def create(cls, name: str, thermostat_entity_id: str, **kwargs) -> Room:

--- a/smart_vent/backend/tests/integration/test_ambient_suppression_tick.py
+++ b/smart_vent/backend/tests/integration/test_ambient_suppression_tick.py
@@ -1,0 +1,108 @@
+"""Full-tick integration tests for ambient pre-cool/pre-heat (Issue #248).
+
+The unit tests in test_cycle_engine.py exercise the per-room vote in isolation;
+these drive the whole scheduler tick against a fake Home Assistant to prove the
+wiring (outside-temp read → mode inference → cycle decision) actually suppresses
+a real presence-driven cycle, and that the control case still runs HVAC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend import db as _db
+from backend.models import PresenceHoldoverState
+
+THERMO = "climate.test_thermostat"
+ROOM_SENSOR = "sensor.office_temp"
+ROOM_VENT = "cover.office_vent"
+OUTDOOR = "sensor.outdoor"
+
+
+def _seed_cold_room(fake_ha, outside_f: str) -> None:
+    """Room at 67°F wanting 70°F (would normally heat); thermostat in heat mode."""
+    fake_ha.seed_state(
+        THERMO,
+        "heat",
+        {"current_temperature": 67.0, "temperature": 70.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(ROOM_SENSOR, "67.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(ROOM_VENT, "open", {})
+    fake_ha.seed_state(OUTDOOR, outside_f, {"unit_of_measurement": "°F"})
+
+
+async def _create_presence_room(client, **ambient):
+    """Create a presence-active room (planted holdover) with the given ambient config."""
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Office",
+            "thermostat_entity_id": THERMO,
+            "system_wide_temp": 70.0,
+            "presence_holdover_hours": 2.0,
+            **ambient,
+        },
+    )
+    assert resp.status == 201, await resp.text()
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": ROOM_SENSOR})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": ROOM_VENT, "control_method": "open_close"},
+    )
+    # Plant an active presence holdover so the room resolves as source="presence".
+    conn = client.app["scheduler"]._db_conn
+    now = datetime.now(UTC)
+    await _db.upsert_holdover_state(
+        conn,
+        PresenceHoldoverState(
+            room_id=room_id, last_detected_at=now, expires_at=now + timedelta(hours=2)
+        ),
+    )
+    return room_id
+
+
+@pytest.mark.asyncio
+async def test_presence_heat_suppressed_when_outside_warm(client, fake_ha, tick) -> None:
+    """Warm outside + feature on → the presence heating demand is suppressed and
+    no cycle starts (the room coasts; vents rest)."""
+    _seed_cold_room(fake_ha, outside_f="80.0")  # 80 >= 70 + 5 → coast up
+    await _create_presence_room(
+        client,
+        ambient_suppression_enabled=True,
+        ambient_suppression_mode="any_presence",
+        ambient_suppression_min_differential=5,
+        ambient_suppression_deadband=3,
+    )
+    await client.put("/api/settings/outside-temp-entity", json={"entity_id": OUTDOOR})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 0, "no cycle should start while the room is coasting"
+    assert client.app["scheduler"]._engines[THERMO].cycle_state.value == "idle"
+
+
+@pytest.mark.asyncio
+async def test_presence_heat_runs_when_differential_too_small(client, fake_ha, tick) -> None:
+    """Only +1°F outside (< 5 differential) → no coasting → a heating cycle runs.
+
+    Identical to the suppression case except the outside reading, proving the
+    feature — not some other idleness — is what held the cycle off."""
+    _seed_cold_room(fake_ha, outside_f="71.0")  # 71 < 70 + 5 → gate not met
+    await _create_presence_room(
+        client,
+        ambient_suppression_enabled=True,
+        ambient_suppression_mode="any_presence",
+        ambient_suppression_min_differential=5,
+        ambient_suppression_deadband=3,
+    )
+    await client.put("/api/settings/outside-temp-entity", json={"entity_id": OUTDOOR})
+
+    await tick()
+
+    assert client.app["scheduler"]._engines[THERMO].cycle_state.value == "running"
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) >= 1, "a heating cycle should start when coasting is not warranted"

--- a/smart_vent/backend/tests/integration/test_rooms_api.py
+++ b/smart_vent/backend/tests/integration/test_rooms_api.py
@@ -259,12 +259,13 @@ async def test_room_ambient_deadband_must_be_at_least_thermostat_deadband(client
     )
     assert resp.status in (200, 201), await resp.text()
 
-    # Below the thermostat deadband -> rejected.
+    # Below the thermostat deadband, with the feature enabled -> rejected.
     resp = await client.post(
         "/api/rooms",
         json={
             "name": "Lower",
             "thermostat_entity_id": "climate.dband",
+            "ambient_suppression_enabled": True,
             "ambient_suppression_deadband": 0.9,
         },
     )
@@ -277,8 +278,32 @@ async def test_room_ambient_deadband_must_be_at_least_thermostat_deadband(client
         json={
             "name": "Equal",
             "thermostat_entity_id": "climate.dband",
+            "ambient_suppression_enabled": True,
             "ambient_suppression_deadband": 1.0,
         },
     )
     assert resp.status == 201, await resp.text()
     assert (await resp.json())["ambient_suppression_deadband"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_deadband_below_thermostat_allowed_when_disabled(
+    client, fake_ha
+) -> None:
+    """The widened-deadband floor only applies when the feature is enabled, so a
+    default widened deadband never blocks a room save on a wide-deadband
+    thermostat (regression for the unconditional-rejection edge case)."""
+    resp = await client.post(
+        "/api/thermostats",
+        json={"thermostat_entity_id": "climate.wide", "total_vents_count": 4, "deadband": 3.0},
+    )
+    assert resp.status in (200, 201), await resp.text()
+
+    # Feature off, widened deadband at the default 2.0 (< the 3.0 thermostat
+    # deadband) -> accepted, because the value is unused while disabled.
+    resp = await client.post(
+        "/api/rooms",
+        json={"name": "Wide", "thermostat_entity_id": "climate.wide"},
+    )
+    assert resp.status == 201, await resp.text()
+    assert (await resp.json())["ambient_suppression_deadband"] == 2.0

--- a/smart_vent/backend/tests/integration/test_rooms_api.py
+++ b/smart_vent/backend/tests/integration/test_rooms_api.py
@@ -136,3 +136,149 @@ async def test_system_enable_disable_roundtrip(client) -> None:
 
     resp = await client.get("/api/system/status")
     assert (await resp.json())["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Ambient-aware presence suppression / pre-cool fields (Issue #248, Phase 1)
+# ---------------------------------------------------------------------------
+
+
+async def _create_room(client, **extra):
+    body = {"name": "Office", "thermostat_entity_id": "climate.test_thermostat", **extra}
+    resp = await client.post("/api/rooms", json=body)
+    assert resp.status == 201, await resp.text()
+    return (await resp.json())["id"]
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_defaults(client, fake_ha) -> None:
+    """A room created without the new fields gets the documented defaults."""
+    room_id = await _create_room(client)
+    detail = await (await client.get(f"/api/rooms/{room_id}")).json()
+    assert detail["ambient_suppression_enabled"] is False
+    assert detail["ambient_suppression_mode"] == "any_presence"
+    assert detail["ambient_suppression_min_differential"] == 5.0
+    assert detail["ambient_suppression_deadband"] == 2.0
+    assert detail["ambient_suppression_off_schedule_window_min"] == 60
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_create_roundtrip(client, fake_ha) -> None:
+    room_id = await _create_room(
+        client,
+        ambient_suppression_enabled=True,
+        ambient_suppression_mode="off_schedule_only",
+        ambient_suppression_min_differential=4,
+        ambient_suppression_deadband=3,
+        ambient_suppression_off_schedule_window_min=90,
+    )
+    detail = await (await client.get(f"/api/rooms/{room_id}")).json()
+    assert detail["ambient_suppression_enabled"] is True
+    assert detail["ambient_suppression_mode"] == "off_schedule_only"
+    assert detail["ambient_suppression_min_differential"] == 4
+    assert detail["ambient_suppression_deadband"] == 3
+    assert detail["ambient_suppression_off_schedule_window_min"] == 90
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_update_roundtrip(client, fake_ha) -> None:
+    room_id = await _create_room(client)
+    resp = await client.put(
+        f"/api/rooms/{room_id}",
+        json={
+            "ambient_suppression_enabled": True,
+            "ambient_suppression_min_differential": 6,
+            "ambient_suppression_deadband": 2.5,
+        },
+    )
+    assert resp.status == 200, await resp.text()
+    detail = await (await client.get(f"/api/rooms/{room_id}")).json()
+    assert detail["ambient_suppression_enabled"] is True
+    assert detail["ambient_suppression_min_differential"] == 6
+    assert detail["ambient_suppression_deadband"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_celsius_delta_conversion(client, fake_ha) -> None:
+    """In Celsius mode the two delta fields are stored as °F (delta, no offset)."""
+    client.app["scheduler"]._active_unit = "C"
+    try:
+        # 2°C differential -> 3.6°F; 2°C widened deadband -> 3.6°F (>= 0.5°F floor).
+        room_id = await _create_room(
+            client,
+            ambient_suppression_min_differential=2,
+            ambient_suppression_deadband=2,
+        )
+    finally:
+        client.app["scheduler"]._active_unit = "F"
+    conn = client.app["scheduler"]._db_conn
+    room = await _db.get_room(conn, room_id)
+    assert room is not None
+    assert room.ambient_suppression_min_differential == 3.6
+    assert room.ambient_suppression_deadband == 3.6
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_rejects_negative_differential(client, fake_ha) -> None:
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Bad",
+            "thermostat_entity_id": "climate.test_thermostat",
+            "ambient_suppression_min_differential": -1,
+        },
+    )
+    assert resp.status == 400
+    assert "min_differential" in (await resp.json())["error"]
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_suppression_rejects_invalid_mode(client, fake_ha) -> None:
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Bad",
+            "thermostat_entity_id": "climate.test_thermostat",
+            "ambient_suppression_mode": "sometimes",
+        },
+    )
+    assert resp.status == 400
+    assert "ambient_suppression_mode" in (await resp.json())["error"]
+
+
+@pytest.mark.asyncio
+async def test_room_ambient_deadband_must_be_at_least_thermostat_deadband(client, fake_ha) -> None:
+    # Configure the thermostat with a 1.0°F deadband.
+    resp = await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": "climate.dband",
+            "total_vents_count": 4,
+            "deadband": 1.0,
+        },
+    )
+    assert resp.status in (200, 201), await resp.text()
+
+    # Below the thermostat deadband -> rejected.
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Lower",
+            "thermostat_entity_id": "climate.dband",
+            "ambient_suppression_deadband": 0.9,
+        },
+    )
+    assert resp.status == 400
+    assert "deadband" in (await resp.json())["error"]
+
+    # Equal to the thermostat deadband -> allowed.
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Equal",
+            "thermostat_entity_id": "climate.dband",
+            "ambient_suppression_deadband": 1.0,
+        },
+    )
+    assert resp.status == 201, await resp.text()
+    assert (await resp.json())["ambient_suppression_deadband"] == 1.0

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -2046,10 +2046,23 @@ class TestSuppressionVote:
     deadband 3°F, min differential 5°F, thermostat min/max setpoint 60/85°F.
     """
 
-    def _vote(self, engine, room, effective, *, outside, target=70.0, source="presence", tc=None):
+    def _vote(
+        self,
+        engine,
+        room,
+        effective,
+        *,
+        outside,
+        target=70.0,
+        source="presence",
+        tc=None,
+        recently_off=False,
+    ):
         if tc is None:
             tc = _make_tc(deadband=2.0, min_setpoint=60.0, max_setpoint=85.0)
-        return engine._suppression_vote(room, effective, target, source, 2.0, outside, tc)
+        return engine._suppression_vote(
+            room, effective, target, source, 2.0, outside, tc, recently_off
+        )
 
     def test_coast_up_suppresses_heat(self):
         # 67°F room, 80°F out: at the widened floor (70-3=67) -> hold off.
@@ -2108,12 +2121,26 @@ class TestSuppressionVote:
             False,
         )
 
-    def test_off_schedule_mode_does_not_engage_in_phase2(self):
+    def test_off_schedule_mode_inert_without_recent_schedule(self):
+        # off_schedule_only + not recently off a schedule -> normal heat.
         engine = _make_engine()
-        assert self._vote(engine, _supp_room(mode="off_schedule_only"), 67.0, outside=80.0) == (
-            "heat",
-            False,
-        )
+        assert self._vote(
+            engine, _supp_room(mode="off_schedule_only"), 67.0, outside=80.0, recently_off=False
+        ) == ("heat", False)
+
+    def test_off_schedule_mode_engages_when_recently_off_schedule(self):
+        # off_schedule_only + within the post-schedule window -> coast (suppress).
+        engine = _make_engine()
+        assert self._vote(
+            engine, _supp_room(mode="off_schedule_only"), 67.0, outside=80.0, recently_off=True
+        ) == ("off", True)
+
+    def test_any_presence_ignores_off_schedule_flag(self):
+        # any_presence engages regardless of the off-schedule flag.
+        engine = _make_engine()
+        assert self._vote(
+            engine, _supp_room(mode="any_presence"), 67.0, outside=80.0, recently_off=False
+        ) == ("off", True)
 
     def test_no_outside_reading_uses_normal_vote(self):
         engine = _make_engine()
@@ -2180,3 +2207,63 @@ class TestSuppressionInInference:
             rooms, 2.0, ha.get_state(THERMO_ID), outside_temp=71.0, tc=self._tc()
         )
         assert result == "heating"
+
+    @pytest.mark.asyncio
+    async def test_compute_off_schedule_flags_respects_window(self):
+        # Naive-local datetimes keep the result timezone-independent.
+        from datetime import time
+
+        from backend import db
+        from backend.models import Schedule
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        room = _supp_room(room_id="r1", mode="off_schedule_only")
+        room.ambient_suppression_off_schedule_window_min = 60
+        await db.upsert_room(conn, room)
+        await db.upsert_schedule(
+            conn,
+            Schedule(
+                id="s1",
+                room_id="r1",
+                days_of_week=[0],  # Monday 22:00 -> Tuesday 07:00 (overnight)
+                start_time=time(22, 0),
+                end_time=time(7, 0),
+                target_temp=68.0,
+            ),
+        )
+        active = {"r1": ActiveRoom(room=room, target_temp=70.0, source="presence")}
+        engine = _make_engine()
+
+        within = await engine._compute_off_schedule_flags(
+            conn,
+            active,
+            now=datetime(2026, 4, 14, 7, 30),  # 30 min after end
+        )
+        assert within == {"r1": True}
+
+        outside = await engine._compute_off_schedule_flags(
+            conn,
+            active,
+            now=datetime(2026, 4, 14, 9, 0),  # 120 min after end
+        )
+        assert outside == {"r1": False}
+
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_compute_off_schedule_flags_skips_other_modes(self):
+        # any_presence and disabled rooms are not queried at all.
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        from backend import db
+
+        await db.init_db(conn)
+        any_room = _supp_room(room_id="r1", mode="any_presence")
+        active = {"r1": ActiveRoom(room=any_room, target_temp=70.0, source="presence")}
+        engine = _make_engine()
+        flags = await engine._compute_off_schedule_flags(conn, active)
+        assert flags == {}
+        await conn.close()

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -2114,6 +2114,17 @@ class TestSuppressionVote:
         engine = _make_engine()
         assert self._vote(engine, _supp_room(enabled=False), 67.0, outside=80.0) == ("heat", False)
 
+    def test_hard_cap_not_applied_when_feature_disabled(self):
+        # The hard cap is part of the feature: a room not using pre-cool/pre-heat
+        # keeps its plain deadband vote even at the setpoint bound. Target 60 ==
+        # min_setpoint, room exactly at 60 -> within deadband -> "off", NOT a
+        # hard-capped "heat".
+        engine = _make_engine()
+        tc = _make_tc(deadband=2.0, min_setpoint=60.0, max_setpoint=85.0)
+        assert self._vote(
+            engine, _supp_room(enabled=False), 60.0, outside=80.0, target=60.0, tc=tc
+        ) == ("off", False)
+
     def test_non_presence_source_is_never_suppressed(self):
         engine = _make_engine()
         assert self._vote(engine, _supp_room(), 67.0, outside=80.0, source="schedule") == (

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -2013,3 +2013,170 @@ class TestRestoreFromDb:
         remaining = await db.get_open_cycle_logs(conn, THERMO_ID)
         assert remaining == []
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Ambient-aware presence suppression / pre-cool (Issue #248, Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _supp_room(
+    *,
+    room_id: str = "r1",
+    enabled: bool = True,
+    mode: str = "any_presence",
+    min_differential: float = 5.0,
+    deadband: float = 3.0,
+) -> Room:
+    return Room(
+        id=room_id,
+        name="Office",
+        thermostat_entity_id=THERMO_ID,
+        ambient_suppression_enabled=enabled,
+        ambient_suppression_mode=mode,
+        ambient_suppression_min_differential=min_differential,
+        ambient_suppression_deadband=deadband,
+    )
+
+
+class TestSuppressionVote:
+    """The per-room demand vote with ambient pre-cool/pre-heat (Issue #248).
+
+    Fixed scenario unless noted: target 70°F, normal deadband 2°F, widened
+    deadband 3°F, min differential 5°F, thermostat min/max setpoint 60/85°F.
+    """
+
+    def _vote(self, engine, room, effective, *, outside, target=70.0, source="presence", tc=None):
+        if tc is None:
+            tc = _make_tc(deadband=2.0, min_setpoint=60.0, max_setpoint=85.0)
+        return engine._suppression_vote(room, effective, target, source, 2.0, outside, tc)
+
+    def test_coast_up_suppresses_heat(self):
+        # 67°F room, 80°F out: at the widened floor (70-3=67) -> hold off.
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 67.0, outside=80.0) == ("off", True)
+
+    def test_coast_up_below_widened_floor_still_heats(self):
+        # 66°F < widened floor 67°F -> comfort protection heats, not suppressed.
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 66.0, outside=80.0) == ("heat", False)
+
+    def test_threshold_crossing_cools_at_normal_not_widened(self):
+        # Coasting up, the room overshoots past target. Even at 72.9°F (inside
+        # the widened ceiling 73°F) it must cool, because crossing the target
+        # reverts the cool side to the NORMAL deadband (cool at 70+2=72, not 73).
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 72.1, outside=80.0) == ("cool", False)
+        assert self._vote(engine, _supp_room(), 72.9, outside=80.0) == ("cool", False)
+
+    def test_insufficient_differential_runs_heat(self):
+        # 71°F outside is only +1 over target (< 5 differential) -> too little
+        # push, so normal heating runs instead of coasting.
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 67.0, outside=71.0) == ("heat", False)
+
+    def test_coast_down_suppresses_cool(self):
+        # 72.5°F room (past the normal cool edge 72°F), 60°F out (<= 70-5):
+        # coast down, widened ceiling 73°F -> hold off.
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 72.5, outside=60.0) == ("off", True)
+
+    def test_coast_down_above_widened_ceiling_still_cools(self):
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 74.0, outside=60.0) == ("cool", False)
+
+    def test_hard_cap_min_setpoint_overrides_suppression(self):
+        # Widened floor 67°F would suppress a 67.5°F room, but a 68°F min setpoint
+        # forces heat — the absolute comfort floor always wins.
+        engine = _make_engine()
+        tc = _make_tc(deadband=2.0, min_setpoint=68.0, max_setpoint=85.0)
+        assert self._vote(engine, _supp_room(), 67.5, outside=80.0, tc=tc) == ("heat", False)
+
+    def test_hard_cap_max_setpoint_overrides_suppression(self):
+        engine = _make_engine()
+        tc = _make_tc(deadband=2.0, min_setpoint=60.0, max_setpoint=72.0)
+        assert self._vote(engine, _supp_room(), 72.5, outside=60.0, tc=tc) == ("cool", False)
+
+    def test_disabled_room_uses_normal_vote(self):
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(enabled=False), 67.0, outside=80.0) == ("heat", False)
+
+    def test_non_presence_source_is_never_suppressed(self):
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 67.0, outside=80.0, source="schedule") == (
+            "heat",
+            False,
+        )
+
+    def test_off_schedule_mode_does_not_engage_in_phase2(self):
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(mode="off_schedule_only"), 67.0, outside=80.0) == (
+            "heat",
+            False,
+        )
+
+    def test_no_outside_reading_uses_normal_vote(self):
+        engine = _make_engine()
+        assert self._vote(engine, _supp_room(), 67.0, outside=None) == ("heat", False)
+
+
+class TestSuppressionInInference:
+    """End-to-end behavior through _infer_mode_from_room_temps / _filter."""
+
+    def _tc(self):
+        return _make_tc(deadband=2.0, min_setpoint=60.0, max_setpoint=85.0)
+
+    @pytest.mark.asyncio
+    async def test_all_rooms_suppressed_infers_off(self):
+        # Two presence rooms coasting up on warm outside air -> no demand at all.
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"], "r2": ["s2"]}
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s1": 67.0,
+            "s2": 67.0,
+        }.get(eid)
+        rooms = {
+            "r1": ActiveRoom(room=_supp_room(room_id="r1"), target_temp=70.0, source="presence"),
+            "r2": ActiveRoom(room=_supp_room(room_id="r2"), target_temp=70.0, source="presence"),
+        }
+        result = await engine._infer_mode_from_room_temps(
+            rooms, 2.0, ha.get_state(THERMO_ID), outside_temp=80.0, tc=self._tc()
+        )
+        assert result == "off"
+
+    @pytest.mark.asyncio
+    async def test_suppressed_room_excluded_from_another_rooms_heating_cycle(self):
+        # Room A (presence) is coasting up and would normally call for heat —
+        # the SAME direction as the cycle — but must still be excluded so it
+        # coasts. Room B (schedule) genuinely needs heat and is kept.
+        ha = _make_ha(ambient=68.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"A": ["sa"], "B": ["sb"]}
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "sa": 67.0,
+            "sb": 68.0,
+        }.get(eid)
+        active = {
+            "A": ActiveRoom(room=_supp_room(room_id="A"), target_temp=70.0, source="presence"),
+            "B": ActiveRoom(room=_make_room("B"), target_temp=74.0, source="schedule"),
+        }
+        filtered = await engine._filter_rooms_for_mode(
+            active, "heating", 2.0, ha.get_state(THERMO_ID), 80.0, self._tc()
+        )
+        assert set(filtered) == {"B"}
+
+    @pytest.mark.asyncio
+    async def test_insufficient_differential_room_still_drives_cycle(self):
+        # Only +1°F outside -> no coasting -> the presence room votes heat.
+        ha = _make_ha(ambient=68.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 67.0
+        rooms = {
+            "r1": ActiveRoom(room=_supp_room(room_id="r1"), target_temp=70.0, source="presence"),
+        }
+        result = await engine._infer_mode_from_room_temps(
+            rooms, 2.0, ha.get_state(THERMO_ID), outside_temp=71.0, tc=self._tc()
+        )
+        assert result == "heating"

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -21,6 +21,7 @@ from backend import db
 from backend.engine.room_manager import (
     _find_matching_schedule,
     _schedule_active,
+    _seconds_since_schedule_end,
     expire_holdovers,
     get_active_rooms,
     get_overflow_candidates,
@@ -857,3 +858,42 @@ class TestGetOverflowCandidates:
         )
         assert out == []
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _seconds_since_schedule_end (ambient off_schedule_only window — Issue #248)
+# ---------------------------------------------------------------------------
+
+
+class TestSecondsSinceScheduleEnd:
+    """Naive-local datetimes are used so the result is timezone-independent."""
+
+    def test_no_schedules_returns_none(self):
+        assert _seconds_since_schedule_end([], datetime(2026, 4, 13, 8, 0)) is None
+
+    def test_daytime_block_just_ended(self):
+        # Mon 08:00–17:00 block; now Mon 17:30 -> 30 min since it ended.
+        sched = _make_schedule(days=[0], start=time(8, 0), end=time(17, 0))
+        gap = _seconds_since_schedule_end([sched], datetime(2026, 4, 13, 17, 30))
+        assert gap == 30 * 60
+
+    def test_block_still_active_returns_previous_week(self):
+        # Mon noon, inside the 08:00–17:00 block: today's end hasn't happened,
+        # so the most recent end is last Monday — far outside any short window.
+        sched = _make_schedule(days=[0], start=time(8, 0), end=time(17, 0))
+        gap = _seconds_since_schedule_end([sched], datetime(2026, 4, 13, 12, 0))
+        assert gap is not None
+        assert gap > 6 * 24 * 3600  # ~6.8 days
+
+    def test_overnight_block_ends_next_morning(self):
+        # Mon 21:00 -> Tue 07:00; now Tue 07:15 -> 15 min since the morning end.
+        sched = _make_schedule(days=[0], start=time(21, 0), end=time(7, 0))
+        gap = _seconds_since_schedule_end([sched], datetime(2026, 4, 14, 7, 15))
+        assert gap == 15 * 60
+
+    def test_picks_smallest_gap_across_blocks(self):
+        # Two blocks; the more recently ended one wins.
+        morning = _make_schedule(days=[0], start=time(6, 0), end=time(9, 0), sid="m")
+        afternoon = _make_schedule(days=[0], start=time(13, 0), end=time(15, 0), sid="a")
+        gap = _seconds_since_schedule_end([morning, afternoon], datetime(2026, 4, 13, 15, 10))
+        assert gap == 10 * 60

--- a/smart_vent/backend/tests/test_routes_helpers.py
+++ b/smart_vent/backend/tests/test_routes_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from backend.api.routes import _delta_to_f, _from_f, _to_f
+from backend.api.routes import _delta_to_f, _from_f, _from_f_delta, _to_f
 
 
 class TestToF:
@@ -74,3 +74,23 @@ class TestFromF:
 
     def test_none_returns_empty_string_celsius(self):
         assert _from_f(None, "C") == ""
+
+
+class TestFromFDelta:
+    def test_fahrenheit_input_is_noop(self):
+        assert _from_f_delta(2.0, "F") == 2.0
+
+    def test_fahrenheit_rounds_to_1dp(self):
+        assert _from_f_delta(2.34, "F") == 2.3
+
+    def test_celsius_delta_no_offset(self):
+        # 1.8°F delta → 1.0°C delta (multiply only, no -32 offset)
+        assert _from_f_delta(1.8, "C") == 1.0
+
+    def test_celsius_delta_2_degrees(self):
+        # 3.6°F delta → 2.0°C delta
+        assert _from_f_delta(3.6, "C") == 2.0
+
+    def test_celsius_delta_does_not_subtract_offset(self):
+        # A 2°F deadband is ~1.1°C, never a negative number.
+        assert _from_f_delta(2.0, "C") == 1.1

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -11,6 +11,13 @@ export interface Room {
   presence_holdover_hours: number;
   notes: string;
   temp_offset: number;
+  // Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
+  // The two delta fields are stored in °F; the form holds display units.
+  ambient_suppression_enabled: boolean;
+  ambient_suppression_mode: "any_presence" | "off_schedule_only";
+  ambient_suppression_min_differential: number;
+  ambient_suppression_deadband: number;
+  ambient_suppression_off_schedule_window_min: number;
   sensors?: RoomSensor[];
   vents?: RoomVent[];
   presence_sensors?: RoomPresenceSensor[];

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -48,6 +48,11 @@ describe("Dashboard Page", () => {
         temp_offset: 0,
         notes: "",
         system_wide_temp: null,
+        ambient_suppression_enabled: false,
+        ambient_suppression_mode: "any_presence",
+        ambient_suppression_min_differential: 5,
+        ambient_suppression_deadband: 2,
+        ambient_suppression_off_schedule_window_min: 60,
       },
     ]);
     vi.mocked(api.getThermostats).mockResolvedValue([

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -41,6 +41,11 @@ const mockRooms: api.Room[] = [
     temp_offset: 0,
     system_wide_temp: 72,
     notes: "",
+    ambient_suppression_enabled: false,
+    ambient_suppression_mode: "any_presence",
+    ambient_suppression_min_differential: 5,
+    ambient_suppression_deadband: 2,
+    ambient_suppression_off_schedule_window_min: 60,
     sensors: [{ id: "s1", room_id: "room-1", entity_id: "sensor.temp" }],
     vents: [{ id: "v1", room_id: "room-1", entity_id: "cover.vent", control_method: "open_close" }],
     presence_sensors: [],
@@ -86,6 +91,11 @@ describe("Rooms Page", () => {
       { entity_id: "cover.another_vent", friendly_name: "Another Vent", state: "" },
       { entity_id: "binary_sensor.motion", friendly_name: "Motion", state: "" },
     ]);
+    // Default: an outside sensor is configured, so pre-cool/pre-heat is enabled.
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: "sensor.outdoor",
+      current_value: 80,
+    });
   });
 
   it("renders the rooms list", async () => {
@@ -609,5 +619,85 @@ describe("Rooms Page — Clear presence button", () => {
     expect(badge).toHaveTextContent("1 stale sensor");
     // Title attribute carries the per-sensor detail used by browsers as a tooltip.
     expect(badge.getAttribute("title")).toContain("sensor.dead_battery");
+  });
+
+  // -------------------------------------------------------------------------
+  // Ambient-aware presence suppression / pre-cool (Issue #248, Phase 4)
+  // -------------------------------------------------------------------------
+
+  const openNewRoom = async () => {
+    fireEvent.click(await screen.findByText("+ Add room"));
+    await screen.findByText("New Room", { selector: ".modal-title" });
+  };
+
+  it("reveals pre-cool/pre-heat controls with worked examples when enabled", async () => {
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: "sensor.outdoor",
+      current_value: 80,
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+    await openNewRoom();
+
+    const toggle = await screen.findByLabelText(/pre-cool \/ pre-heat/i);
+    await waitFor(() => expect(toggle).not.toBeDisabled());
+    fireEvent.click(toggle);
+
+    // The minimum-differential field carries a concrete worked example.
+    expect(screen.getByText(/only skips heating when it is at least/i)).toBeInTheDocument();
+    // The widened-deadband control and mode select are revealed.
+    expect(screen.getByLabelText(/Widened deadband/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/When to apply/i)).toBeInTheDocument();
+  });
+
+  it("disables pre-cool/pre-heat without an outside sensor", async () => {
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: null,
+      current_value: null,
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+    await openNewRoom();
+
+    const toggle = await screen.findByLabelText(/pre-cool \/ pre-heat/i);
+    await waitFor(() => expect(toggle).toBeDisabled());
+    expect(screen.getByText(/Add an outside temperature sensor/i)).toBeInTheDocument();
+  });
+
+  it("blocks a widened deadband below the thermostat deadband", async () => {
+    vi.mocked(api.getOutsideTempEntity).mockResolvedValue({
+      entity_id: "sensor.outdoor",
+      current_value: 80,
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+    await openNewRoom();
+
+    fireEvent.change(screen.getByLabelText(/Room name/i), { target: { value: "X" } });
+    fireEvent.change(screen.getByRole("combobox", { name: /Thermostat/i }), {
+      target: { value: "climate.test" },
+    });
+
+    const toggle = await screen.findByLabelText(/pre-cool \/ pre-heat/i);
+    await waitFor(() => expect(toggle).not.toBeDisabled());
+    fireEvent.click(toggle);
+
+    // Thermostat deadband is 0.5°F; 0.1 is below it -> blocked before any POST.
+    fireEvent.change(screen.getByLabelText(/Widened deadband/i), { target: { value: "0.1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Create room/i }));
+
+    expect(
+      await screen.findByText(/widened deadband must be at least the thermostat's deadband/i)
+    ).toBeInTheDocument();
+    expect(api.createRoom).not.toHaveBeenCalled();
   });
 });

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -16,6 +16,7 @@ import {
   clearPresenceHoldover,
   getThermostats,
   getEntityStates,
+  getOutsideTempEntity,
   getRoomActiveStatuses,
   getSensorHealth,
   type StaleSensor,
@@ -56,8 +57,42 @@ function RoomModal({
   );
   const [tempOffset, setTempOffset] = useState(String(toDisplayDelta(room?.temp_offset ?? 0)));
   const [notes, setNotes] = useState(room?.notes ?? "");
+  // Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
+  const [ambientEnabled, setAmbientEnabled] = useState(room?.ambient_suppression_enabled ?? false);
+  const [ambientMode, setAmbientMode] = useState<"any_presence" | "off_schedule_only">(
+    room?.ambient_suppression_mode ?? "any_presence"
+  );
+  const [ambientMinDiff, setAmbientMinDiff] = useState(
+    String(toDisplayDelta(room?.ambient_suppression_min_differential ?? 5))
+  );
+  const [ambientDeadband, setAmbientDeadband] = useState(
+    String(toDisplayDelta(room?.ambient_suppression_deadband ?? 2))
+  );
+  const [ambientWindow, setAmbientWindow] = useState(
+    String(room?.ambient_suppression_off_schedule_window_min ?? 60)
+  );
+  // The feature is inert without an outside temperature sensor, so the controls
+  // are disabled until one is configured (system-wide setting).
+  const [hasOutsideSensor, setHasOutsideSensor] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    getOutsideTempEntity()
+      .then((r) => {
+        if (!cancelled) setHasOutsideSensor(!!r?.entity_id);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Widened deadband must be >= the selected thermostat's deadband. The
+  // thermostat stores it in °F; show/compare in display units.
+  const selectedThermo = thermostats.find((t) => t.thermostat_entity_id === thermostat);
+  const thermoDeadbandDisplay = toDisplayDelta(selectedThermo?.deadband ?? 0.5);
 
   const save = async () => {
     if (!name.trim()) {
@@ -84,6 +119,29 @@ function RoomModal({
       }
     }
 
+    // Pre-cool/pre-heat (Issue #248): the two delta fields are validated the
+    // same way the backend does, so a bad value is caught before the request.
+    const minDiffVal = parseFloat(ambientMinDiff);
+    if (isNaN(minDiffVal) || minDiffVal < 0) {
+      setError("Pre-cool/pre-heat: minimum outside difference must be 0 or greater");
+      return;
+    }
+    const deadbandVal = parseFloat(ambientDeadband);
+    if (isNaN(deadbandVal) || deadbandVal < thermoDeadbandDisplay - 1e-6) {
+      setError(
+        `Pre-cool/pre-heat: widened deadband must be at least the thermostat's deadband ` +
+          `(${thermoDeadbandDisplay}${unitLabel})`
+      );
+      return;
+    }
+    if (ambientMode === "off_schedule_only") {
+      const windowVal = parseInt(ambientWindow, 10);
+      if (isNaN(windowVal) || windowVal < 0) {
+        setError("Pre-cool/pre-heat: schedule window must be 0 or greater");
+        return;
+      }
+    }
+
     setSaving(true);
     setError("");
     try {
@@ -96,6 +154,11 @@ function RoomModal({
         presence_holdover_hours: parseFloat(holdover) || 0,
         include_thermostat_sensor: includeThermoSensor,
         temp_offset: parseFloat(tempOffset) || 0,
+        ambient_suppression_enabled: ambientEnabled,
+        ambient_suppression_mode: ambientMode,
+        ambient_suppression_min_differential: parseFloat(ambientMinDiff) || 0,
+        ambient_suppression_deadband: parseFloat(ambientDeadband) || 0,
+        ambient_suppression_off_schedule_window_min: parseInt(ambientWindow, 10) || 0,
         notes,
       };
       const saved = room ? await updateRoom(room.id, payload) : await createRoom(payload);
@@ -234,6 +297,139 @@ function RoomModal({
             accurately.
           </div>
         </div>
+
+        <hr className="divider" />
+
+        <div className="form-group">
+          <label
+            htmlFor="room-ambient-enabled"
+            style={{ display: "flex", alignItems: "center", gap: ".5rem", cursor: "pointer" }}
+          >
+            <input
+              id="room-ambient-enabled"
+              type="checkbox"
+              checked={ambientEnabled}
+              disabled={!hasOutsideSensor}
+              onChange={(e) => setAmbientEnabled(e.target.checked)}
+            />
+            <span>
+              Skip presence heating/cooling when the weather will do it for me (pre-cool / pre-heat)
+            </span>
+          </label>
+          {!hasOutsideSensor && (
+            <div className="form-hint" style={{ color: "var(--orange)" }}>
+              Add an outside temperature sensor on the <strong>Metrics</strong> page to use this —
+              it has no effect without one.
+            </div>
+          )}
+          <div className="form-hint">
+            When presence would heat or cool this room but the outside air will carry it to target
+            on its own, Plenum skips the HVAC and lets the room drift.
+            <br />
+            <strong>Example:</strong> your night schedule holds this room at 68{unitLabel} and ends
+            at 7am. At 7:30am someone walks in and presence wants 70{unitLabel}. It is already
+            warmer outside, so the room will reach 70{unitLabel} on its own — Plenum skips the
+            heater. The moment the room actually reaches 70{unitLabel}, normal heating/cooling
+            resumes.
+          </div>
+        </div>
+
+        {ambientEnabled && (
+          <>
+            <div className="form-group">
+              <label className="form-label" htmlFor="room-ambient-mode">
+                When to apply
+              </label>
+              <select
+                id="room-ambient-mode"
+                className="form-control"
+                value={ambientMode}
+                onChange={(e) =>
+                  setAmbientMode(e.target.value as "any_presence" | "off_schedule_only")
+                }
+              >
+                <option value="any_presence">Any presence</option>
+                <option value="off_schedule_only">Only after a schedule ends</option>
+              </select>
+              <div className="form-hint">
+                <strong>Example:</strong> &ldquo;Only after a schedule ends&rdquo; skips presence
+                heat/cool just after a schedule block ends (the 7am case) but behaves normally
+                midday. &ldquo;Any presence&rdquo; applies the check every time presence activates
+                the room.
+              </div>
+            </div>
+
+            {ambientMode === "off_schedule_only" && (
+              <div className="form-group">
+                <label className="form-label" htmlFor="room-ambient-window">
+                  Schedule window (minutes)
+                </label>
+                <input
+                  id="room-ambient-window"
+                  className="form-control"
+                  type="number"
+                  step="5"
+                  min="0"
+                  value={ambientWindow}
+                  onChange={(e) => setAmbientWindow(e.target.value)}
+                />
+                <div className="form-hint">
+                  How long after a schedule ends this still applies. <strong>Example:</strong> 60 =
+                  applies until 8am for a schedule ending at 7am.
+                </div>
+              </div>
+            )}
+
+            <div className="form-group">
+              <label className="form-label" htmlFor="room-ambient-mindiff">
+                Minimum outside difference ({unitLabel})
+              </label>
+              <input
+                id="room-ambient-mindiff"
+                className="form-control"
+                type="number"
+                step="0.5"
+                min="0"
+                value={ambientMinDiff}
+                onChange={(e) => setAmbientMinDiff(e.target.value)}
+              />
+              <div className="form-hint">
+                How far past the target the outside temperature must be before coasting.
+                <br />
+                <strong>Example:</strong> set to 5{unitLabel} with a 70{unitLabel} target, Plenum
+                only skips heating when it is at least 75{unitLabel} outside, and only skips cooling
+                when it is at most 65{unitLabel} outside. If it is only 71{unitLabel} out, that is
+                too little push, so it heats normally. Bigger = only coast when the weather strongly
+                favors it.
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label className="form-label" htmlFor="room-ambient-deadband">
+                Widened deadband ({unitLabel})
+              </label>
+              <input
+                id="room-ambient-deadband"
+                className="form-control"
+                type="number"
+                step="0.5"
+                min={thermoDeadbandDisplay}
+                value={ambientDeadband}
+                onChange={(e) => setAmbientDeadband(e.target.value)}
+              />
+              <div className="form-hint">
+                <strong>Example:</strong> your thermostat&rsquo;s deadband is{" "}
+                {thermoDeadbandDisplay}
+                {unitLabel}. This widened deadband must be at least that — set it the same or
+                higher. With a 70{unitLabel} target and a widened deadband of 3{unitLabel}, while
+                coasting up Plenum will not call for heat until the room drops 3{unitLabel} below
+                target. The instant the room rises past 70{unitLabel}, normal control resumes — it
+                cools at the normal deadband, not the widened one. The thermostat&rsquo;s min/max
+                setpoint always overrides this.
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="form-group">
           <label className="form-label" htmlFor="room-notes">

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -119,26 +119,29 @@ function RoomModal({
       }
     }
 
-    // Pre-cool/pre-heat (Issue #248): the two delta fields are validated the
-    // same way the backend does, so a bad value is caught before the request.
-    const minDiffVal = parseFloat(ambientMinDiff);
-    if (isNaN(minDiffVal) || minDiffVal < 0) {
-      setError("Pre-cool/pre-heat: minimum outside difference must be 0 or greater");
-      return;
-    }
-    const deadbandVal = parseFloat(ambientDeadband);
-    if (isNaN(deadbandVal) || deadbandVal < thermoDeadbandDisplay - 1e-6) {
-      setError(
-        `Pre-cool/pre-heat: widened deadband must be at least the thermostat's deadband ` +
-          `(${thermoDeadbandDisplay}${unitLabel})`
-      );
-      return;
-    }
-    if (ambientMode === "off_schedule_only") {
-      const windowVal = parseInt(ambientWindow, 10);
-      if (isNaN(windowVal) || windowVal < 0) {
-        setError("Pre-cool/pre-heat: schedule window must be 0 or greater");
+    // Pre-cool/pre-heat (Issue #248): validate the same way the backend does,
+    // but only when the feature is enabled — a disabled room's defaults must
+    // never block an unrelated save (e.g. on a wide-deadband thermostat).
+    if (ambientEnabled) {
+      const minDiffVal = parseFloat(ambientMinDiff);
+      if (isNaN(minDiffVal) || minDiffVal < 0) {
+        setError("Pre-cool/pre-heat: minimum outside difference must be 0 or greater");
         return;
+      }
+      const deadbandVal = parseFloat(ambientDeadband);
+      if (isNaN(deadbandVal) || deadbandVal < thermoDeadbandDisplay - 1e-6) {
+        setError(
+          `Pre-cool/pre-heat: widened deadband must be at least the thermostat's deadband ` +
+            `(${thermoDeadbandDisplay}${unitLabel})`
+        );
+        return;
+      }
+      if (ambientMode === "off_schedule_only") {
+        const windowVal = parseInt(ambientWindow, 10);
+        if (isNaN(windowVal) || windowVal < 0) {
+          setError("Pre-cool/pre-heat: schedule window must be 0 or greater");
+          return;
+        }
       }
     }
 
@@ -318,8 +321,8 @@ function RoomModal({
           </label>
           {!hasOutsideSensor && (
             <div className="form-hint" style={{ color: "var(--orange)" }}>
-              Add an outside temperature sensor on the <strong>Metrics</strong> page to use this —
-              it has no effect without one.
+              Add an outside temperature sensor on the <strong>Thermostats</strong> page to use this
+              — it has no effect without one.
             </div>
           )}
           <div className="form-hint">

--- a/smart_vent/frontend/src/pages/Schedules.test.tsx
+++ b/smart_vent/frontend/src/pages/Schedules.test.tsx
@@ -19,6 +19,11 @@ const mockRooms: api.Room[] = [
     temp_offset: 0,
     notes: "",
     system_wide_temp: null,
+    ambient_suppression_enabled: false,
+    ambient_suppression_mode: "any_presence",
+    ambient_suppression_min_differential: 5,
+    ambient_suppression_deadband: 2,
+    ambient_suppression_off_schedule_window_min: 60,
   },
 ];
 


### PR DESCRIPTION
Closes #248.

Adds a **per-room, opt-in** feature that lets a presence-active room **coast to its target on outside air** instead of running HVAC, when the weather will carry it there. Only functions when an outside temperature sensor is configured; inert (normal presence behavior) otherwise.

## Motivation

> A night schedule holds a room at 68°F and ends at 7am. At 7:30am someone walks in and presence wants 70°F, so the heater runs. But it's already warmer than 70°F outside — the room will drift past 70°F on its own. The heat (and the stored overnight coolness) is wasted.

With the feature on, that morning presence event doesn't call for heat; the room is left to drift up. A hard floor still protects comfort.

## Behavior

- **Minimum-differential gate** — only coast when the outside temp is at least `min_differential`° past the target on the helpful side. So at a 70°F target: 80°F outside coasts; 71°F outside (only +1°) still heats normally.
- **Asymmetric widened deadband + threshold-crossing rule** — while coasting, the room rides a wider deadband **only on the side it's drifting from**. The instant it crosses the target, the far side reverts to the **normal** deadband (target 70 / normal 2 / widened 3 → cools at **72**, not 73).
- **Hard cap** — the thermostat min/max setpoint always wins; coasting can never push a room past those bounds. Scoped to feature-active rooms.
- **Trigger scope (per-room)** — `any_presence` or `off_schedule_only` (only within a configurable window after a schedule block ends — the night→morning case).
- **No-demand vent behavior** — a suppressed room contributes no demand: all-suppressed ⇒ no cycle ⇒ vents rest open; otherwise it's excluded from another room's cycle. Schedule/override targets are never suppressed.

## Built in focused commits

1. **Data model + API** — five per-room fields, migration, `_delta_to_f` conversion, validation, both temperature-field parity manifests. Inert.
2. **Engine logic** (`any_presence`) — `_suppression_vote` in `_infer_mode_from_room_temps` / `_filter_rooms_for_mode`.
3. **`off_schedule_only` scope** — `_seconds_since_schedule_end` + per-room window flag.
4. **UI** — Rooms modal controls, each with worked-example helper text, disabled until an outside sensor exists; client-side validation mirrors the backend.
5. **Docs + e2e** — `docs/precool-presence.md` + cross-links + README; `// @covers` round-trip in the °F/°C matrix.

## Post-open review fixes (`0cb18f9`)

A self-review surfaced three edge cases in the validation/scoping seams:

1. **Hard cap leaked to non-feature rooms** — moved inside the eligibility check so a room not using the feature keeps its plain deadband vote (fully inert when inactive).
2. **Widened-deadband floor blocked unrelated saves** — the default widened deadband (2.0) would reject room saves on thermostats with deadband > 2°F even with the feature off. Now enforced only when enabled (the engine clamps with `max()` regardless). Frontend gated to match.
3. **Wrong page reference** — the outside sensor is configured on the **Thermostats** page (`OutsideTempPicker`), not Metrics; fixed the UI hint and the doc.

Follow-up issue #251 filed for consolidating the temperature-conversion helpers (out of scope here).

## Final audit (`373c97f`)

1. **E2E global-state contamination** — the round-trip sets the home-wide outside-temp entity, and `e2e.yml` runs all specs sequentially against one stack; `thermostats.spec.ts` (runs after) screenshots the page rendering `OutsideTempPicker`. Now captures the prior value and restores it in `finally` so the golden isn't shifted. (The conversion matrix runs this spec in isolation, so it was only the full screenshot suite at risk.)
2. **Missing full-tick integration coverage** — added `test_ambient_suppression_tick.py`: a presence room that would normally heat is suppressed (engine idle, no cycle) when it's warm enough outside, while the otherwise-identical +1°F case runs the heating cycle — exercising the `tick()` wiring end-to-end, not just the helpers.

## Test plan

- **Backend:** 724 tests pass, coverage 92.76% (≥ 92.5% gate); `ruff` + `mypy` clean. Coverage spans the full vote matrix (coast up/down, cool-at-72-not-73 threshold crossing, 71°F-runs-heat gate, hard-cap overrides + not-applied-when-disabled, every inactive path), all-suppressed→off, same-direction exclusion, the full-tick suppression/run pair, `_seconds_since_schedule_end`, the `off_schedule_only` window, Celsius delta conversion, and the deadband/differential validation rules (incl. disabled-room acceptance).
- **Frontend:** 241 tests pass, coverage thresholds met, lint + `tsc` clean. Controls reveal with worked examples, disabled without an outside sensor, sub-thermostat-deadband save blocked.
- **E2E:** round-trip asserts both delta fields survive the °F/°C matrix unchanged and restores global state; `test_temperature_field_parity.py` keeps the three manifests in lockstep.

Each commit leaves `main` green and is independently reviewable.