### PR TITLE
Abort cycles on sustained thermostat unavailability; close critical engine test gaps

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -839,6 +839,7 @@ async def create_thermostat(request: web.Request) -> web.Response:
         "has_bypass_damper",
         "min_open_vents_fraction",
         "overflow_during_min_runtime",
+        "unavailable_abort_after_min",
     ):
         if field in body:
             if field in ("min_setpoint", "max_setpoint"):
@@ -878,6 +879,13 @@ async def create_thermostat(request: web.Request) -> web.Response:
                 setattr(tc, field, float(val))
             elif field == "overflow_during_min_runtime":
                 setattr(tc, field, bool(body[field]))
+            elif field == "unavailable_abort_after_min":
+                # Minutes of sustained thermostat unavailability before a
+                # running cycle is aborted (#267). 0 = never abort.
+                val = body[field]
+                if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                    return error("unavailable_abort_after_min must be a non-negative integer")
+                setattr(tc, field, val)
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -945,6 +953,7 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
         "has_bypass_damper",
         "min_open_vents_fraction",
         "overflow_during_min_runtime",
+        "unavailable_abort_after_min",
     ):
         if field in body:
             if field in ("min_setpoint", "max_setpoint"):
@@ -984,6 +993,13 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
                 setattr(tc, field, float(val))
             elif field == "overflow_during_min_runtime":
                 setattr(tc, field, bool(body[field]))
+            elif field == "unavailable_abort_after_min":
+                # Minutes of sustained thermostat unavailability before a
+                # running cycle is aborted (#267). 0 = never abort.
+                val = body[field]
+                if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                    return error("unavailable_abort_after_min must be a non-negative integer")
+                setattr(tc, field, val)
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -1535,6 +1551,44 @@ async def get_sensor_health(request: web.Request) -> web.Response:
             "rooms": stale_rooms,
         }
     )
+
+
+@docs(tags=["diagnostics"], summary="Thermostat availability summary (Issue #267)")
+@response_schema(schemas.ThermostatHealthSchema)
+@routes.get("/api/thermostat-health")
+async def get_thermostat_health(request: web.Request) -> web.Response:
+    """Registered thermostats whose climate entity is currently unavailable —
+    drives the Dashboard banner (Issue #267), mirroring /api/sensor-health.
+
+    A thermostat not in the HA state cache at all is reported with
+    ``reason="not_in_cache"`` so the UI can distinguish "went unavailable" from
+    "never seen". ``unavailable_seconds`` comes from the engine's per-tick
+    availability tracking and may be null before the first tick of an outage.
+    Healthy thermostats are omitted from the response.
+    """
+    conn = await get_conn(request)
+    ha = request.app["ha"]
+    scheduler = request.app["scheduler"]
+    now = datetime.now(UTC)
+
+    unavailable: list[dict] = []
+    for tc in await db.get_all_thermostat_configs(conn):
+        state = ha.get_state(tc.thermostat_entity_id)
+        if state is not None and state.get("state") != "unavailable":
+            continue
+        engine = scheduler.get_engine(tc.thermostat_entity_id)
+        since = engine.unavailable_since if engine else None
+        unavailable.append(
+            {
+                "thermostat_entity_id": tc.thermostat_entity_id,
+                "name": tc.name,
+                "reason": "not_in_cache" if state is None else "unavailable",
+                "unavailable_seconds": (now - since).total_seconds() if since else None,
+                "abort_after_min": tc.unavailable_abort_after_min,
+                "cycle_running": bool(engine and engine.cycle_state.value == "running"),
+            }
+        )
+    return json_response({"thermostats": unavailable})
 
 
 @docs(tags=["settings"], summary="Get log retention settings")

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -210,6 +210,19 @@ class SensorHealthSchema(Schema):
     rooms = fields.List(fields.Nested(StaleRoomSchema))
 
 
+class UnavailableThermostatSchema(Schema):
+    thermostat_entity_id = fields.Str()
+    name = fields.Str()
+    reason = fields.Str()
+    unavailable_seconds = fields.Float(allow_none=True)
+    abort_after_min = fields.Int()
+    cycle_running = fields.Bool()
+
+
+class ThermostatHealthSchema(Schema):
+    thermostats = fields.List(fields.Nested(UnavailableThermostatSchema))
+
+
 class VacationModeSchema(Schema):
     enabled = fields.Bool()
     return_at = fields.Str(allow_none=True)

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -105,7 +105,8 @@ CREATE TABLE IF NOT EXISTS thermostat_configs (
     total_vents_count INTEGER,
     has_bypass_damper INTEGER NOT NULL DEFAULT 0,
     min_open_vents_fraction REAL NOT NULL DEFAULT 0.333,
-    overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1
+    overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1,
+    unavailable_abort_after_min INTEGER NOT NULL DEFAULT 5
 );
 
 CREATE TABLE IF NOT EXISTS room_overrides (
@@ -404,6 +405,10 @@ _MIGRATIONS = [
     "ALTER TABLE rooms ADD COLUMN ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0",
     "ALTER TABLE rooms ADD COLUMN ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0",
     "ALTER TABLE rooms ADD COLUMN ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60",
+    # Thermostat-unavailability abort (Issue #267). Minutes of sustained
+    # climate-entity unavailability before a running cycle is aborted and all
+    # zone vents re-opened. 0 = never abort.
+    "ALTER TABLE thermostat_configs ADD COLUMN unavailable_abort_after_min INTEGER NOT NULL DEFAULT 5",
 ]
 
 
@@ -739,6 +744,9 @@ def _row_to_tc(row) -> ThermostatConfig:
         overflow_during_min_runtime=bool(row["overflow_during_min_runtime"])
         if "overflow_during_min_runtime" in keys
         else True,
+        unavailable_abort_after_min=int(row["unavailable_abort_after_min"])
+        if "unavailable_abort_after_min" in keys and row["unavailable_abort_after_min"] is not None
+        else 5,
     )
 
 
@@ -750,8 +758,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             reconciliation_interval_min,vacation_hvac_mode,
             min_cycle_runtime_min,min_cycle_offtime_min,cooling_lockout_below_f,
             total_vents_count,has_bypass_damper,min_open_vents_fraction,
-            overflow_during_min_runtime)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            overflow_during_min_runtime,unavailable_abort_after_min)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(thermostat_entity_id) DO UPDATE SET
              name=excluded.name,
              default_temp=excluded.default_temp,
@@ -769,7 +777,8 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
              total_vents_count=excluded.total_vents_count,
              has_bypass_damper=excluded.has_bypass_damper,
              min_open_vents_fraction=excluded.min_open_vents_fraction,
-             overflow_during_min_runtime=excluded.overflow_during_min_runtime
+             overflow_during_min_runtime=excluded.overflow_during_min_runtime,
+             unavailable_abort_after_min=excluded.unavailable_abort_after_min
         """,
         (
             tc.thermostat_entity_id,
@@ -790,6 +799,7 @@ async def upsert_thermostat_config(conn: aiosqlite.Connection, tc: ThermostatCon
             int(tc.has_bypass_damper),
             tc.min_open_vents_fraction,
             int(tc.overflow_during_min_runtime),
+            tc.unavailable_abort_after_min,
         ),
     )
     await conn.commit()

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -52,15 +52,10 @@ BroadcastFn = Callable[[str, dict], Coroutine]
 # averages so the engine never drives control decisions off stale data.
 SENSOR_STALE_AFTER_MIN: float = 30.0
 
-# Thermostat-unavailability tolerance (Issue #267). A transient outage (HA
-# integration reload, brief network blip) must not kill a running cycle, but a
-# sustained one suspends every per-tick safety monitor — cycle timeout, the
-# max_vent_closed_min watchdog, and reconciliation all live below the
-# availability guard in _do_tick. After this many consecutive unavailable
-# ticks (~60s each) a running cycle is aborted: the abort re-opens all zone
-# vents (vent entities are independent of the climate entity, so those
-# commands still work), bounding the closed-vent window during an outage.
-UNAVAILABLE_ABORT_AFTER_TICKS: int = 5
+# Thermostat-unavailability tolerance (Issue #267): the abort threshold is the
+# per-thermostat ``unavailable_abort_after_min`` config field (default 5 min,
+# 0 = never abort), surfaced on the Thermostats page. See the availability
+# guard at the top of ``_do_tick``.
 
 
 class CycleState(Enum):
@@ -115,9 +110,11 @@ class CycleEngine:
         # server restart resets it (a restart is itself a multi-minute gap).
         self._last_cycle_ended_at: datetime | None = None
 
-        # Consecutive ticks the thermostat has been unavailable (Issue #267).
-        # Reset to 0 the moment a tick sees it available again.
-        self._unavailable_ticks: int = 0
+        # When the thermostat entity became unavailable (Issue #267); None
+        # while it is reachable. Cleared the moment a tick sees it available
+        # again. Drives both the cycle-abort threshold and the UI banner
+        # (/api/thermostat-health).
+        self._unavailable_since: datetime | None = None
 
         # Sensor-staleness episodes already announced via the event log
         # (Issue #211). Tracked per-engine so we warn once per stale episode
@@ -154,6 +151,14 @@ class CycleEngine:
     @property
     def current_cycle_id(self) -> str | None:
         return self._cycle_log.id if self._cycle_log else None
+
+    @property
+    def unavailable_since(self) -> datetime | None:
+        """When the thermostat entity became unavailable; None while reachable.
+
+        Read by ``/api/thermostat-health`` to drive the UI banner (Issue #267).
+        """
+        return self._unavailable_since
 
     async def tick(self, conn: aiosqlite.Connection) -> None:
         """Main entry point — called by scheduler every 60s or on state change."""
@@ -244,11 +249,14 @@ class CycleEngine:
         # running at the last commanded setpoint with vents closed.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
-            self._unavailable_ticks += 1
+            now = datetime.now(UTC)
+            if self._unavailable_since is None:
+                self._unavailable_since = now
+            outage_min = (now - self._unavailable_since).total_seconds() / 60
             log.warning(
-                "Thermostat %s unavailable — skipping tick (%d consecutive)",
+                "Thermostat %s unavailable — skipping tick (%.1f min so far)",
                 self.thermostat_entity_id,
-                self._unavailable_ticks,
+                outage_min,
             )
             if self._logger:
                 await self._logger.log(
@@ -257,13 +265,15 @@ class CycleEngine:
                     f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick",
                     {"thermostat": self.thermostat_entity_id},
                 )
-            if (
-                self._state != CycleState.IDLE
-                and self._unavailable_ticks >= UNAVAILABLE_ABORT_AFTER_TICKS
-            ):
-                await self._abort_cycle(conn, reason="thermostat unavailable")
+            if self._state != CycleState.IDLE:
+                tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+                if (
+                    tc.unavailable_abort_after_min > 0
+                    and outage_min >= tc.unavailable_abort_after_min
+                ):
+                    await self._abort_cycle(conn, reason="thermostat unavailable")
             return
-        self._unavailable_ticks = 0
+        self._unavailable_since = None
 
         # System disabled guard — if a cycle is running, abort it immediately.
         # _abort_cycle handles all logging; no pre-call log needed here.

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -3,7 +3,9 @@ HVAC Cycle Engine — one instance per thermostat zone.
 
 State machine:
   IDLE → RUNNING → (all rooms at target) → TERMINATING → IDLE
-  RUNNING → ABORTED (thermostat unavailable, mode change, timeout)
+  RUNNING → ABORTED (system disabled, vacation mode, no active rooms,
+                     sustained thermostat unavailability)
+  RUNNING → TERMINATED (cycle timeout)
 """
 
 from __future__ import annotations
@@ -49,6 +51,16 @@ BroadcastFn = Callable[[str, dict], Coroutine]
 # older than this threshold (minutes) are excluded from room-temperature
 # averages so the engine never drives control decisions off stale data.
 SENSOR_STALE_AFTER_MIN: float = 30.0
+
+# Thermostat-unavailability tolerance (Issue #267). A transient outage (HA
+# integration reload, brief network blip) must not kill a running cycle, but a
+# sustained one suspends every per-tick safety monitor — cycle timeout, the
+# max_vent_closed_min watchdog, and reconciliation all live below the
+# availability guard in _do_tick. After this many consecutive unavailable
+# ticks (~60s each) a running cycle is aborted: the abort re-opens all zone
+# vents (vent entities are independent of the climate entity, so those
+# commands still work), bounding the closed-vent window during an outage.
+UNAVAILABLE_ABORT_AFTER_TICKS: int = 5
 
 
 class CycleState(Enum):
@@ -102,6 +114,10 @@ class CycleEngine:
         # off-time lockout before a new cycle may start. In-memory only — a
         # server restart resets it (a restart is itself a multi-minute gap).
         self._last_cycle_ended_at: datetime | None = None
+
+        # Consecutive ticks the thermostat has been unavailable (Issue #267).
+        # Reset to 0 the moment a tick sees it available again.
+        self._unavailable_ticks: int = 0
 
         # Sensor-staleness episodes already announced via the event log
         # (Issue #211). Tracked per-engine so we warn once per stale episode
@@ -220,12 +236,19 @@ class CycleEngine:
             self._stale_after_min = SENSOR_STALE_AFTER_MIN
 
         # Thermostat availability check — always runs, even when system is
-        # disabled or vacation mode is active. Transient outages are tolerated.
+        # disabled or vacation mode is active. Transient outages are tolerated;
+        # a sustained outage with a cycle in flight aborts it (Issue #267),
+        # because every per-tick safety monitor (cycle timeout, the
+        # max_vent_closed_min watchdog, reconciliation) lives below this guard
+        # and would otherwise stay suspended while the physical HVAC keeps
+        # running at the last commanded setpoint with vents closed.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
+            self._unavailable_ticks += 1
             log.warning(
-                "Thermostat %s unavailable — skipping tick",
+                "Thermostat %s unavailable — skipping tick (%d consecutive)",
                 self.thermostat_entity_id,
+                self._unavailable_ticks,
             )
             if self._logger:
                 await self._logger.log(
@@ -234,7 +257,13 @@ class CycleEngine:
                     f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick",
                     {"thermostat": self.thermostat_entity_id},
                 )
+            if (
+                self._state != CycleState.IDLE
+                and self._unavailable_ticks >= UNAVAILABLE_ABORT_AFTER_TICKS
+            ):
+                await self._abort_cycle(conn, reason="thermostat unavailable")
             return
+        self._unavailable_ticks = 0
 
         # System disabled guard — if a cycle is running, abort it immediately.
         # _abort_cycle handles all logging; no pre-call log needed here.
@@ -1306,7 +1335,6 @@ class CycleEngine:
         self,
         conn: aiosqlite.Connection,
         reason: str,
-        safe_close: bool = False,
     ) -> None:
         log.warning("Aborting cycle for %s — %s", self.thermostat_entity_id, reason)
         if self._logger and self._state != CycleState.IDLE:
@@ -1362,25 +1390,22 @@ class CycleEngine:
                     exc,
                 )
 
-        # Include idle-room vents (closed at cycle start) so the normal abort
-        # path returns the zone to fully-open idle state (issue #244).
+        # Include idle-room vents (closed at cycle start) so the abort path
+        # returns the zone to fully-open idle state (issue #244).
         all_vents = [v for vl in self._room_vents.values() for v in vl]
-        if not safe_close:
-            try:
-                _active_ids = set(self._active_rooms.keys())
-                for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
-                    if _zr.id not in _active_ids:
-                        all_vents.extend(await db.get_room_vents(conn, _zr.id))
-            except Exception:
-                log.exception(
-                    "Failed to fetch idle-room vents for %s during abort — "
-                    "idle vents may remain closed until the next reconcile pass",
-                    self.thermostat_entity_id,
-                )
         try:
-            if safe_close:
-                await self._vent.close_all_zone_vents(all_vents)
-            elif all_vents:
+            _active_ids = set(self._active_rooms.keys())
+            for _zr in await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id):
+                if _zr.id not in _active_ids:
+                    all_vents.extend(await db.get_room_vents(conn, _zr.id))
+        except Exception:
+            log.exception(
+                "Failed to fetch idle-room vents for %s during abort — "
+                "idle vents may remain closed until the next reconcile pass",
+                self.thermostat_entity_id,
+            )
+        try:
+            if all_vents:
                 await self._vent.open_room_vents(all_vents)
                 if self._logger:
                     await self._logger.log(
@@ -1395,34 +1420,34 @@ class CycleEngine:
         # Reset the thermostat setpoint to current ambient so the HVAC goes idle.
         # _terminate_cycle() does this on normal termination; mirroring it here
         # ensures an aborted cycle never leaves a stale active setpoint in place.
-        # Skip when safe_close=True (thermostat unavailable — commands would fail).
-        if not safe_close:
-            thermo_state = self._ha.get_state(self.thermostat_entity_id)
-            if thermo_state:
-                ambient = thermo_state.get("attributes", {}).get("current_temperature")
-                if ambient is not None:
-                    ambient_f = float(ambient)
-                    try:
-                        await self._ha.set_thermostat_temperature(
-                            self.thermostat_entity_id,
-                            ambient_f,
-                            hvac_mode=self._cycle_ha_mode,
+        # On an unavailability abort (#267) the ambient read comes back None and
+        # this block is skipped — there is nothing to command.
+        thermo_state = self._ha.get_state(self.thermostat_entity_id)
+        if thermo_state:
+            ambient = thermo_state.get("attributes", {}).get("current_temperature")
+            if ambient is not None:
+                ambient_f = float(ambient)
+                try:
+                    await self._ha.set_thermostat_temperature(
+                        self.thermostat_entity_id,
+                        ambient_f,
+                        hvac_mode=self._cycle_ha_mode,
+                    )
+                    self._last_setpoint_sent = ambient_f
+                    if self._logger:
+                        await self._logger.log(
+                            "info",
+                            "engine",
+                            f"Cycle aborted for {self.thermostat_entity_id} — "
+                            f"setpoint reset to ambient {ambient_f}°F",
+                            {
+                                "thermostat": self.thermostat_entity_id,
+                                "setpoint": ambient_f,
+                                "hvac_mode": self._cycle_ha_mode,
+                            },
                         )
-                        self._last_setpoint_sent = ambient_f
-                        if self._logger:
-                            await self._logger.log(
-                                "info",
-                                "engine",
-                                f"Cycle aborted for {self.thermostat_entity_id} — "
-                                f"setpoint reset to ambient {ambient_f}°F",
-                                {
-                                    "thermostat": self.thermostat_entity_id,
-                                    "setpoint": ambient_f,
-                                    "hvac_mode": self._cycle_ha_mode,
-                                },
-                            )
-                    except Exception as exc:
-                        log.error("Abort: failed to reset setpoint to ambient: %s: %r", exc, exc)
+                except Exception as exc:
+                    log.error("Abort: failed to reset setpoint to ambient: %s: %r", exc, exc)
 
         self._state = CycleState.IDLE
         self._cycle_mode = None

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -198,12 +198,13 @@ class CycleEngine:
         room_states: list[RoomLiveState] = []
         for room_id, ar in self._active_rooms.items():
             vents = self._room_vents.get(room_id, [])
+            total_sensors, available_sensors = self._sensor_counts(ar.room)
             room_states.append(
                 RoomLiveState(
                     room_id=room_id,
                     avg_temp=self._get_avg_temp(ar.room),
-                    sensor_count=len(ar.room.include_thermostat_sensor and [1] or []),
-                    available_sensor_count=0,
+                    sensor_count=total_sensors,
+                    available_sensor_count=available_sensors,
                     vent_states=self._vent.get_vent_states(vents),
                     presence_active=ar.source == "presence",
                     holdover_expires_at=None,
@@ -250,6 +251,7 @@ class CycleEngine:
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state is None or thermo_state.get("state") == "unavailable":
             now = datetime.now(UTC)
+            first_tick_of_outage = self._unavailable_since is None
             if self._unavailable_since is None:
                 self._unavailable_since = now
             outage_min = (now - self._unavailable_since).total_seconds() / 60
@@ -258,11 +260,15 @@ class CycleEngine:
                 self.thermostat_entity_id,
                 outage_min,
             )
-            if self._logger:
+            # Event-log warning once per outage episode (Issue #270), not on
+            # every 60-second tick — mirrors the #211 sensor-staleness
+            # rate-limiting so a multi-hour outage doesn't bury the feed.
+            if first_tick_of_outage and self._logger:
                 await self._logger.log(
                     "warning",
                     "engine",
-                    f"Thermostat {self.thermostat_entity_id} unavailable — skipping tick",
+                    f"Thermostat {self.thermostat_entity_id} is unavailable in Home Assistant "
+                    "— the engine cannot supervise this zone until it reports again.",
                     {"thermostat": self.thermostat_entity_id},
                 )
             if self._state != CycleState.IDLE:
@@ -273,7 +279,19 @@ class CycleEngine:
                 ):
                     await self._abort_cycle(conn, reason="thermostat unavailable")
             return
-        self._unavailable_since = None
+        # Available again — if we had been in an outage, announce recovery once
+        # (symmetric with the once-per-episode warning above).
+        if self._unavailable_since is not None:
+            log.info("Thermostat %s is reporting again", self.thermostat_entity_id)
+            if self._logger:
+                await self._logger.log(
+                    "info",
+                    "engine",
+                    f"Thermostat {self.thermostat_entity_id} is reporting again — "
+                    "normal supervision resumed.",
+                    {"thermostat": self.thermostat_entity_id},
+                )
+            self._unavailable_since = None
 
         # System disabled guard — if a cycle is running, abort it immediately.
         # _abort_cycle handles all logging; no pre-call log needed here.
@@ -2094,6 +2112,35 @@ class CycleEngine:
         if not readings:
             return None
         return sum(readings) / len(readings)
+
+    def _sensor_counts(self, room: Room) -> tuple[int, int]:
+        """Return (configured_sensor_count, available_sensor_count) for a room.
+
+        Mirrors ``_get_avg_temp``'s sources: the room's configured temperature
+        sensors plus the thermostat probe when ``include_thermostat_sensor`` is
+        set. "Available" counts only sensors with a fresh reading (stale ones
+        are excluded the same way ``_get_avg_temp`` excludes them), so the UI
+        can show "2 of 3 sensors reporting" rather than a misleading 1/0.
+        """
+        sensor_ids = self._sensor_ids_for_room.get(room.id, [])
+        total = len(sensor_ids)
+        available = sum(
+            1
+            for eid in sensor_ids
+            if self._ha.get_numeric_state(eid, max_age_min=self._stale_after_min) is not None
+        )
+        if room.include_thermostat_sensor:
+            total += 1
+            thermo = self._ha.get_state(room.thermostat_entity_id)
+            if thermo:
+                t = thermo.get("attributes", {}).get("current_temperature")
+                if t is not None:
+                    try:
+                        float(t)
+                        available += 1
+                    except (ValueError, TypeError):
+                        pass
+        return total, available
 
     async def _set_thermostat_setpoint(
         self,

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -197,6 +197,16 @@ class ThermostatConfig:
     # without crossing into their opposite-direction trigger. Disabled in
     # vacation mode regardless of this setting. See docs/overflow-conditioning.md.
     overflow_during_min_runtime: bool = True
+    # Thermostat-unavailability abort (Issue #267). While the climate entity is
+    # unavailable the engine skips its tick, which suspends every per-tick
+    # safety monitor (cycle timeout, max_vent_closed_min watchdog,
+    # reconciliation) — meanwhile the physical HVAC may keep running at the
+    # last commanded setpoint with vents closed. Once the entity has been
+    # unavailable this many minutes, a running cycle is aborted and all zone
+    # vents re-opened (cover entities are independent of the climate entity).
+    # Transient outages shorter than this are tolerated and the cycle resumes
+    # untouched. 0 = never abort (not recommended).
+    unavailable_abort_after_min: int = 5
 
 
 @dataclass

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -195,6 +195,14 @@ class Scheduler:
     def get_system_enabled(self) -> bool:
         return self._system_enabled
 
+    def get_engine(self, thermostat_entity_id: str) -> CycleEngine | None:
+        """Return the engine for a thermostat, or None if not (yet) created.
+
+        Used by ``/api/thermostat-health`` to read per-zone availability state
+        (Issue #267) without reaching into the private engine map.
+        """
+        return self._engines.get(thermostat_entity_id)
+
     async def set_system_enabled(self, enabled: bool) -> None:
         self._system_enabled = enabled
         await db.set_system_setting(self._db_conn, "system_enabled", "1" if enabled else "0")

--- a/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
+++ b/smart_vent/backend/tests/integration/test_airflow_floor_bypass.py
@@ -133,6 +133,21 @@ async def test_last_vent_bypass_close_is_paired_with_immediate_reopen(
     assert any(c.data.get("entity_id") == "cover.bed" for c in close_calls), close_calls
     assert any(c.data.get("entity_id") == "cover.bed" for c in open_calls), open_calls
 
+    # Ordering invariant (#210): within the single tick, the bypass close must
+    # be FOLLOWED by the terminate reopen — never the reverse — so the vent is
+    # not left closed. Check the position of cover.bed actions in the ordered
+    # service-call log, not just that both happened.
+    bed_actions = [
+        c.service
+        for c in fake_ha.calls
+        if c.service in ("close_cover", "open_cover") and c.data.get("entity_id") == "cover.bed"
+    ]
+    assert bed_actions, "expected close/open actions on cover.bed"
+    assert bed_actions[0] == "close_cover", bed_actions
+    assert bed_actions[-1] == "open_cover", (
+        f"the last action on the vent must be the reopen, got {bed_actions}"
+    )
+
     # Final state: the vent is open. The bypass window must not be observable
     # after the tick.
     assert fake_ha.get_state("cover.bed")["state"] == "open"

--- a/smart_vent/backend/tests/integration/test_setpoint_bounds.py
+++ b/smart_vent/backend/tests/integration/test_setpoint_bounds.py
@@ -119,6 +119,50 @@ async def test_heating_setpoint_clamped_to_max_setpoint(client, fake_ha, tick) -
 
 
 @pytest.mark.asyncio
+async def test_tightened_max_setpoint_respected_on_midcycle_resetpoint(
+    client, fake_ha, tick
+) -> None:
+    """Tightening max_setpoint during a RUNNING heating cycle is honored the
+    next time the setpoint is re-derived (here, a mid-cycle override changes
+    the trigger), not only at cycle start (Issue #270)."""
+    await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": "climate.test_thermostat",
+            "total_vents_count": 6,
+            "min_setpoint": 55.0,
+            "max_setpoint": 85.0,
+            "overshoot_delta": 2.0,
+        },
+    )
+    fake_ha.seed_state(
+        "climate.test_thermostat",
+        "heat",
+        {"current_temperature": 70.0, "temperature": 70.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state("sensor.test_room_temp", "66.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.test_room_vent", "closed", {})
+    room_id = await _make_room_with_schedule(client, target_temp=80.0)
+
+    await tick()  # cycle starts; setpoint = 80 + 2 = 82, within the 85 ceiling
+    first = fake_ha.calls_for("set_temperature")[-1].data["temperature"]
+    assert first == pytest.approx(82.0, abs=0.5)
+
+    # Operator tightens the ceiling to 78, then an override bumps the target to
+    # 83 (still heating, ambient 70) — a mid-cycle trigger change that forces a
+    # re-derive. The new setpoint (83 + 2 = 85) must clamp to the NEW max.
+    await client.put("/api/thermostats/climate.test_thermostat", json={"max_setpoint": 78.0})
+    await client.post(
+        f"/api/rooms/{room_id}/override", json={"target_temp": 83.0, "duration_hours": 2}
+    )
+    await tick()
+
+    latest = fake_ha.calls_for("set_temperature")[-1].data["temperature"]
+    assert latest <= 78.0, f"re-derived setpoint {latest} breached the tightened max=78"
+    assert latest == pytest.approx(78.0, abs=0.5)
+
+
+@pytest.mark.asyncio
 async def test_external_setpoint_drift_outside_bounds_is_flagged(client, fake_ha, tick) -> None:
     """If an external actor sets the HA setpoint outside the configured bounds
     while the engine is idle, the reconcile loop must surface a warning so

--- a/smart_vent/backend/tests/integration/test_thermostat_health.py
+++ b/smart_vent/backend/tests/integration/test_thermostat_health.py
@@ -1,0 +1,174 @@
+"""Thermostat availability surface (Issue #267).
+
+Drives the full app against a fake Home Assistant and verifies:
+
+  - ``/api/thermostat-health`` reports thermostats whose climate entity is
+    unavailable (or missing from the cache entirely), with the outage age the
+    engine has tracked and the per-thermostat abort threshold — this feeds the
+    Dashboard banner, mirroring ``/api/sensor-health``;
+  - healthy thermostats are omitted;
+  - the ``unavailable_abort_after_min`` config field round-trips through the
+    REST API and the DB, and rejects invalid values.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+
+
+async def _register_thermostat(client) -> None:
+    resp = await client.post(
+        "/api/thermostats",
+        json={"thermostat_entity_id": THERMO, "name": "Hallway", "total_vents_count": 2},
+    )
+    assert resp.status == 201, await resp.text()
+
+
+async def _add_room(client) -> str:
+    """Engines only exist for thermostats with rooms — give the zone one so
+    the per-tick availability tracking has an engine to live in."""
+    resp = await client.post("/api/rooms", json={"name": "Bedroom", "thermostat_entity_id": THERMO})
+    assert resp.status == 201, await resp.text()
+    room_id: str = (await resp.json())["id"]
+    return room_id
+
+
+@pytest.mark.asyncio
+async def test_healthy_thermostat_not_reported(client, fake_ha) -> None:
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 72.0, "temperature": 72.0, "hvac_action": "idle"},
+    )
+    await _register_thermostat(client)
+
+    health = await (await client.get("/api/thermostat-health")).json()
+    assert health["thermostats"] == []
+
+
+@pytest.mark.asyncio
+async def test_unavailable_thermostat_reported_with_outage_age(client, fake_ha, tick) -> None:
+    fake_ha.seed_state(THERMO, "unavailable", {})
+    await _register_thermostat(client)
+    await _add_room(client)
+
+    # One tick lets the engine notice the outage and start its clock.
+    await tick()
+
+    health = await (await client.get("/api/thermostat-health")).json()
+    assert len(health["thermostats"]) == 1
+    entry = health["thermostats"][0]
+    assert entry["thermostat_entity_id"] == THERMO
+    assert entry["name"] == "Hallway"
+    assert entry["reason"] == "unavailable"
+    assert entry["abort_after_min"] == 5  # default threshold
+    assert entry["unavailable_seconds"] is not None
+    assert entry["unavailable_seconds"] >= 0
+    assert entry["cycle_running"] is False
+
+
+@pytest.mark.asyncio
+async def test_thermostat_missing_from_cache_reported_as_not_in_cache(client, fake_ha) -> None:
+    # Registered in the app but never seen in the HA state cache at all.
+    await _register_thermostat(client)
+
+    health = await (await client.get("/api/thermostat-health")).json()
+    assert len(health["thermostats"]) == 1
+    assert health["thermostats"][0]["reason"] == "not_in_cache"
+
+
+@pytest.mark.asyncio
+async def test_outage_clock_clears_when_thermostat_recovers(client, fake_ha, tick) -> None:
+    fake_ha.seed_state(THERMO, "unavailable", {})
+    await _register_thermostat(client)
+    await _add_room(client)
+    await tick()
+    health = await (await client.get("/api/thermostat-health")).json()
+    assert len(health["thermostats"]) == 1
+    assert health["thermostats"][0]["unavailable_seconds"] is not None
+
+    await fake_ha.set_entity_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 72.0, "temperature": 72.0, "hvac_action": "idle"},
+    )
+    await tick()
+
+    health = await (await client.get("/api/thermostat-health")).json()
+    assert health["thermostats"] == []
+    engine = client.app["scheduler"].get_engine(THERMO)
+    assert engine is not None and engine.unavailable_since is None
+
+
+@pytest.mark.asyncio
+async def test_sustained_outage_aborts_running_cycle_through_full_tick(
+    client, fake_ha, tick
+) -> None:
+    """Full-stack version of the unit test: a cycle started through the real
+    tick path is aborted once the outage exceeds the configured threshold."""
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 78.0, "temperature": 76.0, "hvac_action": "cooling"},
+    )
+    fake_ha.seed_state("sensor.bed", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.bed", "open", {})
+    await _register_thermostat(client)
+    resp = await client.post("/api/rooms", json={"name": "Bedroom", "thermostat_entity_id": THERMO})
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.bed"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.bed", "control_method": "open_close"},
+    )
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+
+    await tick()
+    engine = client.app["scheduler"].get_engine(THERMO)
+    assert engine.cycle_state.value == "running"
+
+    # Thermostat drops off; backdate the outage clock past the 5-min default.
+    await fake_ha.set_entity_state(THERMO, "unavailable", {})
+    engine._unavailable_since = datetime.now(UTC) - timedelta(minutes=6)
+    await tick()
+
+    assert engine.cycle_state.value == "idle"
+    logs = await (await client.get("/api/logs")).json()
+    assert logs[0]["ended_reason"] == "aborted: thermostat unavailable"
+    assert fake_ha.get_state("cover.bed")["state"] == "open", "abort must leave the zone vents open"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_abort_config_roundtrips_through_api(client, fake_ha) -> None:
+    fake_ha.seed_state(THERMO, "cool", {"current_temperature": 72.0})
+    await _register_thermostat(client)
+
+    resp = await client.put(f"/api/thermostats/{THERMO}", json={"unavailable_abort_after_min": 12})
+    assert resp.status == 200
+    assert (await resp.json())["unavailable_abort_after_min"] == 12
+
+    listing = await (await client.get("/api/thermostats")).json()
+    entry = next(t for t in listing if t["thermostat_entity_id"] == THERMO)
+    assert entry["unavailable_abort_after_min"] == 12
+
+    # Invalid values are rejected.
+    for bad in (-1, "5", 2.5, True):
+        resp = await client.put(
+            f"/api/thermostats/{THERMO}", json={"unavailable_abort_after_min": bad}
+        )
+        assert resp.status == 400, f"value {bad!r} should be rejected"

--- a/smart_vent/backend/tests/integration/test_trigger_change_characterization.py
+++ b/smart_vent/backend/tests/integration/test_trigger_change_characterization.py
@@ -270,7 +270,14 @@ async def test_direction_flip_is_handled_by_the_mode_filter(client, fake_ha, tic
 
     closed = (await _logs(client))[0]
     assert closed["ended_at"] is not None
-    # The reason is the mode-filter abort, NOT a "trigger changed" teardown.
+    # SAFETY PROPERTY (what actually matters): a direction flip must STOP the
+    # cycle — the engine must not keep heating a room that now needs cooling.
+    assert _engine_state(client) == "idle", "the heating cycle must not continue"
+    assert await _open_cycles(client) == [], "no cycle may remain open after the flip"
+    # IMPLEMENTATION DETAIL (characterization): today that stop comes from the
+    # mode filter, not a "trigger changed" teardown. Kept as a regression note
+    # for the #215 path; if a refactor relocates the stop, update this pair but
+    # keep the safety assertions above.
     assert "filtering" in (closed["ended_reason"] or "")
     assert "trigger changed" not in (closed["ended_reason"] or "")
 
@@ -378,6 +385,93 @@ async def test_source_change_updates_in_place(client, fake_ha, tick) -> None:
     room_entry = next(iter(open_cycles[0]["rooms"].values()))
     assert room_entry["source"] == "schedule"
     assert room_entry["target"] == 70.0
+
+
+@pytest.mark.asyncio
+async def test_schedule_to_presence_handoff_updates_in_place(client, fake_ha, tick) -> None:
+    """When a schedule ends but a presence holdover is active at the SAME
+    target, the cycle continues with source schedule→presence — no teardown
+    (Issue #270 handoff matrix; the inverse of the presence→schedule test)."""
+    _seed_heating_thermostat(fake_ha)
+    fake_ha.seed_state("sensor.bed", "65.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.bed", "closed", {})
+    fake_ha.seed_state("binary_sensor.bed_presence", "off", {})
+
+    # Room wired for BOTH presence (system_wide_temp 68) and a schedule at the
+    # same 68°F. Schedule outranks presence while both are active.
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Bedroom",
+            "thermostat_entity_id": THERMO,
+            "system_wide_temp": 68.0,
+            "presence_holdover_hours": 2.0,
+        },
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": "sensor.bed"})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": "cover.bed", "control_method": "open_close"},
+    )
+    await client.post(
+        f"/api/rooms/{room_id}/presence",
+        json={"entity_id": "binary_sensor.bed_presence"},
+    )
+    sched_id = await _all_day_schedule(client, room_id, 68.0)
+
+    # Fire presence so a holdover exists, then tick — the schedule wins.
+    await fake_ha.set_entity_state("binary_sensor.bed_presence", "on", {})
+    await tick()
+    started = await _open_cycles(client)
+    assert len(started) == 1
+    cycle_id = started[0]["id"]
+    assert next(iter(started[0]["rooms"].values()))["source"] == "schedule"
+
+    # Delete the schedule → the presence holdover (same 68°F) takes over.
+    await client.delete(f"/api/rooms/{room_id}/schedules/{sched_id}")
+    await tick()
+
+    open_cycles = await _open_cycles(client)
+    assert len(open_cycles) == 1, "the cycle must keep running — no teardown"
+    assert open_cycles[0]["id"] == cycle_id, "it must be the SAME cycle"
+    assert len(await _logs(client)) == 1, "no second cycle log was created"
+    room_entry = next(iter(open_cycles[0]["rooms"].values()))
+    assert room_entry["source"] == "presence"
+    assert room_entry["target"] == 68.0
+
+
+@pytest.mark.asyncio
+async def test_override_to_schedule_handoff_updates_in_place(client, fake_ha, tick) -> None:
+    """An override handed back to the underlying schedule at the SAME target
+    updates the running cycle in place — source flips override→schedule with no
+    teardown (Issue #270 handoff matrix)."""
+    _seed_heating_thermostat(fake_ha)
+    room_id, _sched = await _heating_room(
+        client, fake_ha, "Bedroom", "sensor.bed", "cover.bed", 68.0
+    )
+    # Override at the same 68°F target → still heating, source 'override'.
+    await client.post(
+        f"/api/rooms/{room_id}/override", json={"target_temp": 68.0, "duration_hours": 2}
+    )
+
+    await tick()
+    started = await _open_cycles(client)
+    assert len(started) == 1
+    cycle_id = started[0]["id"]
+    assert next(iter(started[0]["rooms"].values()))["source"] == "override"
+
+    # Clear the override → the schedule (same 68°F) takes back over.
+    await client.delete(f"/api/rooms/{room_id}/override")
+    await tick()
+
+    open_cycles = await _open_cycles(client)
+    assert len(open_cycles) == 1, "the cycle must keep running — no teardown"
+    assert open_cycles[0]["id"] == cycle_id, "it must be the SAME cycle"
+    assert len(await _logs(client)) == 1, "no second cycle log was created"
+    room_entry = next(iter(open_cycles[0]["rooms"].values()))
+    assert room_entry["source"] == "schedule"
+    assert room_entry["target"] == 68.0
 
 
 @pytest.mark.asyncio

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -902,6 +902,118 @@ class TestEngineStateProperties:
         assert status.cycle_id is None
         assert status.hvac_action == "idle"
 
+    def test_get_zone_status_reports_real_sensor_counts(self):
+        """sensor_count / available_sensor_count reflect configured-vs-fresh
+        sensors, not the old boolean-flag stand-in (Issue #270)."""
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        room = _make_room("r1")
+        room.include_thermostat_sensor = True  # +1 sensor, fresh (ambient 72)
+        engine._active_rooms = {
+            "r1": ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+        }
+        engine._sensor_map = {"r1": ["sensor.a", "sensor.b"]}
+        # sensor.a fresh, sensor.b stale (returns None under the freshness guard).
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            70.0 if eid == "sensor.a" else None
+        )
+
+        status = engine.get_zone_status()
+        rs = status.rooms[0]
+        # 2 configured sensors + the thermostat probe.
+        assert rs.sensor_count == 3
+        # sensor.a + the fresh thermostat probe; sensor.b is stale.
+        assert rs.available_sensor_count == 2
+
+
+class TestSensorCounts:
+    """_sensor_counts — the (configured, available) pair behind RoomLiveState."""
+
+    def test_no_sensors_no_thermostat(self):
+        engine = _make_engine()
+        engine._sensor_map = {"r1": []}
+        room = _make_room("r1")
+        assert engine._sensor_counts(room) == (0, 0)
+
+    def test_all_fresh(self):
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1", "s2"]}
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: 70.0
+        assert engine._sensor_counts(_make_room("r1")) == (2, 2)
+
+    def test_some_stale(self):
+        ha = _make_ha()
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1", "s2", "s3"]}
+        ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: (
+            70.0 if eid == "s1" else None
+        )
+        assert engine._sensor_counts(_make_room("r1")) == (3, 1)
+
+    def test_thermostat_sensor_counted_when_included(self):
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": []}
+        room = _make_room("r1")
+        room.include_thermostat_sensor = True
+        # No room sensors, but the thermostat probe is present and fresh.
+        assert engine._sensor_counts(room) == (1, 1)
+
+    def test_thermostat_sensor_counted_but_unavailable(self):
+        ha = _make_ha()
+        ha.get_state.return_value = None  # thermostat probe unreadable
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": []}
+        room = _make_room("r1")
+        room.include_thermostat_sensor = True
+        # Configured (counts toward total) but not available.
+        assert engine._sensor_counts(room) == (1, 0)
+
+
+class TestMaybeBroadcast:
+    """_maybe_broadcast — the WebSocket zone-status push (Issue #270)."""
+
+    @pytest.mark.asyncio
+    async def test_emits_zone_status_event(self):
+        ha = _make_ha(ambient=72.0, hvac_mode="cool", hvac_action="idle")
+        broadcast = AsyncMock()
+        engine = CycleEngine(
+            thermostat_entity_id=THERMO_ID,
+            ha=ha,
+            vent_ctrl=VentController(ha),
+            broadcast=broadcast,
+            get_enabled=lambda: True,
+        )
+
+        await engine._maybe_broadcast()
+
+        broadcast.assert_awaited_once()
+        event, payload = broadcast.await_args.args
+        assert event == "zone_status"
+        assert payload["thermostat_entity_id"] == THERMO_ID
+        assert payload["cycle_state"] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_noop_without_callback(self):
+        engine = _make_engine()  # no broadcast configured
+        await engine._maybe_broadcast()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_swallows_broadcast_errors(self):
+        ha = _make_ha()
+        broadcast = AsyncMock(side_effect=RuntimeError("ws gone"))
+        engine = CycleEngine(
+            thermostat_entity_id=THERMO_ID,
+            ha=ha,
+            vent_ctrl=VentController(ha),
+            broadcast=broadcast,
+            get_enabled=lambda: True,
+        )
+        # A dead WebSocket must never bubble out of the tick.
+        await engine._maybe_broadcast()
+        broadcast.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # _abort_cycle: DB close ordering (issue #51)
@@ -2562,6 +2674,85 @@ class TestThermostatUnavailableAbort:
 
         assert engine.cycle_state == CycleState.IDLE
         assert engine._cycle_log is None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_warns_once_per_outage_then_announces_recovery(self):
+        """The event log gets one warning per outage episode (not one per
+        60-second tick) and one recovery info event — mirroring the #211
+        sensor-staleness rate-limiting so a long outage doesn't bury the feed
+        (Issue #270)."""
+        from backend import db
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        engine = _make_engine()
+        engine._logger = MagicMock()
+        engine._logger.log = AsyncMock()
+        available_state = engine._ha.get_state.return_value
+
+        # Three consecutive unavailable ticks (all inside the 5-min default).
+        engine._ha.get_state.return_value = None
+        for _ in range(3):
+            await engine._do_tick(conn)
+        # Recovery.
+        engine._ha.get_state.return_value = available_state
+        await engine._do_tick(conn)
+
+        warn = [
+            c
+            for c in engine._logger.log.await_args_list
+            if c.args[0] == "warning" and "unavailable" in c.args[2].lower()
+        ]
+        info = [
+            c
+            for c in engine._logger.log.await_args_list
+            if c.args[0] == "info" and "reporting again" in c.args[2].lower()
+        ]
+        assert len(warn) == 1, "exactly one unavailability warning per outage episode"
+        assert len(info) == 1, "exactly one recovery event"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_do_tick_skips_when_hvac_mode_unknown(self):
+        """If the thermostat mode cannot be determined after active rooms are
+        resolved, the tick bails without starting a cycle or commanding HVAC
+        (defensive guard, Issue #270)."""
+        from datetime import time as _time
+
+        from backend import db
+        from backend.models import Schedule
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        room = Room.create(name="Bedroom", thermostat_entity_id=THERMO_ID)
+        room.id = "r1"
+        await db.upsert_room(conn, room)
+        # All-day schedule so the room resolves as active and the tick reaches
+        # the mode check rather than returning earlier for "no active rooms".
+        sched = Schedule.create(
+            room_id="r1",
+            days_of_week=list(range(7)),
+            start_time=_time(0, 0),
+            end_time=_time(23, 59),
+            target_temp=72.0,
+        )
+        await db.upsert_schedule(conn, sched)
+
+        ha = _make_ha(ambient=72.0)
+        engine = _make_engine(ha)
+        # Thermostat is reachable (passes the availability guard) but its mode
+        # reads back indeterminate on this tick.
+        engine._read_hvac_mode = lambda: "unknown"
+
+        await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.IDLE
+        ha.set_thermostat_temperature.assert_not_called()
         await conn.close()
 
 

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -21,7 +21,12 @@ from unittest.mock import AsyncMock, MagicMock
 import aiosqlite
 import pytest
 
-from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
+from backend.engine.cycle_engine import (
+    UNAVAILABLE_ABORT_AFTER_TICKS,
+    CycleEngine,
+    CycleState,
+    _is_at_target,
+)
 from backend.engine.room_manager import ActiveRoom
 from backend.engine.vent_controller import VentController
 from backend.models import (
@@ -1348,10 +1353,20 @@ class TestEnterMinRuntimeHold:
 class TestMinRuntimeHoldGate:
     """Issue #237: while a cycle is in the min-runtime hold the per-room
     close-vent loop must be short-circuited, otherwise vents the hold has just
-    re-opened are re-closed on the next tick (the original thrashing bug)."""
+    re-opened are re-closed on the next tick (the original thrashing bug).
+
+    Two distinct branches in _monitor_rooms protect this:
+    - the hold-ENTRY branch (all rooms satisfied, runtime unsatisfied) enters
+      the hold and returns before the close loop;
+    - the hold GATE (in_min_runtime_hold already set) short-circuits the close
+      loop on later ticks — the only protection once a room has drifted off
+      target during the hold, because the entry branch no longer fires then.
+    """
 
     @pytest.mark.asyncio
-    async def test_hold_gate_skips_close_loop(self):
+    async def test_hold_entry_branch_skips_close_loop(self):
+        """All rooms satisfied + runtime unsatisfied → the hold-entry branch
+        returns before the close loop runs."""
         from backend.models import RoomVent
 
         engine, conn, cycle = await _setup_engine_with_running_cycle()
@@ -1377,10 +1392,57 @@ class TestMinRuntimeHoldGate:
         engine._ha.close_cover.reset_mock()
         await engine._monitor_rooms(conn, "cooling")
 
-        # The hold gate must prevent any close calls.
+        # The hold-entry branch must prevent any close calls.
         engine._ha.close_cover.assert_not_awaited()
         # Vent state untouched.
         assert rcs.vent_closed_at is None
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_hold_gate_prevents_reclosing_when_a_room_drifts_off_target(self):
+        """One room drifted OFF target during the hold → the entry branch
+        cannot fire (not all rooms satisfied), so only the gate stops the
+        close loop from re-closing the at-target room's just-reopened vent —
+        the original #237 thrashing bug."""
+        from backend import db as _db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._cycle_log.in_min_runtime_hold = True
+
+        room2 = Room.create(name="Office", thermostat_entity_id=THERMO_ID)
+        room2.id = "r2"
+        await _db.upsert_room(conn, room2)
+        engine._active_rooms["r2"] = ActiveRoom(room=room2, target_temp=74.0, source="schedule")
+        engine._room_vents = {
+            "r1": [RoomVent.create("r1", "cover.vent_r1")],
+            "r2": [RoomVent.create("r2", "cover.vent_r2")],
+        }
+        # r1: at target with its vent re-opened by the hold (vent_closed_at is
+        # None) — exactly what the close loop would re-close.
+        # r2: drifted off target during the hold.
+        engine._room_cycle_states = {
+            "r1": RoomCycleState(cycle_id=cycle.id, room_id="r1", target_temp=74.0),
+            "r2": RoomCycleState(cycle_id=cycle.id, room_id="r2", target_temp=74.0),
+        }
+        engine._sensor_map = {"r1": ["s_r1"], "r2": ["s_r2"]}
+        engine._ha.get_numeric_state.side_effect = lambda eid, max_age_min=None: {
+            "s_r1": 73.5,  # at target → close loop would re-close its vent
+            "s_r2": 76.0,  # off target → hold-entry branch cannot fire
+        }.get(eid)
+
+        tc = _make_tc(min_cycle_runtime_min=10)
+        engine._cycle_log.started_at = datetime.now(UTC) - timedelta(seconds=30)
+        await _db.upsert_thermostat_config(conn, tc)
+
+        engine._ha.close_cover.reset_mock()
+        await engine._monitor_rooms(conn, "cooling")
+
+        # The gate must short-circuit the close loop entirely.
+        engine._ha.close_cover.assert_not_awaited()
+        assert engine._room_cycle_states["r1"].vent_closed_at is None
+        # The cycle keeps running — the gate defers, it does not terminate.
+        assert engine._state == CycleState.RUNNING
         await conn.close()
 
     @pytest.mark.asyncio
@@ -2395,4 +2457,140 @@ class TestSuppressionInInference:
         engine = _make_engine()
         flags = await engine._compute_off_schedule_flags(conn, active)
         assert flags == {}
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Thermostat unavailability during a cycle (Issue #267)
+# ---------------------------------------------------------------------------
+
+
+class TestThermostatUnavailableAbort:
+    """A transient thermostat outage must not kill a running cycle, but a
+    sustained one must abort it: while the thermostat is unavailable _do_tick
+    returns before the cycle timeout, the max_vent_closed_min watchdog, and
+    reconciliation, so an open-ended outage would leave the physical HVAC
+    running at the last commanded setpoint with vents closed and every safety
+    monitor suspended."""
+
+    @pytest.mark.asyncio
+    async def test_transient_outage_keeps_cycle_running(self):
+        from backend import db
+
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        engine._ha.get_state.return_value = None
+
+        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS - 1):
+            await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.RUNNING
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 1, "a transient outage must not abort the cycle"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_sustained_outage_aborts_cycle_and_reopens_vents(self):
+        from backend import db
+        from backend.models import RoomVent
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        # Thermostat gone; the vent entity is still reachable (covers are
+        # independent of the climate entity).
+        engine._ha.get_state.side_effect = lambda eid: (
+            None if eid == THERMO_ID else {"state": "closed", "attributes": {}}
+        )
+        engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
+
+        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS):
+            await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.IDLE
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.ended_reason == "aborted: thermostat unavailable"
+        opened = [c.args[0] for c in engine._ha.open_cover.await_args_list]
+        assert "cover.vent_r1" in opened, "abort must re-open the zone vents"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_resets_the_unavailable_counter(self):
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        available_state = engine._ha.get_state.return_value
+
+        engine._ha.get_state.return_value = None
+        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS - 1):
+            await engine._do_tick(conn)
+        assert engine._unavailable_ticks == UNAVAILABLE_ABORT_AFTER_TICKS - 1
+
+        # Thermostat comes back — one available tick resets the counter, so a
+        # later outage needs the full threshold again before aborting.
+        engine._ha.get_state.return_value = available_state
+        await engine._do_tick(conn)
+        assert engine._unavailable_ticks == 0
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_idle_engine_skips_unavailable_ticks_without_abort(self):
+        from backend import db
+
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+
+        engine = _make_engine()
+        engine._ha.get_state.return_value = None
+
+        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS + 2):
+            await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.IDLE
+        assert engine._cycle_log is None
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# In-tick abort guards: system disabled / vacation mode (Issue #269)
+# ---------------------------------------------------------------------------
+
+
+class TestDoTickAbortGuards:
+    """The scheduler calls force_abort on toggles, but _do_tick carries its own
+    guards as the backstop when a flag flips between scheduler events. If
+    either guard regresses, a disabled system (or a vacation-mode house) keeps
+    actively conditioning."""
+
+    @pytest.mark.asyncio
+    async def test_system_disabled_mid_cycle_aborts_on_tick(self):
+        from backend import db
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._get_enabled = lambda: False
+
+        await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.IDLE
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.ended_reason == "aborted: system disabled"
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_vacation_mode_mid_cycle_aborts_and_applies_hold(self):
+        from backend import db
+
+        engine, conn, cycle = await _setup_engine_with_running_cycle()
+        engine._get_vacation_mode = lambda: True
+        engine._ha.set_thermostat_hvac_mode = AsyncMock()
+        # Default config: vacation_hvac_mode="single", bounds 60–85. Ambient 72
+        # is inside the band, so the hold turns the (still "cool") HVAC off.
+        await db.upsert_thermostat_config(conn, _make_tc())
+
+        await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.IDLE
+        db_cycle = await db.get_cycle_log(conn, cycle.id)
+        assert db_cycle is not None
+        assert db_cycle.ended_reason == "aborted: vacation mode"
+        # The vacation hold ran in the same tick.
+        engine._ha.set_thermostat_hvac_mode.assert_awaited_once_with(THERMO_ID, "off")
         await conn.close()

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -21,12 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiosqlite
 import pytest
 
-from backend.engine.cycle_engine import (
-    UNAVAILABLE_ABORT_AFTER_TICKS,
-    CycleEngine,
-    CycleState,
-    _is_at_target,
-)
+from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
 from backend.engine.room_manager import ActiveRoom
 from backend.engine.vent_controller import VentController
 from backend.models import (
@@ -2471,7 +2466,8 @@ class TestThermostatUnavailableAbort:
     returns before the cycle timeout, the max_vent_closed_min watchdog, and
     reconciliation, so an open-ended outage would leave the physical HVAC
     running at the last commanded setpoint with vents closed and every safety
-    monitor suspended."""
+    monitor suspended. The threshold is the per-thermostat
+    ``unavailable_abort_after_min`` config field (default 5 min, 0 = never)."""
 
     @pytest.mark.asyncio
     async def test_transient_outage_keeps_cycle_running(self):
@@ -2480,10 +2476,12 @@ class TestThermostatUnavailableAbort:
         engine, conn, _cycle = await _setup_engine_with_running_cycle()
         engine._ha.get_state.return_value = None
 
-        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS - 1):
-            await engine._do_tick(conn)
+        # A couple of ticks well inside the 5-minute default threshold.
+        await engine._do_tick(conn)
+        await engine._do_tick(conn)
 
         assert engine.cycle_state == CycleState.RUNNING
+        assert engine.unavailable_since is not None
         open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
         assert len(open_logs) == 1, "a transient outage must not abort the cycle"
         await conn.close()
@@ -2501,8 +2499,9 @@ class TestThermostatUnavailableAbort:
         )
         engine._room_vents = {"r1": [RoomVent.create("r1", "cover.vent_r1")]}
 
-        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS):
-            await engine._do_tick(conn)
+        # Outage started 6 minutes ago — past the 5-minute default threshold.
+        engine._unavailable_since = datetime.now(UTC) - timedelta(minutes=6)
+        await engine._do_tick(conn)
 
         assert engine.cycle_state == CycleState.IDLE
         db_cycle = await db.get_cycle_log(conn, cycle.id)
@@ -2513,20 +2512,36 @@ class TestThermostatUnavailableAbort:
         await conn.close()
 
     @pytest.mark.asyncio
-    async def test_recovery_resets_the_unavailable_counter(self):
+    async def test_zero_threshold_disables_the_abort(self):
+        from backend import db
+
+        engine, conn, _cycle = await _setup_engine_with_running_cycle()
+        await db.upsert_thermostat_config(conn, _make_tc(unavailable_abort_after_min=0))
+        engine._ha.get_state.return_value = None
+        # Outage of an hour — with the guard disabled the cycle must survive.
+        engine._unavailable_since = datetime.now(UTC) - timedelta(minutes=60)
+
+        await engine._do_tick(conn)
+
+        assert engine.cycle_state == CycleState.RUNNING
+        open_logs = await db.get_open_cycle_logs(conn, THERMO_ID)
+        assert len(open_logs) == 1
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_recovery_clears_unavailable_since(self):
         engine, conn, _cycle = await _setup_engine_with_running_cycle()
         available_state = engine._ha.get_state.return_value
 
         engine._ha.get_state.return_value = None
-        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS - 1):
-            await engine._do_tick(conn)
-        assert engine._unavailable_ticks == UNAVAILABLE_ABORT_AFTER_TICKS - 1
+        await engine._do_tick(conn)
+        assert engine.unavailable_since is not None
 
-        # Thermostat comes back — one available tick resets the counter, so a
-        # later outage needs the full threshold again before aborting.
+        # Thermostat comes back — one available tick clears the outage clock,
+        # so a later outage starts the threshold from zero again.
         engine._ha.get_state.return_value = available_state
         await engine._do_tick(conn)
-        assert engine._unavailable_ticks == 0
+        assert engine.unavailable_since is None
         await conn.close()
 
     @pytest.mark.asyncio
@@ -2539,9 +2554,11 @@ class TestThermostatUnavailableAbort:
 
         engine = _make_engine()
         engine._ha.get_state.return_value = None
+        # Long-stale outage clock — an IDLE engine has nothing to abort.
+        engine._unavailable_since = datetime.now(UTC) - timedelta(minutes=60)
 
-        for _ in range(UNAVAILABLE_ABORT_AFTER_TICKS + 2):
-            await engine._do_tick(conn)
+        await engine._do_tick(conn)
+        await engine._do_tick(conn)
 
         assert engine.cycle_state == CycleState.IDLE
         assert engine._cycle_log is None

--- a/smart_vent/backend/tests/test_vacation_mode.py
+++ b/smart_vent/backend/tests/test_vacation_mode.py
@@ -334,6 +334,60 @@ async def test_engine_vacation_mode_already_off_no_redundant_call():
         await conn.close()
 
 
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_single_no_current_temp_forces_off():
+    """Single mode with no readable current_temperature: the bound checks
+    cannot be evaluated, so the hold fails safe by turning the HVAC off
+    (Issue #270 — previously untested branch)."""
+    ha = _make_ha(hvac_mode="heat", current_temp=None)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        # No temperature to compare against the bounds → force the HVAC off
+        # rather than guess a direction.
+        ha.set_thermostat_hvac_mode.assert_called_once_with(THERMO_A, "off")
+        ha.set_thermostat_temperature.assert_not_called()
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_engine_vacation_mode_single_no_current_temp_already_off_noop():
+    """Single mode, no current_temperature AND already off: no redundant call."""
+    ha = _make_ha(hvac_mode="off", current_temp=None)
+    engine = _make_engine(ha, vacation_mode=True)
+
+    conn = await _setup_db()
+    try:
+        await _insert_room(conn, "room1", THERMO_A)
+        tc = ThermostatConfig(
+            thermostat_entity_id=THERMO_A,
+            min_setpoint=62.0,
+            max_setpoint=80.0,
+            vacation_hvac_mode="single",
+        )
+        await db.upsert_thermostat_config(conn, tc)
+
+        await engine.tick(conn)
+
+        ha.set_thermostat_hvac_mode.assert_not_called()
+        ha.set_thermostat_temperature.assert_not_called()
+    finally:
+        await conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Engine reverts heat_cool when vacation mode is NOT active (test-button fix)
 # ---------------------------------------------------------------------------

--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -11,6 +11,7 @@ describe("App Root", () => {
     vi.clearAllMocks();
     vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
     vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
+    vi.mocked(api.getThermostatHealth).mockResolvedValue({ thermostats: [] });
     vi.mocked(api.getSystemStatus).mockResolvedValue({ enabled: true, dev_mode: false });
     vi.mocked(api.getSettings).mockResolvedValue({
       temperature_unit: "F",

--- a/smart_vent/frontend/src/api.test.ts
+++ b/smart_vent/frontend/src/api.test.ts
@@ -573,6 +573,12 @@ describe("API Client", () => {
     expect(fetch).toHaveBeenCalledWith("/api/sensor-health", expect.anything());
   });
 
+  it("getThermostatHealth fetches the availability summary", async () => {
+    mockJsonResponse({ thermostats: [] });
+    await api.getThermostatHealth();
+    expect(fetch).toHaveBeenCalledWith("/api/thermostat-health", expect.anything());
+  });
+
   it("triggerMonthlyRollup sends months_back when provided", async () => {
     mockJsonResponse({});
     await api.triggerMonthlyRollup(3);

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -102,6 +102,11 @@ export interface ThermostatConfig {
   // surplus conditioned air without crossing into the opposite-direction
   // trigger. Disabled in vacation mode regardless of this flag.
   overflow_during_min_runtime: boolean;
+  // Thermostat-unavailability abort (Issue #267). Minutes of sustained
+  // climate-entity unavailability before a running cycle is aborted and all
+  // zone vents re-opened — while unavailable, the engine cannot supervise the
+  // cycle. 0 = never abort (not recommended).
+  unavailable_abort_after_min: number;
 }
 
 export interface VacationMode {
@@ -751,6 +756,28 @@ export const setSensorStaleness = (stale_after_min: number) =>
   });
 
 export const getSensorHealth = () => api<SensorHealth>("/api/sensor-health");
+
+// Thermostat availability (Issue #267). /api/thermostat-health lists the
+// registered thermostats whose climate entity is currently unavailable in
+// Home Assistant — used by the Dashboard banner, mirroring the stale-sensors
+// one. While a thermostat is unavailable the engine cannot supervise its
+// cycle; after `abort_after_min` minutes a running cycle is aborted and all
+// zone vents re-opened (configurable per thermostat on the Thermostats page).
+
+export interface UnavailableThermostat {
+  thermostat_entity_id: string;
+  name: string;
+  reason: "unavailable" | "not_in_cache";
+  unavailable_seconds: number | null;
+  abort_after_min: number;
+  cycle_running: boolean;
+}
+
+export interface ThermostatHealth {
+  thermostats: UnavailableThermostat[];
+}
+
+export const getThermostatHealth = () => api<ThermostatHealth>("/api/thermostat-health");
 
 export const triggerDailyRollup = (days_back?: number) =>
   api<{ rows_written: number; days_back: number }>("/api/metrics/rollup/daily", {

--- a/smart_vent/frontend/src/components/AirflowConfigBanner.test.tsx
+++ b/smart_vent/frontend/src/components/AirflowConfigBanner.test.tsx
@@ -25,6 +25,7 @@ function tc(over: Partial<api.ThermostatConfig> = {}): api.ThermostatConfig {
     has_bypass_damper: false,
     min_open_vents_fraction: 0.333,
     overflow_during_min_runtime: true,
+    unavailable_abort_after_min: 5,
     ...over,
   };
 }

--- a/smart_vent/frontend/src/components/UnavailableThermostatsBanner.tsx
+++ b/smart_vent/frontend/src/components/UnavailableThermostatsBanner.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { getThermostatHealth, type ThermostatHealth, type UnavailableThermostat } from "../api";
+
+/**
+ * Surfaces thermostat unavailability on the Dashboard (Issue #267),
+ * mirroring the stale-sensors banner.
+ *
+ * Polls ``/api/thermostat-health`` every 30 s. Renders nothing while every
+ * registered thermostat is reachable; renders a red card listing the
+ * unavailable ones otherwise. While a thermostat is unavailable the engine
+ * cannot supervise its zone at all — no cycle timeout, no closed-vent
+ * watchdog — so this is the loudest banner on the page.
+ */
+export default function UnavailableThermostatsBanner() {
+  const [health, setHealth] = useState<ThermostatHealth | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      getThermostatHealth()
+        .then((h) => {
+          if (!cancelled) setHealth(h);
+        })
+        .catch(() => {
+          /* network blip — leave previous state in place */
+        });
+    };
+    refresh();
+    const interval = setInterval(refresh, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!health || health.thermostats.length === 0) return null;
+
+  const n = health.thermostats.length;
+
+  return (
+    <div
+      className="card"
+      role="alert"
+      data-testid="unavailable-thermostats-banner"
+      style={{ borderLeft: "3px solid #dc2626", marginBottom: "1rem" }}
+    >
+      <div style={{ display: "flex", alignItems: "baseline", gap: ".5rem" }}>
+        <strong>
+          ⚠ {n} thermostat{n === 1 ? "" : "s"} unavailable in Home Assistant
+        </strong>
+      </div>
+      <div className="text-sm" style={{ marginTop: ".5rem", color: "var(--gray-700)" }}>
+        While a thermostat is unavailable the engine cannot supervise its zone — cycles are not
+        monitored and vents are not adjusted. Check the device's power and connectivity, or the Home
+        Assistant integration that provides it.
+      </div>
+      <ul style={{ margin: "0.5rem 0 0", paddingLeft: "1.25rem" }}>
+        {health.thermostats.map((t) => (
+          <li key={t.thermostat_entity_id} style={{ marginBottom: ".25rem" }}>
+            <strong>{t.name || t.thermostat_entity_id}</strong>{" "}
+            <code>{t.thermostat_entity_id}</code>{" "}
+            <span className="text-sm text-muted">({describe(t)})</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function describe(t: UnavailableThermostat): string {
+  const age =
+    t.reason === "not_in_cache" || t.unavailable_seconds === null
+      ? "never seen by HA"
+      : `unavailable ${formatAge(t.unavailable_seconds)}`;
+  if (!t.cycle_running) return age;
+  if (t.abort_after_min <= 0) {
+    return `${age} — a cycle is running and will NOT be auto-aborted (abort disabled on the Thermostats page)`;
+  }
+  return `${age} — the running cycle aborts after ${t.abort_after_min} min and all vents re-open`;
+}
+
+function formatAge(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 1) return "for under a minute";
+  if (minutes < 60) return `for ${minutes} min`;
+  return `for ${(minutes / 60).toFixed(1)} h`;
+}

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -35,6 +35,7 @@ describe("Dashboard Page", () => {
     vi.clearAllMocks();
     vi.mocked(api.getSensorHealth).mockResolvedValue({ stale_after_min: 30, rooms: [] });
     vi.mocked(api.getSensorStaleness).mockResolvedValue({ stale_after_min: 30 });
+    vi.mocked(api.getThermostatHealth).mockResolvedValue({ thermostats: [] });
     vi.mocked(api.getStatus).mockResolvedValue(mockStatus);
     vi.mocked(api.connectWS).mockReturnValue(() => {});
     vi.mocked(api.getVacationMode).mockResolvedValue({ enabled: false, return_at: null });
@@ -77,6 +78,7 @@ describe("Dashboard Page", () => {
         min_cycle_offtime_min: 0,
         cooling_lockout_below_f: null,
         overflow_during_min_runtime: true,
+        unavailable_abort_after_min: 5,
       },
     ]);
   });
@@ -171,5 +173,70 @@ describe("Dashboard Page", () => {
     );
     await screen.findByText("Dashboard");
     expect(screen.queryByTestId("stale-sensors-banner")).not.toBeInTheDocument();
+  });
+
+  it("surfaces unavailable thermostats as a top-of-Dashboard banner (Issue #267)", async () => {
+    vi.mocked(api.getThermostatHealth).mockResolvedValue({
+      thermostats: [
+        {
+          thermostat_entity_id: "climate.test",
+          name: "Main HVAC",
+          reason: "unavailable",
+          unavailable_seconds: 120,
+          abort_after_min: 5,
+          cycle_running: true,
+        },
+      ],
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    const banner = await screen.findByTestId("unavailable-thermostats-banner");
+    expect(banner).toHaveTextContent("1 thermostat unavailable in Home Assistant");
+    expect(banner).toHaveTextContent("Main HVAC");
+    expect(banner).toHaveTextContent("climate.test");
+    expect(banner).toHaveTextContent("unavailable for 2 min");
+    // With a cycle in flight, the banner says what the engine will do about it.
+    expect(banner).toHaveTextContent("aborts after 5 min");
+  });
+
+  it("warns when the unavailability abort is disabled and a cycle is running", async () => {
+    vi.mocked(api.getThermostatHealth).mockResolvedValue({
+      thermostats: [
+        {
+          thermostat_entity_id: "climate.test",
+          name: "Main HVAC",
+          reason: "unavailable",
+          unavailable_seconds: 600,
+          abort_after_min: 0,
+          cycle_running: true,
+        },
+      ],
+    });
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    const banner = await screen.findByTestId("unavailable-thermostats-banner");
+    expect(banner).toHaveTextContent("will NOT be auto-aborted");
+  });
+
+  it("does not render the unavailable-thermostats banner when all are reachable", async () => {
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <DevModeContext.Provider value={mockDevMode}>
+          <Dashboard />
+        </DevModeContext.Provider>
+      </SystemContext.Provider>
+    );
+    await screen.findByText("Dashboard");
+    expect(screen.queryByTestId("unavailable-thermostats-banner")).not.toBeInTheDocument();
   });
 });

--- a/smart_vent/frontend/src/pages/Dashboard.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import {
 import { useUnit } from "../contexts";
 import AirflowConfigBanner from "../components/AirflowConfigBanner";
 import StaleSensorsBanner from "../components/StaleSensorsBanner";
+import UnavailableThermostatsBanner from "../components/UnavailableThermostatsBanner";
 import VacationModeModal from "../components/VacationModeModal";
 
 function modeColor(mode: string): string {
@@ -222,6 +223,7 @@ export default function Dashboard() {
       </div>
 
       <AirflowConfigBanner />
+      <UnavailableThermostatsBanner />
       <StaleSensorsBanner />
 
       {/* Vacation mode button — sits above climate cards */}

--- a/smart_vent/frontend/src/pages/Metrics.test.tsx
+++ b/smart_vent/frontend/src/pages/Metrics.test.tsx
@@ -62,6 +62,7 @@ describe("Metrics Page", () => {
         min_cycle_offtime_min: 0,
         cooling_lockout_below_f: null,
         overflow_during_min_runtime: true,
+        unavailable_abort_after_min: 5,
       },
     ]);
     vi.mocked(api.getMetricsHomeSummary).mockResolvedValue(mockSummary);

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -28,6 +28,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     min_cycle_offtime_min: 0,
     cooling_lockout_below_f: null,
     overflow_during_min_runtime: true,
+    unavailable_abort_after_min: 5,
   },
 ];
 

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -28,6 +28,7 @@ const mockThermostats: api.ThermostatConfig[] = [
     min_cycle_offtime_min: 0,
     cooling_lockout_below_f: null,
     overflow_during_min_runtime: true,
+    unavailable_abort_after_min: 5,
   },
 ];
 
@@ -212,6 +213,31 @@ describe("Thermostats Page", () => {
     });
   });
 
+  it("edits and saves the thermostat-unavailability abort threshold (Issue #267)", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({} as api.ThermostatConfig);
+    render(<Thermostats />);
+
+    const input = (await screen.findByLabelText(
+      /Abort when thermostat unavailable/i
+    )) as HTMLInputElement;
+    // Initializes from the config value, no unit conversion (it's minutes).
+    expect(input.value).toBe("5");
+    // The helper text explains the consequence, including the 0 = never case.
+    expect(screen.getByText(/cannot supervise the cycle/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 = never abort/i)).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "12" } });
+    const card = input.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({ unavailable_abort_after_min: 12 })
+      );
+    });
+  });
+
   it("disables the overflow-conditioning checkbox when Min cycle runtime is 0 (Issue #237)", async () => {
     // Default mock has min_cycle_runtime_min = 0 — the toggle has nothing
     // to hook into (no hold ever happens), so it is disabled with a hint.
@@ -246,6 +272,7 @@ describe("Thermostats Page", () => {
         "climate.test",
         expect.objectContaining({
           overflow_during_min_runtime: false,
+          unavailable_abort_after_min: 5,
         })
       );
     });

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -93,6 +93,14 @@ const SAFETY_FIELDS: {
     min: "0",
     kind: "other",
   },
+  {
+    key: "unavailable_abort_after_min",
+    label: "Abort when thermostat unavailable (min)",
+    help: "If the thermostat entity is unavailable in Home Assistant for this long while a cycle is running, abort the cycle and re-open all vents — while it is unavailable the engine cannot supervise the cycle (no timeout, no closed-vent watchdog). Shorter outages are tolerated and the cycle resumes untouched. Recommended: 5 min. 0 = never abort (not recommended).",
+    step: "1",
+    min: "0",
+    kind: "other",
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #267, fixes #268, fixes #269, fixes #270 — the three critical findings from the pre-launch engine review plus the consolidated nice-to-fix list.

## Critical fixes

### Sustained thermostat unavailability now aborts a running cycle, with a UI knob and a UI notification (#267)

`_do_tick` returned immediately whenever the climate entity was unavailable. That early return suspended every per-tick safety monitor — the cycle timeout, the `max_vent_closed_min` force-reopen watchdog, and reconciliation — for the duration of the outage, while the physical HVAC kept running at the last commanded setpoint with satisfied rooms' vents closed. The file's state-machine docstring promised an abort on unavailability that never existed in code.

**Engine.** The engine tracks `unavailable_since` per zone. Transient outages are tolerated and the cycle resumes untouched; once the outage exceeds the configured threshold, a running cycle is aborted with reason `thermostat unavailable` and all zone vents re-open (cover entities are independent of the climate entity, so those commands still work). The clock clears the moment a tick sees the thermostat again. Also removed the dead `safe_close` parameter from `_abort_cycle` and fixed the state-machine docstring.

**Config knob (no hardcoded settings).** The threshold is the new per-thermostat `unavailable_abort_after_min` field (default 5 min, 0 = never abort): DB column + migration, validation on both thermostat write endpoints, and an **"Abort when thermostat unavailable (min)"** control in the Thermostats-page safety grid with helper text.

**UI notification (mirrors the stale-sensors banner).** New `GET /api/thermostat-health` endpoint lists registered thermostats whose climate entity is unavailable or missing from the HA cache, with outage age, the configured threshold, and whether a cycle is in flight. A new red `UnavailableThermostatsBanner` on the Dashboard polls it every 30 s, explains the zone is unsupervised, says when the running cycle will abort — and warns loudly when the abort is disabled with a cycle in flight.

### Min-runtime hold gate now actually tested (#268)

Coverage showed the hold gate's continuation branch in `_monitor_rooms` never executed anywhere in the suite — the test named for it passed via the hold-*entry* branch instead. Added `test_hold_gate_prevents_reclosing_when_a_room_drifts_off_target` (one room drifted off target during the hold, one at-target room with a re-opened vent → close loop short-circuited) and renamed the existing test to `test_hold_entry_branch_skips_close_loop`.

### In-tick abort backstops tested (#269)

Added tests driving `_do_tick` directly with a RUNNING cycle for both guards: system disabled → `aborted: system disabled`, and vacation mode → `aborted: vacation mode` plus the vacation hold applied in the same tick.

## Nice-to-fix items (#270)

1. **`ZoneStatus` sensor counts** — `sensor_count`/`available_sensor_count` now report configured-vs-fresh sensors (room sensors + thermostat probe) via a new `_sensor_counts` helper, replacing the boolean-flag 1/0 stand-in.
2. **`_read_hvac_mode` "unknown" skip** — `_do_tick` defensive branch now tested.
3. **Mid-cycle config changes** — tightening `max_setpoint` during a running cycle is honored on the next setpoint re-derive (test added).
4. **Vacation single-setpoint, no `current_temperature`** — force-off path tested (and the already-off no-op).
5. **Bypass close→reopen ordering** — the last-vent bypass test now asserts the close is *followed by* the reopen in the ordered service-call log.
6. **Direction-flip characterization** — now asserts the safety property (cycle must stop) alongside the `ended_reason` implementation note.
7. **`_maybe_broadcast`** — now tested (emits `zone_status`, no-ops without a callback, swallows WebSocket errors).
8. **Handoff matrix** — added `schedule→presence` and `override→schedule` in-place handoff tests.
9. **Per-tick warning spam during outage** — the unavailability event-log warning is now once-per-episode (was every 60 s tick) with a recovery info event, mirroring the #211 sensor-staleness rate-limiting.

## Test plan

- **Backend: 763 tests pass**, coverage 93.11% (gate 92.5%), mypy and ruff clean. Engine unit tests cover the config-driven unavailability threshold (transient tolerated, sustained aborts + reopens vents + closes the cycle log, 0 disables, recovery clears the clock, idle skips, once-per-episode warning + recovery). Integration: `test_thermostat_health.py` (health endpoint, full-tick outage abort, config round-trip + validation), mid-cycle bounds, bypass ordering, both new handoff directions.
- **Frontend: 248 tests pass**, coverage thresholds met (knob renders + saves raw value; banner shows outage/abort messaging incl. the disabled-abort warning, hidden when healthy). No frontend change was needed for the sensor-count fix — that's backend-only.