### PR TITLE
Record overflow-conditioned rooms as cycle data points (Issue #254)

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1191,7 +1191,7 @@ async def ha_entities(request: web.Request) -> web.Response:
     return json_response(result)
 
 
-def _cycle_log_to_dict(log_entry) -> dict:
+def _cycle_log_to_dict(log_entry, had_overflow: bool = False) -> dict:
     try:
         rooms = json.loads(log_entry.rooms_json) if log_entry.rooms_json else {}
     except (ValueError, TypeError):
@@ -1220,6 +1220,9 @@ def _cycle_log_to_dict(log_entry) -> dict:
         "setpoint_at_end": log_entry.setpoint_at_end,
         "vents_at_start": vents_at_start,
         "vents_at_end": vents_at_end,
+        # True when this cycle redirected surplus air into non-active rooms
+        # during its minimum-runtime hold (Issue #254). Drives the Logs badge.
+        "had_overflow": had_overflow,
     }
 
 
@@ -1233,7 +1236,10 @@ async def get_logs(request: web.Request) -> web.Response:
     since = request.rel_url.query.get("since") or None
     until = request.rel_url.query.get("until") or None
     logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
-    return json_response([_cycle_log_to_dict(log_entry) for log_entry in logs])
+    overflow_ids = await db.get_cycle_ids_with_overflow(conn, [log_entry.id for log_entry in logs])
+    return json_response(
+        [_cycle_log_to_dict(log_entry, log_entry.id in overflow_ids) for log_entry in logs]
+    )
 
 
 @docs(tags=["logs"], summary="Get detailed cycle log by ID")
@@ -1254,6 +1260,7 @@ async def get_log_detail(request: web.Request) -> web.Response:
         rooms_meta = {}
 
     room_states = await db.get_room_cycle_states(conn, cycle_id)
+    had_overflow = any(rcs.role == "overflow" for rcs in room_states)
     rooms_payload = []
     for rcs in room_states:
         meta = rooms_meta.get(rcs.room_id, {}) or {}
@@ -1261,10 +1268,16 @@ async def get_log_detail(request: web.Request) -> web.Response:
             trigger = json.loads(rcs.trigger_detail) if rcs.trigger_detail else None
         except (ValueError, TypeError):
             trigger = None
+        # Overflow rooms (Issue #254) are not in the cycle's rooms_json
+        # snapshot, so fall back to the live room name for them.
+        name = meta.get("name")
+        if name is None:
+            room = await db.get_room(conn, rcs.room_id)
+            name = room.name if room else None
         rooms_payload.append(
             {
                 "room_id": rcs.room_id,
-                "name": meta.get("name"),
+                "name": name,
                 "source": meta.get("source"),
                 "target_temp": rcs.target_temp,
                 "reached_at": rcs.reached_at.replace(tzinfo=None).isoformat()
@@ -1279,6 +1292,7 @@ async def get_log_detail(request: web.Request) -> web.Response:
                 "joined_at": rcs.joined_at.replace(tzinfo=None).isoformat()
                 if rcs.joined_at
                 else None,
+                "role": rcs.role,
             }
         )
 
@@ -1308,7 +1322,7 @@ async def get_log_detail(request: web.Request) -> web.Response:
 
     return json_response(
         {
-            "cycle": _cycle_log_to_dict(cycle),
+            "cycle": _cycle_log_to_dict(cycle, had_overflow),
             "rooms": rooms_payload,
             "vent_events": vent_events_payload,
             "setpoint_history": setpoint_history_payload,

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -124,6 +124,7 @@ class CycleLogResponseSchema(Schema):
     setpoint_at_end = fields.Float(allow_none=True)
     vents_at_start = fields.Dict(allow_none=True)
     vents_at_end = fields.Dict(allow_none=True)
+    had_overflow = fields.Bool()
 
 
 class CycleRoomDetailSchema(Schema):
@@ -137,6 +138,7 @@ class CycleRoomDetailSchema(Schema):
     temp_at_end = fields.Float(allow_none=True)
     trigger_detail = fields.Dict(allow_none=True)
     joined_at = fields.DateTime(allow_none=True)
+    role = fields.Str()
 
 
 class CycleVentEventSchema(Schema):

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS room_cycle_states (
     temp_at_end REAL,
     trigger_detail TEXT,
     joined_at TEXT,
+    role TEXT NOT NULL DEFAULT 'active',
     PRIMARY KEY (cycle_id, room_id)
 );
 
@@ -392,6 +393,11 @@ _MIGRATIONS = [
     # loop gates on this to stop reopened vents from flapping back closed.
     "ALTER TABLE cycle_logs ADD COLUMN in_min_runtime_hold INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE thermostat_configs ADD COLUMN overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1",
+    # Overflow-room cycle data points (Issue #254). Non-active rooms opened
+    # during the minimum-runtime hold are now recorded as room_cycle_states
+    # rows tagged role='overflow' so the Logs page can show their start/end
+    # temperatures alongside the cycle that triggered them.
+    "ALTER TABLE room_cycle_states ADD COLUMN role TEXT NOT NULL DEFAULT 'active'",
     # Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248)
     "ALTER TABLE rooms ADD COLUMN ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE rooms ADD COLUMN ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence'",
@@ -1131,8 +1137,8 @@ async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleStat
     await conn.execute(
         """INSERT INTO room_cycle_states(
             cycle_id, room_id, target_temp, reached_at, vent_closed_at,
-            temp_at_start, temp_at_end, trigger_detail, joined_at
-           ) VALUES(?,?,?,?,?,?,?,?,?)
+            temp_at_start, temp_at_end, trigger_detail, joined_at, role
+           ) VALUES(?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(cycle_id,room_id) DO UPDATE SET
              target_temp=excluded.target_temp,
              reached_at=excluded.reached_at,
@@ -1150,6 +1156,7 @@ async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleStat
             rcs.temp_at_end,
             rcs.trigger_detail,
             _dts(rcs.joined_at),
+            rcs.role,
         ),
     )
     await conn.commit()
@@ -1171,6 +1178,7 @@ def _row_to_room_cycle_state(r) -> RoomCycleState:
         temp_at_end=_get("temp_at_end"),
         trigger_detail=_get("trigger_detail"),
         joined_at=_dt(_get("joined_at")) if _get("joined_at") else None,
+        role=_get("role") or "active",
     )
 
 
@@ -1178,6 +1186,22 @@ async def get_room_cycle_states(conn: aiosqlite.Connection, cycle_id: str) -> li
     async with conn.execute("SELECT * FROM room_cycle_states WHERE cycle_id=?", (cycle_id,)) as cur:
         rows = await cur.fetchall()
     return [_row_to_room_cycle_state(r) for r in rows]
+
+
+async def get_cycle_ids_with_overflow(conn: aiosqlite.Connection, cycle_ids: list[str]) -> set[str]:
+    """Return the subset of ``cycle_ids`` that recorded any overflow rooms
+    (Issue #254). Used to flag cycles in the Logs list without an N+1 query.
+    """
+    if not cycle_ids:
+        return set()
+    placeholders = ",".join("?" for _ in cycle_ids)
+    async with conn.execute(
+        f"SELECT DISTINCT cycle_id FROM room_cycle_states "
+        f"WHERE role='overflow' AND cycle_id IN ({placeholders})",
+        tuple(cycle_ids),
+    ) as cur:
+        rows = await cur.fetchall()
+    return {r[0] for r in rows}
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -957,7 +957,10 @@ async def close_open_cycles_for_rooms(
         "AND id IN ("
         f"  SELECT DISTINCT cl.id FROM cycle_logs cl "
         f"  JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id "
-        f"  WHERE cl.ended_at IS NULL AND rcs.room_id IN ({placeholders})"
+        # Overflow rooms (Issue #254) are not active targets — deleting/moving
+        # one must not close an otherwise-running cycle.
+        f"  WHERE cl.ended_at IS NULL AND rcs.role != 'overflow' "
+        f"  AND rcs.room_id IN ({placeholders})"
     )
     params: list = [ended_at.replace(tzinfo=None).isoformat()]
     params.extend(room_ids)
@@ -1791,6 +1794,7 @@ async def _time_to_target_timeseries(
                 MIN((julianday(rcs.reached_at) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0) AS seconds
             FROM cycle_logs cl
             JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id
+                AND rcs.role != 'overflow'
             WHERE cl.ended_at IS NOT NULL
               AND cl.thermostat_entity_id = ?
               AND rcs.reached_at IS NOT NULL
@@ -1910,6 +1914,7 @@ async def compute_overshoot_histogram(
                s.room_temp, s.thermostat_temp
         FROM cycle_logs cl
         JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id
+            AND rcs.role != 'overflow'
         JOIN cycle_temp_samples s ON s.cycle_id = cl.id
             AND (s.room_id = rcs.room_id OR s.room_id IS NULL)
         WHERE {where}
@@ -2009,6 +2014,7 @@ async def compute_room_metrics(
                 THEN (julianday(rcs.reached_at) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0 END) AS avg_time_to_target_seconds
         FROM rooms r
         LEFT JOIN room_cycle_states rcs ON rcs.room_id = r.id
+            AND rcs.role != 'overflow'
         LEFT JOIN cycle_logs cl ON cl.id = rcs.cycle_id
             AND cl.ended_at IS NOT NULL
             AND date(cl.started_at, 'localtime') BETWEEN ? AND ?

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -32,6 +32,7 @@ from ..models import (
 )
 from .room_manager import (
     ActiveRoom,
+    OverflowCandidate,
     _seconds_since_schedule_end,
     expire_holdovers,
     get_active_rooms,
@@ -117,6 +118,14 @@ class CycleEngine:
         # already-satisfied cycle rooms. Recomputed every tick during the hold;
         # cleared at cycle termination.
         self._overflow_room_ids: set[str] = set()
+
+        # Overflow-room cycle data points (Issue #254): the persisted
+        # RoomCycleState (role='overflow') for each non-active room this cycle
+        # has redirected surplus air into, keyed by room_id. Captures
+        # temp_at_start (first overflow-open) and temp_at_end (final close or
+        # cycle end). Kept separate from ``_room_cycle_states`` so overflow
+        # rooms never leak into the active-room paths.
+        self._overflow_room_states: dict[str, RoomCycleState] = {}
 
     # ------------------------------------------------------------------
     # Public
@@ -1190,6 +1199,8 @@ class CycleEngine:
                         await db.upsert_room_cycle_state(conn, rcs)
                     except Exception as exc:
                         log.debug("Failed to persist end-of-cycle room state: %s", exc)
+            # Close out overflow-room data points still open at cycle end (#254).
+            await self._finalize_overflow_rooms(conn)
 
         # Close the DB record FIRST so the cycle log is never left orphaned
         # with ended_at=NULL if subsequent vent/setpoint operations fail.
@@ -1327,6 +1338,8 @@ class CycleEngine:
                         await db.upsert_room_cycle_state(conn, rcs)
                     except Exception as exc:
                         log.debug("Failed to persist abort room state: %s", exc)
+            # Close out overflow-room data points still open at abort (#254).
+            await self._finalize_overflow_rooms(conn)
 
         # Close the DB record FIRST so the cycle log is never left orphaned
         # with ended_at=NULL if subsequent vent/setpoint operations fail.
@@ -2551,9 +2564,21 @@ class CycleEngine:
         self._cycle_mode = to_restore.mode  # 'heating' | 'cooling'
         self._cycle_ha_mode = "cool" if to_restore.mode == "cooling" else "heat"
 
-        # Restore per-room cycle states (which rooms hit target, when vents closed)
+        # Restore per-room cycle states (which rooms hit target, when vents
+        # closed). Overflow rooms (Issue #254) live in a separate dict so they
+        # never leak into the active-room paths; a still-open overflow room
+        # (no temp_at_end yet) is re-tracked so the cycle-end finalize can
+        # close its data point.
         room_states = await db.get_room_cycle_states(conn, to_restore.id)
-        self._room_cycle_states = {rcs.room_id: rcs for rcs in room_states}
+        self._room_cycle_states = {
+            rcs.room_id: rcs for rcs in room_states if rcs.role != "overflow"
+        }
+        self._overflow_room_states = {
+            rcs.room_id: rcs for rcs in room_states if rcs.role == "overflow"
+        }
+        self._overflow_room_ids = {
+            rid for rid, rcs in self._overflow_room_states.items() if rcs.temp_at_end is None
+        }
 
         # Restore active rooms and vents from the rooms_json snapshot + DB
         try:
@@ -3018,6 +3043,11 @@ class CycleEngine:
                         )
                     except Exception as exc:
                         log.debug("Failed to record closed_overflow_hold event: %s", exc)
+                # Capture this room's end temperature at the moment its overflow
+                # vent closes (Issue #254). "Final close wins": a later re-open
+                # clears temp_at_end, so the value persisted here reflects the
+                # most recent disposition.
+                await self._record_overflow_close(conn, room_id, ts)
 
         # Open vents for newly-selected overflow candidates.
         to_open = desired_ids - self._overflow_room_ids
@@ -3045,6 +3075,9 @@ class CycleEngine:
                         )
                     except Exception as exc:
                         log.debug("Failed to record opened_overflow_hold event: %s", exc)
+                # Record / refresh this room's overflow cycle data point so the
+                # Logs page can show its start and end temps (Issue #254).
+                await self._record_overflow_open(conn, c, ts)
 
         self._overflow_room_ids = desired_ids
 
@@ -3073,6 +3106,91 @@ class CycleEngine:
                             "active_cycle_target": active_cycle_target,
                         },
                     )
+
+    async def _record_overflow_open(
+        self, conn: aiosqlite.Connection, c: OverflowCandidate, ts: datetime
+    ) -> None:
+        """Persist an overflow room's cycle data point on its first open, or
+        re-arm it on a subsequent re-open (Issue #254).
+
+        On first open we create a ``room_cycle_states`` row tagged
+        ``role='overflow'`` capturing ``temp_at_start`` (the room's temp when it
+        was chosen). On a re-open we keep the original ``temp_at_start`` but
+        clear ``temp_at_end`` / ``vent_closed_at`` so the room counts as open
+        again — its end temp is re-captured on the next close or at cycle end.
+        """
+        if self._cycle_log is None:
+            return
+        existing = self._overflow_room_states.get(c.room.id)
+        if existing is None:
+            trigger = json.dumps(
+                {
+                    "overflow": True,
+                    "tier": c.tier,
+                    "headroom": c.headroom,
+                    "effective_setpoint": c.effective_setpoint,
+                }
+            )
+            rcs = RoomCycleState(
+                cycle_id=self._cycle_log.id,
+                room_id=c.room.id,
+                # Overflow rooms have no cycle target of their own; record the
+                # room's effective setpoint so the UI has a reference point.
+                target_temp=c.effective_setpoint
+                if c.effective_setpoint is not None
+                else c.current_temp,
+                temp_at_start=c.current_temp,
+                trigger_detail=trigger,
+                joined_at=ts,
+                role="overflow",
+            )
+            self._overflow_room_states[c.room.id] = rcs
+        else:
+            # Re-opened: keep temp_at_start, drop any prior end so the room is
+            # treated as open again.
+            rcs = existing
+            rcs.temp_at_end = None
+            rcs.vent_closed_at = None
+        try:
+            await db.upsert_room_cycle_state(conn, rcs)
+        except Exception as exc:
+            log.debug("Failed to persist overflow room open state: %s", exc)
+
+    async def _record_overflow_close(
+        self, conn: aiosqlite.Connection, room_id: str, ts: datetime
+    ) -> None:
+        """Capture an overflow room's end temperature when its vent closes
+        (Issue #254). No-op for rooms we never recorded as overflow."""
+        if self._cycle_log is None:
+            return
+        rcs = self._overflow_room_states.get(room_id)
+        if rcs is None:
+            return
+        room = await db.get_room(conn, room_id)
+        rcs.temp_at_end = self._get_avg_temp(room) if room else None
+        rcs.vent_closed_at = ts
+        try:
+            await db.upsert_room_cycle_state(conn, rcs)
+        except Exception as exc:
+            log.debug("Failed to persist overflow room close state: %s", exc)
+
+    async def _finalize_overflow_rooms(self, conn: aiosqlite.Connection) -> None:
+        """At cycle termination, fill ``temp_at_end`` for any overflow rooms
+        still open (never swapped out) so their data point closes at cycle end
+        (Issue #254). Then clear the in-memory overflow tracking."""
+        if self._cycle_log is not None:
+            ts = datetime.now(UTC)
+            for room_id, rcs in self._overflow_room_states.items():
+                if rcs.temp_at_end is not None:
+                    continue
+                room = await db.get_room(conn, room_id)
+                rcs.temp_at_end = self._get_avg_temp(room) if room else None
+                rcs.vent_closed_at = ts
+                try:
+                    await db.upsert_room_cycle_state(conn, rcs)
+                except Exception as exc:
+                    log.debug("Failed to finalize overflow room state: %s", exc)
+        self._overflow_room_states = {}
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -269,6 +269,10 @@ class RoomCycleState:
     temp_at_end: float | None = None
     trigger_detail: str | None = None  # JSON: schedule/override/presence metadata
     joined_at: datetime | None = None  # NULL = present at cycle start
+    # Role discriminator (Issue #254). 'active' = a room the cycle was
+    # targeting; 'overflow' = a non-active room opened during the
+    # minimum-runtime hold to absorb surplus conditioned air (Issue #237).
+    role: str = "active"
 
 
 @dataclass

--- a/smart_vent/backend/tests/integration/test_metrics_phase2.py
+++ b/smart_vent/backend/tests/integration/test_metrics_phase2.py
@@ -359,6 +359,98 @@ class TestRoomMetrics:
         assert r["cooling_seconds"] == 15 * 60
         assert r["avg_time_to_target_seconds"] == pytest.approx(15 * 60.0)
 
+    @pytest.mark.asyncio
+    async def test_overflow_rooms_excluded_from_room_metrics(self, client, today_iso, today_dt):
+        """Issue #254: overflow room_cycle_states rows must not inflate
+        per-room participation or heating/cooling time."""
+        conn = await _conn(client)
+        active = Room(id="active1", name="Active", thermostat_entity_id=THERMO_A)
+        overflow = Room(id="overflow1", name="Overflow", thermostat_entity_id=THERMO_A)
+        await db.upsert_room(conn, active)
+        await db.upsert_room(conn, overflow)
+
+        await _seed_cycle(
+            conn,
+            cycle_id="rmov1",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+            rooms_json={active.id: {"name": active.name, "target": 72.0, "source": "schedule"}},
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="rmov1",
+                room_id=active.id,
+                target_temp=72.0,
+                joined_at=today_dt,
+                reached_at=today_dt + timedelta(minutes=15),
+                vent_closed_at=today_dt + timedelta(minutes=15),
+            ),
+        )
+        # An overflow row with full timing — must be ignored by the metric.
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="rmov1",
+                room_id=overflow.id,
+                target_temp=70.0,
+                joined_at=today_dt + timedelta(minutes=20),
+                vent_closed_at=today_dt + timedelta(minutes=30),
+                temp_at_start=75.0,
+                temp_at_end=71.0,
+                role="overflow",
+            ),
+        )
+
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/rooms?start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        by_id = {r["room_id"]: r for r in body["rooms"]}
+        # The overflow room still appears (it's a real room) but with zero
+        # participation / conditioning time — its overflow row is not counted.
+        assert by_id[overflow.id]["participation_count"] == 0
+        assert by_id[overflow.id]["cooling_seconds"] == 0
+        assert by_id[active.id]["participation_count"] == 1
+        assert by_id[active.id]["cooling_seconds"] == 15 * 60
+
+    @pytest.mark.asyncio
+    async def test_overflow_rooms_excluded_from_overshoot(self, client, today_iso, today_dt):
+        """Issue #254: an overflow room's target must not contribute to the
+        overshoot histogram (it would otherwise pair with thermostat samples)."""
+        conn = await _conn(client)
+        await db.upsert_room(conn, Room(id="ovr", name="Ovr", thermostat_entity_id=THERMO_A))
+        await _seed_cycle(
+            conn,
+            cycle_id="ohov1",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="ohov1",
+                room_id="ovr",
+                target_temp=72.0,
+                joined_at=today_dt,
+                role="overflow",
+            ),
+        )
+        # Thermostat-level sample that would register a 2°F overshoot if the
+        # overflow row were joined in.
+        await db.insert_cycle_temp_sample(
+            conn, "ohov1", None, today_dt + timedelta(minutes=12), None, 70.0, 72.0
+        )
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/overshoot-histogram"
+            f"?start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        assert body["overshot_count"] == 0
+        assert all(c == 0 for c in body["counts"])
+
 
 # ---------------------------------------------------------------------------
 # 2e: cycles-vs-outside-temp scatter

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -834,6 +834,85 @@ class TestLogs:
         data = await resp.json()
         assert data["cleared"] is True
 
+    async def test_overflow_rooms_surface_in_detail_and_list(self, client):
+        """Issue #254: overflow rooms must appear in the cycle detail tagged
+        role='overflow' (with a name fallback) and the list must flag the
+        cycle with had_overflow=True."""
+        import json
+        from datetime import UTC, datetime, timedelta
+
+        from backend.models import CycleLog, Room, RoomCycleState
+
+        conn = client.app["scheduler"]._db_conn
+
+        active = Room.create(name="Living Room", thermostat_entity_id="climate.main")
+        active.id = "r_active"
+        await db.upsert_room(conn, active)
+        overflow_room = Room.create(name="Office", thermostat_entity_id="climate.main")
+        overflow_room.id = "r_overflow"
+        await db.upsert_room(conn, overflow_room)
+
+        started = datetime.now(UTC) - timedelta(hours=1)
+        cycle = CycleLog.create(
+            thermostat_entity_id="climate.main",
+            mode="cooling",
+            # Only the active room is in the snapshot — overflow rooms are not.
+            rooms_json=json.dumps({"r_active": {"name": "Living Room", "target": 72.0}}),
+        )
+        cycle.started_at = started
+        await db.insert_cycle_log(conn, cycle)
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id=cycle.id,
+                room_id="r_active",
+                target_temp=72.0,
+                temp_at_start=78.0,
+                temp_at_end=72.0,
+            ),
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id=cycle.id,
+                room_id="r_overflow",
+                target_temp=70.0,
+                temp_at_start=75.0,
+                temp_at_end=71.0,
+                trigger_detail=json.dumps({"overflow": True, "tier": 1}),
+                role="overflow",
+            ),
+        )
+        await db.close_cycle_log(conn, cycle.id, started + timedelta(minutes=20))
+
+        # Detail: overflow room present, tagged, name resolved from live room.
+        resp = await client.get(f"/api/logs/{cycle.id}/detail")
+        assert resp.status == 200
+        detail = await resp.json()
+        assert detail["cycle"]["had_overflow"] is True
+        by_id = {r["room_id"]: r for r in detail["rooms"]}
+        assert by_id["r_active"]["role"] == "active"
+        ov = by_id["r_overflow"]
+        assert ov["role"] == "overflow"
+        assert ov["name"] == "Office"  # fallback to live room name
+        assert ov["temp_at_start"] == 75.0
+        assert ov["temp_at_end"] == 71.0
+
+        # List: the cycle is flagged so the UI can render a badge.
+        resp = await client.get("/api/logs")
+        assert resp.status == 200
+        logs = await resp.json()
+        flagged = {log_["id"]: log_["had_overflow"] for log_ in logs}
+        assert flagged.get(cycle.id) is True
+
+    async def test_cycle_without_overflow_not_flagged(self, client):
+        """A normal cycle must report had_overflow=False in both list and detail."""
+        await _seed_completed_cycle(client)
+        resp = await client.get("/api/logs")
+        logs = await resp.json()
+        assert logs
+        assert all(log_["had_overflow"] is False for log_ in logs)
+
 
 # ---------------------------------------------------------------------------
 # Settings

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -1552,6 +1552,124 @@ class TestOverflowDuringHold:
         await conn.close()
 
 
+class TestOverflowRoomDataPoints:
+    """Issue #254: overflow rooms are recorded as room_cycle_states rows tagged
+    role='overflow' with start/end temperatures, so the Logs page can show the
+    rooms a min-runtime hold redirected into."""
+
+    async def _setup_with_office(self, office_temp):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        office = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        office.id = "r_office"
+        office.system_wide_temp = 70.0
+        await db.upsert_room(conn, office)
+        await db.add_room_vent(conn, RoomVent.create("r_office", "cover.vent_office"))
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=68.0)
+        }
+        engine._sensor_map = {"r_office": ["s_office"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None, t=office_temp: (
+            t if eid == "s_office" else None
+        )
+        tc = _make_tc(min_cycle_runtime_min=10)
+        await db.upsert_thermostat_config(conn, tc)
+        return engine, conn, cycle, tc
+
+    @pytest.mark.asyncio
+    async def test_open_records_overflow_room_state(self):
+        from backend import db
+
+        engine, conn, cycle, tc = await self._setup_with_office(75.0)
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        states = {r.room_id: r for r in await db.get_room_cycle_states(conn, cycle.id)}
+        assert "r_office" in states
+        ov = states["r_office"]
+        assert ov.role == "overflow"
+        assert ov.temp_at_start == 75.0
+        assert ov.temp_at_end is None  # still open
+        # target_temp reflects the room's effective setpoint, not a cycle target.
+        assert ov.target_temp == 70.0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_close_captures_end_temp(self):
+        from backend import db
+
+        engine, conn, cycle, tc = await self._setup_with_office(75.0)
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        # Office drifts below its opposite trigger → no longer a candidate.
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            65.0 if eid == "s_office" else None
+        )
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        states = {r.room_id: r for r in await db.get_room_cycle_states(conn, cycle.id)}
+        ov = states["r_office"]
+        assert ov.temp_at_start == 75.0  # preserved from first open
+        assert ov.temp_at_end == 65.0  # captured at vent-close
+        assert ov.vent_closed_at is not None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_reopen_clears_end_temp(self):
+        from backend import db
+
+        engine, conn, cycle, tc = await self._setup_with_office(75.0)
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+        # Swap out, then bring it back as a candidate on a later tick.
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            65.0 if eid == "s_office" else None
+        )
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            76.0 if eid == "s_office" else None
+        )
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+
+        states = {r.room_id: r for r in await db.get_room_cycle_states(conn, cycle.id)}
+        ov = states["r_office"]
+        assert ov.temp_at_start == 75.0  # first open value, never overwritten
+        assert ov.temp_at_end is None  # cleared on re-open
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_finalize_fills_end_temp_for_still_open_rooms(self):
+        from backend import db
+
+        engine, conn, cycle, tc = await self._setup_with_office(75.0)
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+        assert "r_office" in engine._overflow_room_states
+
+        await engine._finalize_overflow_rooms(conn)
+
+        states = {r.room_id: r for r in await db.get_room_cycle_states(conn, cycle.id)}
+        ov = states["r_office"]
+        assert ov.temp_at_end == 75.0  # filled at cycle end from live temp
+        assert ov.vent_closed_at is not None
+        # In-memory tracking is cleared after finalize.
+        assert engine._overflow_room_states == {}
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_get_cycle_ids_with_overflow(self):
+        from backend import db
+
+        engine, conn, cycle, tc = await self._setup_with_office(75.0)
+        # Before any overflow: empty.
+        assert await db.get_cycle_ids_with_overflow(conn, [cycle.id]) == set()
+        await engine._apply_overflow_during_hold(conn, "cooling", tc)
+        assert await db.get_cycle_ids_with_overflow(conn, [cycle.id]) == {cycle.id}
+        # Empty input short-circuits.
+        assert await db.get_cycle_ids_with_overflow(conn, []) == set()
+        await conn.close()
+
+
 class TestCoolingLockoutState:
     """_cooling_lockout_state — outdoor-temperature cooling lockout (Issue #209)."""
 

--- a/smart_vent/frontend/package-lock.json
+++ b/smart_vent/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^6.30.4",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4129,12 +4129,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4144,13 +4144,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/smart_vent/frontend/package.json
+++ b/smart_vent/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2",
+    "react-router-dom": "^6.30.4",
     "recharts": "^3.8.1"
   },
   "devDependencies": {

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -142,6 +142,9 @@ export interface CycleLog {
   setpoint_at_end?: number | null;
   vents_at_start?: Record<string, string> | null;
   vents_at_end?: Record<string, string> | null;
+  // True when the cycle redirected surplus air into non-active rooms during
+  // its minimum-runtime hold (Issue #254).
+  had_overflow?: boolean;
 }
 
 export interface CycleRoomDetail {
@@ -155,6 +158,9 @@ export interface CycleRoomDetail {
   temp_at_end: number | null;
   trigger_detail: Record<string, unknown> | null;
   joined_at: string | null;
+  // 'active' = a room the cycle targeted; 'overflow' = a non-active room
+  // opened during the minimum-runtime hold to absorb surplus air (Issue #254).
+  role?: string;
 }
 
 export interface CycleVentEvent {

--- a/smart_vent/frontend/src/pages/Logs.test.tsx
+++ b/smart_vent/frontend/src/pages/Logs.test.tsx
@@ -348,6 +348,54 @@ describe("Logs Page", () => {
     expect(await screen.findByText(/No cycle logs in this time window/i)).toBeInTheDocument();
   });
 
+  it("flags overflow cycles and renders the overflow rooms section (Issue #254)", async () => {
+    vi.mocked(api.getLogs).mockResolvedValue([{ ...mockCycleLogs[0], had_overflow: true }]);
+    vi.mocked(api.getCycleDetail).mockResolvedValue({
+      ...mockCycleDetail,
+      cycle: { ...mockCycleLogs[0], had_overflow: true },
+      rooms: [
+        { ...mockCycleDetail.rooms[0], role: "active" },
+        {
+          room_id: "r_office",
+          name: "Office",
+          source: null,
+          target_temp: 70,
+          reached_at: null,
+          vent_closed_at: "2024-01-01T12:50:00",
+          temp_at_start: 75,
+          temp_at_end: 71,
+          trigger_detail: { overflow: true, tier: 1 },
+          joined_at: "2024-01-01T12:40:00",
+          role: "overflow",
+        },
+      ],
+    });
+    render(<Logs />);
+
+    fireEvent.click(screen.getByText("Cycle History"));
+    // The list row carries the overflow badge.
+    expect(await screen.findAllByText(/overflow/i)).not.toHaveLength(0);
+
+    fireEvent.click(await screen.findByText(/climate\.test/i));
+
+    // The dedicated overflow section renders with the redirected room + tier.
+    expect(await screen.findByText(/Overflow rooms/i)).toBeInTheDocument();
+    expect(screen.getByText(/min-runtime redirect/i)).toBeInTheDocument();
+    expect(screen.getByText("Office")).toBeInTheDocument();
+    expect(screen.getByText(/tier 1/i)).toBeInTheDocument();
+  });
+
+  it("omits the overflow section for cycles without overflow rooms", async () => {
+    vi.mocked(api.getCycleDetail).mockResolvedValue(mockCycleDetail);
+    render(<Logs />);
+
+    fireEvent.click(screen.getByText("Cycle History"));
+    fireEvent.click(await screen.findByText(/climate\.test/i));
+
+    expect(await screen.findByText(/Vent activity/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Overflow rooms/i)).not.toBeInTheDocument();
+  });
+
   it("surfaces an error when saving retention fails", async () => {
     vi.mocked(api.setLogRetention).mockRejectedValue(new Error("Save boom"));
     render(<Logs />);

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -354,6 +354,15 @@ function LogRow({ log }: { log: CycleLog }) {
         </td>
         <td>
           <span className={`badge badge-${outcome.color}`}>{outcome.label}</span>
+          {log.had_overflow && (
+            <span
+              className="badge badge-purple"
+              title="Redirected surplus air into non-active rooms during a minimum-runtime hold"
+              style={{ marginLeft: ".35rem" }}
+            >
+              overflow
+            </span>
+          )}
         </td>
         <td>{new Date(log.started_at + "Z").toLocaleString()}</td>
         <td>
@@ -469,36 +478,108 @@ function CycleExpanded({
                 </tr>
               </thead>
               <tbody>
-                {detail.rooms.map((r) => (
-                  <tr key={r.room_id}>
-                    <td style={{ fontWeight: 500 }}>{r.name ?? r.room_id.slice(0, 8)}</td>
-                    <td>
-                      <span className="text-sm">{r.source ?? "—"}</span>
-                      {r.trigger_detail && (
-                        <div className="text-sm text-muted">{triggerSummary(r.trigger_detail)}</div>
-                      )}
-                      {r.joined_at && (
-                        <div className="text-sm text-muted">
-                          joined {new Date(r.joined_at + "Z").toLocaleTimeString()}
-                        </div>
-                      )}
-                    </td>
-                    <td>{fmtTemp(r.target_temp)}</td>
-                    <td>
-                      {fmt(r.temp_at_start)} → {fmt(r.temp_at_end)}
-                    </td>
-                    <td>{fmtTime(r.reached_at)}</td>
-                    <td>{fmtTime(r.vent_closed_at)}</td>
-                    <td>
-                      <button
-                        className="btn btn-sm btn-secondary"
-                        onClick={() => onShowChart(r.room_id, r.name ?? r.room_id.slice(0, 8))}
-                      >
-                        View chart
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                {detail.rooms
+                  .filter((r) => r.role !== "overflow")
+                  .map((r) => (
+                    <tr key={r.room_id}>
+                      <td style={{ fontWeight: 500 }}>{r.name ?? r.room_id.slice(0, 8)}</td>
+                      <td>
+                        <span className="text-sm">{r.source ?? "—"}</span>
+                        {r.trigger_detail && (
+                          <div className="text-sm text-muted">
+                            {triggerSummary(r.trigger_detail)}
+                          </div>
+                        )}
+                        {r.joined_at && (
+                          <div className="text-sm text-muted">
+                            joined {new Date(r.joined_at + "Z").toLocaleTimeString()}
+                          </div>
+                        )}
+                      </td>
+                      <td>{fmtTemp(r.target_temp)}</td>
+                      <td>
+                        {fmt(r.temp_at_start)} → {fmt(r.temp_at_end)}
+                      </td>
+                      <td>{fmtTime(r.reached_at)}</td>
+                      <td>{fmtTime(r.vent_closed_at)}</td>
+                      <td>
+                        <button
+                          className="btn btn-sm btn-secondary"
+                          onClick={() => onShowChart(r.room_id, r.name ?? r.room_id.slice(0, 8))}
+                        >
+                          View chart
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Overflow rooms (Issue #254) — non-active rooms the cycle redirected
+          surplus conditioned air into during its minimum-runtime hold. */}
+      {detail && detail.rooms.some((r) => r.role === "overflow") && (
+        <div className="card" style={{ padding: 0 }}>
+          <div
+            style={{
+              padding: ".5rem .75rem",
+              fontWeight: 600,
+              borderBottom: "1px solid var(--gray-200)",
+              display: "flex",
+              alignItems: "center",
+              gap: ".5rem",
+            }}
+          >
+            Overflow rooms
+            <span className="badge badge-purple">min-runtime redirect</span>
+          </div>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Tier</th>
+                  <th>Setpoint</th>
+                  <th>Start → End</th>
+                  <th>Opened</th>
+                  <th>Closed</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {detail.rooms
+                  .filter((r) => r.role === "overflow")
+                  .map((r) => {
+                    const tier = (r.trigger_detail?.tier as number | undefined) ?? null;
+                    return (
+                      <tr key={r.room_id}>
+                        <td style={{ fontWeight: 500 }}>{r.name ?? r.room_id.slice(0, 8)}</td>
+                        <td>
+                          {tier != null ? (
+                            <span className="badge badge-gray">tier {tier}</span>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                        <td>{fmtTemp(r.target_temp)}</td>
+                        <td>
+                          {fmt(r.temp_at_start)} → {fmt(r.temp_at_end)}
+                        </td>
+                        <td>{fmtTime(r.joined_at)}</td>
+                        <td>{fmtTime(r.vent_closed_at)}</td>
+                        <td>
+                          <button
+                            className="btn btn-sm btn-secondary"
+                            onClick={() => onShowChart(r.room_id, r.name ?? r.room_id.slice(0, 8))}
+                          >
+                            View chart
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
               </tbody>
             </table>
           </div>

--- a/smart_vent/frontend/src/styles.css
+++ b/smart_vent/frontend/src/styles.css
@@ -647,6 +647,10 @@
   background: var(--orange-light);
   color: #c2410c;
 }
+.badge-purple {
+  background: #ede9fe;
+  color: #6d28d9;
+}
 
 /* ── Stat row ── */
 .stat-row {


### PR DESCRIPTION
Closes #254.

## What changed & why

Overflow conditioning (#237) redirects surplus conditioned air into non-active rooms during a minimum-runtime hold, but those rooms were only recorded as opaque `cycle_vent_events` with the temperature buried in a human-readable `reason` string. The Logs page therefore had **no structured record** of which rooms a cycle redirected into, their start temperature, or their end temperature when the min-runtime timer closed the cycle.

This PR captures overflow rooms as proper cycle data points and surfaces them on the Logs page.

### Design (as agreed on the issue)

- **Storage — reuse `room_cycle_states` + a `role` column.** Overflow rooms become `room_cycle_states` rows with `role='overflow'`, reusing `temp_at_start` / `temp_at_end` / `vent_closed_at`. New schema column + migration (the migration runner already ignores the duplicate-column case, matching the existing `in_min_runtime_hold` pattern). Kept in a separate in-memory dict (`_overflow_room_states`) so overflow rooms never leak into the active-room code paths.
- **Granularity — one collapsed record per room.** `temp_at_start` = temp at first overflow-open; `temp_at_end` = final close / cycle end. A re-open keeps the original start and re-arms the end capture.
- **End semantics — vent-close OR cycle-end, whichever first.** Swapped-out rooms capture their temp at vent-close; rooms still open when the timer runs out are finalized at cycle end (both terminate and abort paths). Restored mid-hold after a restart, still-open overflow rooms are re-tracked so the finalize still closes their data point.
- **UI — dedicated section + badge.** The cycle detail shows a new "Overflow rooms" section (name, tier, setpoint, start→end, opened/closed, chart link) rendered like the active-rooms section. The history list flags cycles that performed overflow with an "overflow" badge, backed by a new `had_overflow` flag computed without an N+1 query.

### Regression guard — overflow rows must not leak into existing queries (2nd commit)

Persisting overflow rooms into `room_cycle_states` meant four pre-existing queries silently picked them up. All are now scoped to active rows (`rcs.role != 'overflow'`):

- **`compute_room_metrics`** — overflow rows no longer inflate per-room participation count/rate or heating/cooling seconds (the room still appears, with zero participation).
- **overshoot distribution** — an overflow room's target no longer pairs with thermostat-level samples to register spurious overshoot.
- **time-to-first-room timeseries** — defensively excluded (was already safe via `reached_at IS NOT NULL`, since overflow rows carry a NULL `reached_at`).
- **`close_open_cycles_for_rooms`** — deleting/reassigning a room that was only an overflow participant no longer closes an otherwise-running cycle.

### Security: CVE-2026-40181 (3rd commit)

The Trivy source scan flagged `react-router` `6.30.3` for `CVE-2026-40181` (open redirect via a same-origin redirect with a path starting `//`). Bumped `react-router-dom` to the `6.30.4` patch (pulls `react-router` `6.30.4` + `@remix-run/router` `1.23.3`) — same major, non-breaking; the frontend build and all 243 frontend tests pass. (The scan's pass/fail gate greps for the string `CRITICAL`, which also matches the literal `CRITICAL: 0` in Trivy's summary line, so any finding at all turns it red; removing the only finding clears it.)

### Files

- **Backend**: `models.py` (`RoomCycleState.role`), `db.py` (schema/migration, upsert + row reader, `get_cycle_ids_with_overflow`, four query scopings), `cycle_engine.py` (record open/close, finalize at terminate/abort, restore split), `api/routes.py` (`role` + name fallback in detail, `had_overflow` in list/detail), `api/schemas.py`.
- **Frontend**: `api.ts` (`role`, `had_overflow`), `Logs.tsx` (overflow section + badge), `styles.css` (`badge-purple`), `package.json` + `package-lock.json` (react-router 6.30.4).

This is read-only diagnostic logging — no new temperature **write boundary**, so the temperature-field parity manifests are untouched. The behavior toggle (`overflow_during_min_runtime`) already has its UI.

## Test plan

- **Backend (`pytest`, 733 passed, coverage 92.66% ≥ 92.5%)**
  - `TestOverflowRoomDataPoints`: open creates a `role='overflow'` row with `temp_at_start`; close captures `temp_at_end`; re-open clears the end; cycle-end finalize fills still-open rooms; `get_cycle_ids_with_overflow`.
  - Integration (logs): detail endpoint returns overflow rooms tagged `role='overflow'` with a live-room name fallback and `had_overflow=True`; the list flags the cycle; a normal cycle reports `had_overflow=False`.
  - Integration (metrics regression): overflow rows excluded from per-room participation/conditioning time and from the overshoot histogram.
- **Backend lint/types**: `ruff check`, `ruff format --check`, `mypy` all clean.
- **Frontend (`vitest`, 243 tests passed, coverage above thresholds; `npm run build` clean)**: overflow badge on the list row and the "Overflow rooms" section render; section omitted for non-overflow cycles.
- **Frontend lint/format**: `eslint` (only a pre-existing unrelated DevMode warning) and `prettier --check` clean.