### PR TITLE
fix(logs): Apply button for custom date filter + contained feed auto-scroll

### DIFF
--- a/smart_vent/frontend/src/pages/Logs.test.tsx
+++ b/smart_vent/frontend/src/pages/Logs.test.tsx
@@ -313,8 +313,14 @@ describe("Logs Page", () => {
     const dateInputs = document.querySelectorAll('input[type="datetime-local"]');
     expect(dateInputs.length).toBe(2);
 
+    // Typing in the inputs should NOT trigger a fetch — Apply gates it
+    vi.mocked(api.getLogs).mockClear();
     fireEvent.change(dateInputs[0], { target: { value: "2024-01-01T00:00" } });
     fireEvent.change(dateInputs[1], { target: { value: "2024-01-02T00:00" } });
+    expect(api.getLogs).not.toHaveBeenCalled();
+
+    // Clicking Apply commits the range and fires exactly one fetch
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
     await waitFor(() => {
       expect(api.getLogs).toHaveBeenCalledWith(
         expect.objectContaining({ since: expect.any(String), until: expect.any(String) })

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -85,6 +85,7 @@ function TimeWindowControls({
   onPreset,
   onCustomFrom,
   onCustomTo,
+  onApply,
 }: {
   preset: TimePreset;
   customFrom: string;
@@ -92,6 +93,7 @@ function TimeWindowControls({
   onPreset: (p: TimePreset) => void;
   onCustomFrom: (v: string) => void;
   onCustomTo: (v: string) => void;
+  onApply?: () => void;
 }) {
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: ".4rem", alignItems: "center" }}>
@@ -124,6 +126,13 @@ function TimeWindowControls({
             value={customTo}
             onChange={(e) => onCustomTo(e.target.value)}
           />
+          <button
+            className="btn btn-sm btn-primary"
+            onClick={onApply}
+            disabled={!customFrom || !customTo}
+          >
+            Apply
+          </button>
         </>
       )}
     </div>
@@ -673,15 +682,17 @@ function CycleHistory() {
   const [preset, setPreset] = useState<TimePreset>("24h");
   const [customFrom, setCustomFrom] = useState("");
   const [customTo, setCustomTo] = useState("");
+  const [committedFrom, setCommittedFrom] = useState("");
+  const [committedTo, setCommittedTo] = useState("");
 
   const buildParams = (currentOffset: number) => {
     const since =
       preset !== "custom"
         ? presetToSince(preset)
-        : customFrom
-          ? new Date(customFrom).toISOString()
+        : committedFrom
+          ? new Date(committedFrom).toISOString()
           : undefined;
-    const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
+    const until = preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
     return { limit: PAGE_SIZE, offset: currentOffset, since, until };
   };
 
@@ -705,7 +716,7 @@ function CycleHistory() {
     // `load` closes over offset/state setters; re-running only on filter
     // changes is intentional — adding `load` would fire on every pagination.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preset, customFrom, customTo]);
+  }, [preset, committedFrom, committedTo]);
 
   return (
     <div>
@@ -727,6 +738,10 @@ function CycleHistory() {
           }}
           onCustomFrom={setCustomFrom}
           onCustomTo={setCustomTo}
+          onApply={() => {
+            setCommittedFrom(customFrom);
+            setCommittedTo(customTo);
+          }}
         />
         <button className="btn btn-secondary btn-sm" onClick={() => load(true)}>
           ↻ Refresh
@@ -836,8 +851,10 @@ function LiveFeed() {
   const [preset, setPreset] = useState<TimePreset>("1h");
   const [customFrom, setCustomFrom] = useState("");
   const [customTo, setCustomTo] = useState("");
+  const [committedFrom, setCommittedFrom] = useState("");
+  const [committedTo, setCommittedTo] = useState("");
 
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const feedRef = useRef<HTMLDivElement>(null);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
 
@@ -845,10 +862,10 @@ function LiveFeed() {
     const since =
       preset !== "custom"
         ? presetToSince(preset)
-        : customFrom
-          ? new Date(customFrom).toISOString()
+        : committedFrom
+          ? new Date(committedFrom).toISOString()
           : undefined;
-    const until = preset === "custom" && customTo ? new Date(customTo).toISOString() : undefined;
+    const until = preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
     return {
       limit: PAGE_SIZE,
       offset: currentOffset,
@@ -881,7 +898,7 @@ function LiveFeed() {
     load(true);
     // Re-running only on filter changes is intentional — see note above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [category, levels, preset, customFrom, customTo]);
+  }, [category, levels, preset, committedFrom, committedTo]);
 
   // WebSocket: append new events in real time (unless paused or filtered out)
   useEffect(() => {
@@ -898,9 +915,11 @@ function LiveFeed() {
     return cleanup;
   }, [category, levels]);
 
-  // Auto-scroll to bottom when entries change
+  // Auto-scroll the feed container (not the page) when entries change
   useEffect(() => {
-    if (!paused) bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (!paused && feedRef.current) {
+      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    }
   }, [entries, paused]);
 
   const toggleLevel = (lv: string) =>
@@ -948,6 +967,10 @@ function LiveFeed() {
           }}
           onCustomFrom={setCustomFrom}
           onCustomTo={setCustomTo}
+          onApply={() => {
+            setCommittedFrom(customFrom);
+            setCommittedTo(customTo);
+          }}
         />
       </div>
       <div
@@ -1016,7 +1039,7 @@ function LiveFeed() {
         </div>
       )}
 
-      <div className="card event-feed">
+      <div className="card event-feed" ref={feedRef}>
         {entries.length === 0 ? (
           <div className="empty-state">
             <p>No events in this time window.</p>
@@ -1024,7 +1047,6 @@ function LiveFeed() {
         ) : (
           entries.map((e, i) => <EventEntry key={e.id ?? i} entry={e} />)
         )}
-        <div ref={bottomRef} />
       </div>
 
       {showClearModal && (

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -692,7 +692,8 @@ function CycleHistory() {
         : committedFrom
           ? new Date(committedFrom).toISOString()
           : undefined;
-    const until = preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
+    const until =
+      preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
     return { limit: PAGE_SIZE, offset: currentOffset, since, until };
   };
 
@@ -865,7 +866,8 @@ function LiveFeed() {
         : committedFrom
           ? new Date(committedFrom).toISOString()
           : undefined;
-    const until = preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
+    const until =
+      preset === "custom" && committedTo ? new Date(committedTo).toISOString() : undefined;
     return {
       limit: PAGE_SIZE,
       offset: currentOffset,

--- a/smart_vent/frontend/src/styles.css
+++ b/smart_vent/frontend/src/styles.css
@@ -1064,6 +1064,7 @@ tr:hover td {
 /* ── Event feed ── */
 .event-feed {
   max-height: calc(100vh - 220px);
+  min-height: 400px;
   overflow-y: auto;
   padding: 0.5rem;
   font-family: ui-monospace, monospace;


### PR DESCRIPTION
Fixes #263.

## Summary

- **Apply button for custom date range** — the Logs page (Live Feed and Cycle History) previously fired an API request on every keystroke when "Custom" was selected. Added an Apply button that gates the fetch: input state (what the fields show) is now separate from committed state (what the fetch depends on). No requests fire until the user fills both fields and clicks Apply.
- **Contained feed auto-scroll** — `scrollIntoView()` on the bottom sentinel div could scroll the whole page, pushing the filter controls off-screen. Replaced with `feedRef.current.scrollTop = feedRef.current.scrollHeight` so only the feed container scrolls, leaving the page viewport and filter bar stationary.
- **Mobile min-height** — `.event-feed` now has `min-height: 400px` so the feed area stays usable on narrow viewports.

## Changes

- `Logs.tsx` — `TimeWindowControls`: add `onApply` prop + Apply button (disabled until both dates filled). `CycleHistory` + `LiveFeed`: split input/committed state; `useEffect` depends on committed values only. `LiveFeed`: replace `bottomRef` sentinel + `scrollIntoView` with `feedRef` on the container + `scrollTop` assignment.
- `styles.css` — add `min-height: 400px` to `.event-feed`.
- `Logs.test.tsx` — updated "reveals custom date inputs" test: asserts no fetch fires on input change, and exactly one fetch fires with correct `since`/`until` when Apply is clicked.

## Test plan

- [ ] Select Custom on Live Feed — type a From date, type a To date; verify no network request fires during typing.
- [ ] Click Apply — verify one fetch fires with correct `since`/`until` query params.
- [ ] Switch back to a preset (e.g. 1h) — verify data reloads immediately without needing Apply.
- [ ] Navigate to Logs → Live Feed — verify the page does not auto-scroll and the Window/filter controls remain visible.
- [ ] Resize to a narrow viewport (~375 px) — verify the feed area is at least 400 px tall.
- [ ] All 243 frontend tests pass (`npx vitest run`).
