### PR TITLE
Per-room deadband override (#277)

### DIFF
--- a/e2e/tests/temperature-fields.ts
+++ b/e2e/tests/temperature-fields.ts
@@ -25,7 +25,11 @@
 
 /** Conversion kind — drives `_to_f` vs `_delta_to_f` on the backend
  * and whether `null` is accepted as a value. */
-export type TempKind = "absolute" | "absolute_nullable" | "delta";
+export type TempKind =
+  | "absolute"
+  | "absolute_nullable"
+  | "delta"
+  | "delta_nullable";
 
 export interface TempField {
   /** Body key exactly as it appears on the wire. */
@@ -90,6 +94,14 @@ export const TEMPERATURE_FIELDS: TempField[] = [
   {
     field: "temp_offset",
     kind: "delta",
+    ui: true,
+    endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
+  },
+  // ── Per-room deadband override (Issue #277). Nullable delta written by the
+  // Rooms modal; null clears the override (inherit the thermostat deadband).
+  {
+    field: "deadband_override",
+    kind: "delta_nullable",
     ui: true,
     endpoints: ["POST /api/rooms", "PUT /api/rooms/{id}"],
   },

--- a/e2e/tests/temperature-units.spec.ts
+++ b/e2e/tests/temperature-units.spec.ts
@@ -39,6 +39,9 @@ const COOLING_LOCKOUT = isCelsius ? "12" : "54";
 const SCHEDULE_TARGET = isCelsius ? "20" : "68";
 const ROOM_SYS_TEMP = isCelsius ? "21" : "70";
 const ROOM_TEMP_OFFSET = isCelsius ? "0.5" : "0.9";
+// Per-room deadband override (Issue #277). A delta, so it round-trips through
+// the backend's 2dp °F storage cleanly at 0.5°C → 0.9°F.
+const ROOM_DEADBAND_OVERRIDE = isCelsius ? "0.5" : "0.9";
 // Ambient pre-cool/pre-heat deltas (Issue #248). 5°C → 9.0°F and 3°C → 5.4°F
 // both round-trip cleanly through the backend's 2dp °F storage, and the
 // widened deadband (3) clears any thermostat deadband set earlier in this file.
@@ -140,7 +143,7 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
   test("room presence temp and offset persist exactly as entered (#231)", async ({
     page,
   }) => {
-    // @covers: system_wide_temp, temp_offset
+    // @covers: system_wide_temp, temp_offset, deadband_override
     await page.goto("/rooms");
     await page.waitForSelector(".loading", {
       state: "detached",
@@ -168,11 +171,12 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
       .getByLabel(/Presence-triggered temperature/i)
       .fill(ROOM_SYS_TEMP);
     await modal.getByLabel(/Temperature offset/i).fill(ROOM_TEMP_OFFSET);
+    await modal.getByLabel(/Deadband override/i).fill(ROOM_DEADBAND_OVERRIDE);
 
     await modal.getByRole("button", { name: /Save changes/i }).click();
     await modal.waitFor({ state: "detached", timeout: 5_000 });
 
-    // Reopen and verify both persisted values.
+    // Reopen and verify all persisted values.
     modal = await openModal();
     const sysTempAfter = await modal
       .getByLabel(/Presence-triggered temperature/i)
@@ -180,9 +184,16 @@ test.describe(`Temperature round-trip (PLENUM_TEMP_UNIT=${UNIT})`, () => {
     const offsetAfter = await modal
       .getByLabel(/Temperature offset/i)
       .inputValue();
+    const deadbandOverrideAfter = await modal
+      .getByLabel(/Deadband override/i)
+      .inputValue();
     expect(parseFloat(sysTempAfter)).toBeCloseTo(parseFloat(ROOM_SYS_TEMP), 1);
     expect(parseFloat(offsetAfter)).toBeCloseTo(
       parseFloat(ROOM_TEMP_OFFSET),
+      1,
+    );
+    expect(parseFloat(deadbandOverrideAfter)).toBeCloseTo(
+      parseFloat(ROOM_DEADBAND_OVERRIDE),
       1,
     );
   });

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -89,6 +89,27 @@ def _temp_range_error(field: str, low_f: float, high_f: float, unit: str) -> web
     return error(f"{field} must be between {low} and {high}°{unit}")
 
 
+def _validate_deadband_override(val, unit: str) -> tuple[web.Response | None, float | None]:
+    """Validate a present per-room ``deadband_override`` value (Issue #277).
+
+    ``val`` is the raw body value, already known to be present in the request.
+    ``None`` clears the override so the room inherits the thermostat's deadband.
+    A number is a delta (no -32 offset) converted to °F via ``_delta_to_f`` and
+    bounded to a sane 0–10 °F band.
+
+    Returns ``(error_response | None, value_f | None)``. On the error path the
+    second element is meaningless; callers must check the response first.
+    """
+    if val is None:
+        return None, None
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        return error("deadband_override must be a number or null"), None
+    val_f = _delta_to_f(val, unit)
+    if not (0 <= val_f <= 10):
+        return error("deadband_override must be between 0 and 10°F (or equivalent)"), None
+    return None, val_f
+
+
 def _validate_ambient_suppression(
     body: dict, unit: str, tc_deadband_f: float, feature_enabled: bool
 ) -> tuple[web.Response | None, dict]:
@@ -183,6 +204,7 @@ def _validate_ambient_suppression(
 #   "absolute"          — _to_f, value must be present (NOT NULL in DB).
 #   "absolute_nullable" — _to_f, null clears / disables the value.
 #   "delta"             — _delta_to_f (no -32 offset). Treated as 0 if absent.
+#   "delta_nullable"    — _delta_to_f (no -32 offset), null clears the value.
 # ---------------------------------------------------------------------------
 
 TEMPERATURE_FIELDS: dict[str, str] = {
@@ -196,6 +218,9 @@ TEMPERATURE_FIELDS: dict[str, str] = {
     # Room
     "system_wide_temp": "absolute_nullable",
     "temp_offset": "delta",
+    # Per-room deadband override (Issue #277). Nullable delta: null clears the
+    # override, restoring inheritance of the thermostat's deadband.
+    "deadband_override": "delta_nullable",
     # Room — ambient-aware presence suppression / pre-cool (Issue #248)
     "ambient_suppression_min_differential": "delta",
     "ambient_suppression_deadband": "delta",
@@ -261,6 +286,13 @@ async def create_room(request: web.Request) -> web.Response:
     if not (-20 <= temp_offset_f <= 20):
         return error("temp_offset must be between -20 and 20°F (or equivalent)")
 
+    # Per-room deadband override (Issue #277). Absent → inherit (None).
+    deadband_override_f: float | None = None
+    if "deadband_override" in body:
+        err, deadband_override_f = _validate_deadband_override(body["deadband_override"], unit)
+        if err is not None:
+            return err
+
     conn = await get_conn(request)
     # Ambient suppression (Issue #248): widened deadband is validated against the
     # room's thermostat deadband. get_thermostat_config returns a default config
@@ -279,6 +311,7 @@ async def create_room(request: web.Request) -> web.Response:
         presence_holdover_hours=holdover,
         notes=body.get("notes", ""),
         temp_offset=temp_offset_f,
+        deadband_override=deadband_override_f,
         **ambient_updates,
     )
     await db.upsert_room(conn, room)
@@ -342,6 +375,14 @@ async def update_room(request: web.Request) -> web.Response:
         val_f = _delta_to_f(val, unit)
         if not (-20 <= val_f <= 20):
             return error("temp_offset must be between -20 and 20°F (or equivalent)")
+    # Per-room deadband override (Issue #277). Validated and converted up front;
+    # applied below only when the key is present (null clears the override).
+    deadband_override_present = "deadband_override" in body
+    deadband_override_f: float | None = None
+    if deadband_override_present:
+        err, deadband_override_f = _validate_deadband_override(body["deadband_override"], unit)
+        if err is not None:
+            return err
     # Ambient suppression (Issue #248): validate against the *effective* thermostat
     # (a request can switch thermostat_entity_id in the same PUT).
     effective_thermostat = body.get("thermostat_entity_id", room.thermostat_entity_id)
@@ -366,6 +407,8 @@ async def update_room(request: web.Request) -> web.Response:
         room.system_wide_temp = _to_f(val, unit) if val is not None else None
     if "temp_offset" in body:
         room.temp_offset = _delta_to_f(body["temp_offset"], unit)
+    if deadband_override_present:
+        room.deadband_override = deadband_override_f
     for attr, value in ambient_updates.items():
         setattr(room, attr, value)
     await db.upsert_room(conn, room)

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS rooms (
     presence_holdover_hours REAL NOT NULL DEFAULT 2.0,
     notes TEXT NOT NULL DEFAULT '',
     temp_offset REAL NOT NULL DEFAULT 0.0,
+    deadband_override REAL,
     ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0,
     ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence',
     ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0,
@@ -409,6 +410,9 @@ _MIGRATIONS = [
     # climate-entity unavailability before a running cycle is aborted and all
     # zone vents re-opened. 0 = never abort.
     "ALTER TABLE thermostat_configs ADD COLUMN unavailable_abort_after_min INTEGER NOT NULL DEFAULT 5",
+    # Per-room deadband override (Issue #277). NULL = inherit the thermostat's
+    # deadband, so existing rooms keep their current behaviour after upgrade.
+    "ALTER TABLE rooms ADD COLUMN deadband_override REAL",
 ]
 
 
@@ -479,6 +483,7 @@ def _row_to_room(row) -> Room:
         presence_holdover_hours=row["presence_holdover_hours"],
         notes=row["notes"],
         temp_offset=row["temp_offset"] if row["temp_offset"] is not None else 0.0,
+        deadband_override=row["deadband_override"],
         ambient_suppression_enabled=bool(row["ambient_suppression_enabled"]),
         ambient_suppression_mode=row["ambient_suppression_mode"],
         ambient_suppression_min_differential=row["ambient_suppression_min_differential"],
@@ -492,11 +497,11 @@ def _row_to_room(row) -> Room:
 async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
     await conn.execute(
         """INSERT INTO rooms (id,name,thermostat_entity_id,include_thermostat_sensor,
-           system_wide_temp,presence_holdover_hours,notes,temp_offset,
+           system_wide_temp,presence_holdover_hours,notes,temp_offset,deadband_override,
            ambient_suppression_enabled,ambient_suppression_mode,
            ambient_suppression_min_differential,ambient_suppression_deadband,
            ambient_suppression_off_schedule_window_min)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
            ON CONFLICT(id) DO UPDATE SET
              name=excluded.name,
              thermostat_entity_id=excluded.thermostat_entity_id,
@@ -505,6 +510,7 @@ async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
              presence_holdover_hours=excluded.presence_holdover_hours,
              notes=excluded.notes,
              temp_offset=excluded.temp_offset,
+             deadband_override=excluded.deadband_override,
              ambient_suppression_enabled=excluded.ambient_suppression_enabled,
              ambient_suppression_mode=excluded.ambient_suppression_mode,
              ambient_suppression_min_differential=excluded.ambient_suppression_min_differential,
@@ -520,6 +526,7 @@ async def upsert_room(conn: aiosqlite.Connection, room: Room) -> None:
             room.presence_holdover_hours,
             room.notes,
             room.temp_offset,
+            room.deadband_override,
             int(room.ambient_suppression_enabled),
             room.ambient_suppression_mode,
             room.ambient_suppression_min_differential,

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1722,7 +1722,7 @@ class CycleEngine:
                 effective,
                 ar.target_temp,
                 ar.source,
-                deadband,
+                _effective_deadband(ar.room, deadband),
                 outside_temp,
                 tc,
                 recently_off,
@@ -1825,12 +1825,13 @@ class CycleEngine:
                 continue
             effective = avg + ar.room.temp_offset
             recently_off = bool(off_schedule_ok and off_schedule_ok.get(ar.room.id))
+            room_deadband = _effective_deadband(ar.room, deadband)
             vote, suppressed = self._suppression_vote(
                 ar.room,
                 effective,
                 ar.target_temp,
                 ar.source,
-                deadband,
+                room_deadband,
                 outside_temp,
                 tc,
                 recently_off,
@@ -1874,7 +1875,7 @@ class CycleEngine:
                     ar.room.name,
                     effective,
                     ar.target_temp,
-                    deadband,
+                    room_deadband,
                 )
                 if self._logger:
                     await self._logger.log(
@@ -1900,7 +1901,7 @@ class CycleEngine:
                     ar.room.name,
                     effective,
                     ar.target_temp,
-                    deadband,
+                    room_deadband,
                 )
                 if self._logger:
                     await self._logger.log(
@@ -3273,6 +3274,22 @@ class CycleEngine:
                 except Exception as exc:
                     log.debug("Failed to finalize overflow room state: %s", exc)
         self._overflow_room_states = {}
+
+
+def _effective_deadband(room: Room, thermostat_deadband: float) -> float:
+    """Deadband (±°F) governing this room's start-cycle / join-cycle vote.
+
+    Rooms may override the thermostat's deadband (Issue #277). ``None`` on the
+    room means inherit the thermostat value, so rooms without an override are
+    unaffected. The override only widens/narrows the at-target tolerance band
+    used when deciding whether a room demands HVAC — it is unrelated to the
+    pre-cool/pre-heat ``ambient_suppression_deadband`` (the widened coasting
+    band), which the suppression vote still clamps with ``max()`` against
+    whatever deadband is passed here.
+    """
+    if room.deadband_override is not None:
+        return room.deadband_override
+    return thermostat_deadband
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -42,6 +42,15 @@ class Room:
     presence_holdover_hours: float = 2.0
     notes: str = ""
     temp_offset: float = 0.0  # °F added to measured avg before comparing to target
+    # Per-room deadband override (Issue #277). When set, this replaces the
+    # thermostat's ``deadband`` for THIS room's start-cycle / join-cycle vote
+    # only — the ±°F tolerance band around target within which the room is
+    # considered "at target" and calls for no HVAC. ``None`` (the default)
+    # means inherit the thermostat's deadband, so existing rooms are
+    # unaffected. This is distinct from ``ambient_suppression_deadband`` below,
+    # which is the *widened* coasting band used only by the pre-cool/pre-heat
+    # feature.
+    deadband_override: float | None = None
     # Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
     # Per-room opt-in; only active when an outside temperature sensor is
     # configured. When the outside temp is at least

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -167,6 +167,52 @@ class TestRoomsValidation:
         resp = await client.put(f"/api/rooms/{room['id']}", json={"temp_offset": 25})
         assert resp.status == 400
 
+    # Per-room deadband override (Issue #277)
+    async def test_create_room_deadband_override(self, client):
+        resp = await client.post(
+            "/api/rooms",
+            json={
+                "name": "Nursery",
+                "thermostat_entity_id": "climate.x",
+                "deadband_override": 1.5,
+            },
+        )
+        assert resp.status == 201
+        assert (await resp.json())["deadband_override"] == 1.5
+
+    async def test_create_room_deadband_override_defaults_none(self, client):
+        room = await _create_room(client)
+        assert room["deadband_override"] is None
+
+    async def test_create_room_invalid_deadband_override_non_numeric(self, client):
+        resp = await client.post(
+            "/api/rooms",
+            json={"name": "Room", "thermostat_entity_id": "climate.x", "deadband_override": "bad"},
+        )
+        assert resp.status == 400
+
+    async def test_create_room_invalid_deadband_override_out_of_range(self, client):
+        resp = await client.post(
+            "/api/rooms",
+            json={"name": "Room", "thermostat_entity_id": "climate.x", "deadband_override": 25},
+        )
+        assert resp.status == 400
+
+    async def test_update_room_deadband_override_set_and_clear(self, client):
+        room = await _create_room(client)
+        resp = await client.put(f"/api/rooms/{room['id']}", json={"deadband_override": 2.0})
+        assert resp.status == 200
+        assert (await resp.json())["deadband_override"] == 2.0
+        # Null clears the override, restoring inheritance.
+        resp = await client.put(f"/api/rooms/{room['id']}", json={"deadband_override": None})
+        assert resp.status == 200
+        assert (await resp.json())["deadband_override"] is None
+
+    async def test_update_room_invalid_deadband_override_out_of_range(self, client):
+        room = await _create_room(client)
+        resp = await client.put(f"/api/rooms/{room['id']}", json={"deadband_override": -1})
+        assert resp.status == 400
+
 
 # ---------------------------------------------------------------------------
 # Sensors
@@ -1205,6 +1251,33 @@ class TestRoomTempConversion:
         )
         assert resp.status == 200
         assert (await resp.json())["temp_offset"] == 1.8  # 1°C delta → 1.8°F
+
+    async def test_create_room_deadband_override_celsius(self, celsius_client):
+        # Per-room deadband override is a delta (Issue #277) — 1°C → 1.8°F, no
+        # -32 offset. The frontend sends the raw °C value; the backend converts.
+        resp = await celsius_client.post(
+            "/api/rooms",
+            json={
+                "name": "Office",
+                "thermostat_entity_id": "climate.test",
+                "deadband_override": 1.0,
+            },
+        )
+        assert resp.status == 201
+        assert (await resp.json())["deadband_override"] == 1.8  # 1°C delta → 1.8°F
+
+    async def test_update_room_deadband_override_delta_celsius(self, celsius_client):
+        r = await celsius_client.post(
+            "/api/rooms",
+            json={"name": "Den", "thermostat_entity_id": "climate.test"},
+        )
+        room_id = (await r.json())["id"]
+        resp = await celsius_client.put(
+            f"/api/rooms/{room_id}",
+            json={"deadband_override": 1.0},
+        )
+        assert resp.status == 200
+        assert (await resp.json())["deadband_override"] == 1.8  # 1°C delta → 1.8°F
 
     async def test_update_room_system_wide_temp_none(self, celsius_client):
         r = await celsius_client.post(

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -21,7 +21,12 @@ from unittest.mock import AsyncMock, MagicMock
 import aiosqlite
 import pytest
 
-from backend.engine.cycle_engine import CycleEngine, CycleState, _is_at_target
+from backend.engine.cycle_engine import (
+    CycleEngine,
+    CycleState,
+    _effective_deadband,
+    _is_at_target,
+)
 from backend.engine.room_manager import ActiveRoom
 from backend.engine.vent_controller import VentController
 from backend.models import (
@@ -64,12 +69,14 @@ def _make_room(
     room_id: str = "room1",
     name: str = "Bedroom",
     temp_offset: float = 0.0,
+    deadband_override: float | None = None,
 ) -> Room:
     return Room(
         id=room_id,
         name=name,
         thermostat_entity_id=THERMO_ID,
         temp_offset=temp_offset,
+        deadband_override=deadband_override,
     )
 
 
@@ -685,6 +692,95 @@ class TestInferMode:
         # Sanity: ambient 85 > max(targets) + deadband = 74.5 → contradicts → flip to cooling
         result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
         assert result == "cooling"
+
+
+# ---------------------------------------------------------------------------
+# Per-room deadband override (Issue #277)
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveDeadband:
+    """The _effective_deadband helper resolves override vs inheritance."""
+
+    def test_none_inherits_thermostat_deadband(self):
+        room = _make_room("r1", deadband_override=None)
+        assert _effective_deadband(room, 0.5) == 0.5
+
+    def test_override_replaces_thermostat_deadband(self):
+        room = _make_room("r1", deadband_override=2.0)
+        assert _effective_deadband(room, 0.5) == 2.0
+
+    def test_zero_override_is_honored_not_treated_as_unset(self):
+        # 0.0 is a valid (exact-match) deadband and must not collapse to the
+        # thermostat value — only None inherits.
+        room = _make_room("r1", deadband_override=0.0)
+        assert _effective_deadband(room, 0.5) == 0.0
+
+
+class TestInferModeDeadbandOverride:
+    """A room's deadband override governs its own start-cycle vote."""
+
+    @pytest.mark.asyncio
+    async def test_wide_override_suppresses_demand_within_band(self):
+        # Room is 1.5°F above target. The thermostat's 0.5°F deadband would call
+        # for cooling, but the room's 2.0°F override keeps it 'at target' → off.
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 75.5
+
+        rooms = {
+            "r1": ActiveRoom(
+                room=_make_room("r1", deadband_override=2.0),
+                target_temp=74.0,
+                source="schedule",
+            ),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "off"
+
+    @pytest.mark.asyncio
+    async def test_narrow_override_calls_for_hvac_inside_thermostat_band(self):
+        # Room is 0.3°F above target. The thermostat's 0.5°F deadband would treat
+        # it as 'at target', but the room's 0.2°F override demands cooling.
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 74.3
+
+        rooms = {
+            "r1": ActiveRoom(
+                room=_make_room("r1", deadband_override=0.2),
+                target_temp=74.0,
+                source="schedule",
+            ),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._infer_mode_from_room_temps(rooms, 0.5, thermo)
+        assert result == "cooling"
+
+    @pytest.mark.asyncio
+    async def test_filter_excludes_opposite_demand_via_override(self):
+        # Heating cycle. Room is 0.3°F above target. Under the thermostat's 0.5°F
+        # deadband it is 'at target' (vote off) and would ride the cycle; the
+        # room's narrow 0.2°F override flips it to a cooling vote, so the filter
+        # excludes it from the heating cycle (opposite direction).
+        ha = _make_ha(ambient=74.0)
+        engine = _make_engine(ha)
+        engine._sensor_map = {"r1": ["s1"]}
+        ha.get_numeric_state.return_value = 74.3
+
+        active = {
+            "r1": ActiveRoom(
+                room=_make_room("r1", deadband_override=0.2),
+                target_temp=74.0,
+                source="schedule",
+            ),
+        }
+        thermo = ha.get_state(THERMO_ID)
+        result = await engine._filter_rooms_for_mode(active, "heating", 0.5, thermo)
+        assert "r1" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/tests/test_db_migration.py
+++ b/smart_vent/backend/tests/test_db_migration.py
@@ -11,10 +11,33 @@ import aiosqlite
 import pytest
 
 from backend import db
+from backend.engine.cycle_engine import _effective_deadband
 from backend.main import _migrate_db_filename
 from backend.models import ThermostatConfig
 
 _SHORT_CYCLE_SENTINEL = "migration_short_cycle_defaults_v1"
+
+# The exact `rooms` schema as it shipped *before* the per-room deadband override
+# (Issue #277) — i.e. the current schema minus the `deadband_override` column.
+# Used to simulate an upgrade: an existing DB whose rooms table predates the new
+# column, where the column is added only by the ALTER in db._MIGRATIONS.
+_PRE_DEADBAND_OVERRIDE_ROOMS_SCHEMA = """
+CREATE TABLE rooms (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    thermostat_entity_id TEXT NOT NULL,
+    include_thermostat_sensor INTEGER NOT NULL DEFAULT 0,
+    system_wide_temp REAL,
+    presence_holdover_hours REAL NOT NULL DEFAULT 2.0,
+    notes TEXT NOT NULL DEFAULT '',
+    temp_offset REAL NOT NULL DEFAULT 0.0,
+    ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0,
+    ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence',
+    ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0,
+    ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0,
+    ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60
+);
+"""
 
 
 def test_fresh_dir_is_noop(tmp_path: Path) -> None:
@@ -172,5 +195,107 @@ async def test_migration_runs_only_once() -> None:
         tc = await db.get_thermostat_config(conn, "climate.x")
         assert tc.min_cycle_runtime_min == 0
         assert tc.min_cycle_offtime_min == 0
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-room deadband override upgrade path (Issue #277)
+#
+# The override column is nullable; an existing room with no override must keep
+# behaving exactly as before — the engine falls back to the thermostat deadband.
+# These tests simulate the real upgrade: a rooms table that predates the column,
+# carrying a room row, then init_db adds the column via ALTER.
+# ---------------------------------------------------------------------------
+
+
+async def _upgraded_db_with_legacy_room(room_id: str = "room-legacy") -> aiosqlite.Connection:
+    """Return a connection whose rooms table started out *without*
+    ``deadband_override`` and carried a room row, then was upgraded by
+    ``init_db`` (which runs the ALTER migration)."""
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    # Create the pre-#277 rooms table and insert a room the way an older build
+    # would have — no knowledge of deadband_override.
+    await conn.executescript(_PRE_DEADBAND_OVERRIDE_ROOMS_SCHEMA)
+    await conn.execute(
+        "INSERT INTO rooms (id, name, thermostat_entity_id) VALUES (?, ?, ?)",
+        (room_id, "Bedroom", "climate.house"),
+    )
+    await conn.commit()
+    # Upgrade. CREATE TABLE IF NOT EXISTS leaves the existing table alone, so the
+    # new column arrives solely via the ALTER in db._MIGRATIONS.
+    await db.init_db(conn)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_legacy_room_gets_null_override_after_upgrade() -> None:
+    """A room that existed before the feature loads with deadband_override=None
+    (inherit) after the column is added by the upgrade migration."""
+    conn = await _upgraded_db_with_legacy_room()
+    try:
+        # The column now exists on the upgraded table.
+        async with conn.execute("PRAGMA table_info(rooms)") as cur:
+            columns = {row["name"] for row in await cur.fetchall()}
+        assert "deadband_override" in columns
+
+        room = await db.get_room(conn, "room-legacy")
+        assert room is not None
+        # NULL in the back-filled column → None in the model → inherit.
+        assert room.deadband_override is None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_room_inherits_thermostat_deadband_after_upgrade() -> None:
+    """The behavioural guarantee: with no override configured, the engine's
+    effective deadband for the room is exactly the thermostat's deadband — i.e.
+    cycle decisions are unchanged from before the upgrade."""
+    conn = await _upgraded_db_with_legacy_room()
+    try:
+        room = await db.get_room(conn, "room-legacy")
+        assert room is not None
+        thermostat_deadband = 0.5  # the long-standing default
+        assert _effective_deadband(room, thermostat_deadband) == thermostat_deadband
+        # And any thermostat deadband flows through untouched.
+        assert _effective_deadband(room, 1.25) == 1.25
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_room_resaves_with_null_override_preserved() -> None:
+    """Editing other fields on a legacy room (a plain upsert of the loaded
+    object) must not invent an override — it round-trips as NULL/None."""
+    conn = await _upgraded_db_with_legacy_room()
+    try:
+        room = await db.get_room(conn, "room-legacy")
+        assert room is not None
+        room.notes = "edited after upgrade"
+        await db.upsert_room(conn, room)
+
+        reloaded = await db.get_room(conn, "room-legacy")
+        assert reloaded is not None
+        assert reloaded.notes == "edited after upgrade"
+        assert reloaded.deadband_override is None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_room_defaults_to_no_override() -> None:
+    """A brand-new install (init_db on an empty DB) also defaults rooms to no
+    override, so fresh and upgraded installs behave identically."""
+    conn = await _fresh_db()
+    try:
+        from backend.models import Room
+
+        await db.upsert_room(conn, Room.create(name="New", thermostat_entity_id="climate.house"))
+        rooms = await db.get_all_rooms(conn)
+        assert len(rooms) == 1
+        assert rooms[0].deadband_override is None
+        assert _effective_deadband(rooms[0], 0.5) == 0.5
     finally:
         await conn.close()

--- a/smart_vent/backend/tests/test_temperature_field_parity.py
+++ b/smart_vent/backend/tests/test_temperature_field_parity.py
@@ -44,7 +44,7 @@ ROUTES_PY = REPO_ROOT / "smart_vent" / "backend" / "api" / "routes.py"
 _ENTRY_RE = re.compile(
     r"\{\s*"
     r"field:\s*\"(?P<field>[^\"]+)\",\s*"
-    r"kind:\s*\"(?P<kind>absolute|absolute_nullable|delta)\",\s*"
+    r"kind:\s*\"(?P<kind>absolute_nullable|absolute|delta_nullable|delta)\",\s*"
     r"ui:\s*(?P<ui>true|false),\s*"
     r"endpoints:\s*\[[^\]]*\],?\s*"
     r"\}",

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -11,6 +11,9 @@ export interface Room {
   presence_holdover_hours: number;
   notes: string;
   temp_offset: number;
+  // Per-room deadband override (Issue #277). Stored in °F as a delta; null
+  // means inherit the thermostat's deadband. The form holds display units.
+  deadband_override: number | null;
   // Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
   // The two delta fields are stored in °F; the form holds display units.
   ambient_suppression_enabled: boolean;

--- a/smart_vent/frontend/src/pages/Dashboard.test.tsx
+++ b/smart_vent/frontend/src/pages/Dashboard.test.tsx
@@ -47,6 +47,7 @@ describe("Dashboard Page", () => {
         include_thermostat_sensor: false,
         presence_holdover_hours: 2,
         temp_offset: 0,
+        deadband_override: null,
         notes: "",
         system_wide_temp: null,
         ambient_suppression_enabled: false,

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -423,6 +423,38 @@ describe("Rooms Page", () => {
     });
   });
 
+  it("clears an existing override back to null when the field is emptied", async () => {
+    // The user's "changed my mind" flow: a room that already HAS an override,
+    // opened in the modal (field pre-populated), cleared, then saved → null.
+    const roomWithOverride = { ...mockRooms[0], deadband_override: 1.5 };
+    vi.mocked(api.getRooms).mockResolvedValue([roomWithOverride]);
+    vi.mocked(api.getRoom).mockResolvedValue(roomWithOverride);
+    vi.mocked(api.updateRoom).mockResolvedValue(roomWithOverride);
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Configure sensors/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Edit settings/i }));
+
+    // Field initialises with the stored override (1.5°F → "1.5" in °F mode).
+    const overrideInput = screen.getByLabelText(/Deadband override/i) as HTMLInputElement;
+    expect(overrideInput.value).toBe("1.5");
+
+    // Clear it and save — no validation error, payload carries null.
+    fireEvent.change(overrideInput, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => {
+      expect(api.updateRoom).toHaveBeenCalledWith(
+        "room-1",
+        expect.objectContaining({ deadband_override: null })
+      );
+    });
+  });
+
   it("returns to the room list with the back button", async () => {
     render(
       <SystemContext.Provider value={mockSystem}>

--- a/smart_vent/frontend/src/pages/Rooms.test.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.test.tsx
@@ -40,6 +40,7 @@ const mockRooms: api.Room[] = [
     include_thermostat_sensor: false,
     presence_holdover_hours: 2,
     temp_offset: 0,
+    deadband_override: null,
     system_wide_temp: 72,
     notes: "",
     ambient_suppression_enabled: false,
@@ -380,6 +381,7 @@ describe("Rooms Page", () => {
     fireEvent.change(screen.getByLabelText(/Presence holdover/i), { target: { value: "3" } });
     fireEvent.click(screen.getByLabelText(/Include thermostat's built-in sensor/i));
     fireEvent.change(screen.getByLabelText(/Temperature offset/i), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText(/Deadband override/i), { target: { value: "1.5" } });
     fireEvent.change(screen.getByLabelText(/Notes/i), { target: { value: "hello" } });
 
     fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
@@ -391,8 +393,32 @@ describe("Rooms Page", () => {
           name: "Renamed",
           presence_holdover_hours: 3,
           include_thermostat_sensor: true,
+          deadband_override: 1.5,
           notes: "hello",
         })
+      );
+    });
+  });
+
+  it("sends null deadband_override when the field is left blank (inherit)", async () => {
+    vi.mocked(api.updateRoom).mockResolvedValue(mockRooms[0]);
+    render(
+      <SystemContext.Provider value={mockSystem}>
+        <Rooms />
+      </SystemContext.Provider>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Configure sensors/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Edit settings/i }));
+
+    // mockRooms[0] has no deadband_override → the field renders blank and the
+    // payload carries null so the room keeps inheriting the thermostat deadband.
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => {
+      expect(api.updateRoom).toHaveBeenCalledWith(
+        "room-1",
+        expect.objectContaining({ deadband_override: null })
       );
     });
   });
@@ -513,6 +539,28 @@ describe("Rooms Page — Celsius mode", () => {
       expect(api.updateRoom).toHaveBeenCalledWith(
         "room-1",
         expect.objectContaining({ system_wide_temp: 22 })
+      );
+    });
+  });
+
+  it("sends the user's raw °C deadband_override when updating room (#231)", async () => {
+    vi.mocked(api.updateRoom).mockResolvedValue(mockRooms[0]);
+
+    renderInCelsius();
+    const editBtn = await screen.findByRole("button", { name: /Settings/i });
+    fireEvent.click(editBtn);
+
+    // deadband_override is a delta: the frontend sends the display value as-is
+    // and the backend's _delta_to_f converts °C → °F. Asserting the raw value
+    // guards against the #231 double-conversion.
+    fireEvent.change(screen.getByLabelText(/Deadband override/i), { target: { value: "1" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    await waitFor(() => {
+      expect(api.updateRoom).toHaveBeenCalledWith(
+        "room-1",
+        expect.objectContaining({ deadband_override: 1 })
       );
     });
   });

--- a/smart_vent/frontend/src/pages/Rooms.tsx
+++ b/smart_vent/frontend/src/pages/Rooms.tsx
@@ -56,6 +56,12 @@ function RoomModal({
     room?.include_thermostat_sensor ?? false
   );
   const [tempOffset, setTempOffset] = useState(String(toDisplayDelta(room?.temp_offset ?? 0)));
+  // Per-room deadband override (Issue #277). Empty string = inherit the
+  // thermostat's deadband (stored as null). Holds display units like the other
+  // delta fields; convert the °F value from the API via toDisplayDelta on init.
+  const [deadbandOverride, setDeadbandOverride] = useState(
+    room?.deadband_override != null ? String(toDisplayDelta(room.deadband_override)) : ""
+  );
   const [notes, setNotes] = useState(room?.notes ?? "");
   // Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248).
   const [ambientEnabled, setAmbientEnabled] = useState(room?.ambient_suppression_enabled ?? false);
@@ -119,6 +125,17 @@ function RoomModal({
       }
     }
 
+    // Per-room deadband override (Issue #277). Empty = inherit; otherwise it is
+    // a delta and must fall in 0–10°F (display equivalent), matching the
+    // backend bound.
+    if (deadbandOverride.trim() !== "") {
+      const dbVal = parseFloat(deadbandOverride);
+      if (isNaN(dbVal) || dbVal < 0 || dbVal > toDisplayDelta(10)) {
+        setError(`Deadband override must be between 0 and ${toDisplayDelta(10)}${unitLabel}`);
+        return;
+      }
+    }
+
     // Pre-cool/pre-heat (Issue #248): validate the same way the backend does,
     // but only when the feature is enabled — a disabled room's defaults must
     // never block an unrelated save (e.g. on a wide-deadband thermostat).
@@ -157,6 +174,7 @@ function RoomModal({
         presence_holdover_hours: parseFloat(holdover) || 0,
         include_thermostat_sensor: includeThermoSensor,
         temp_offset: parseFloat(tempOffset) || 0,
+        deadband_override: deadbandOverride.trim() === "" ? null : parseFloat(deadbandOverride),
         ambient_suppression_enabled: ambientEnabled,
         ambient_suppression_mode: ambientMode,
         ambient_suppression_min_differential: parseFloat(ambientMinDiff) || 0,
@@ -298,6 +316,35 @@ function RoomModal({
             system will now close the vent when the room reads 67°F (67 + 3 = 70, "at target"), and
             the room drifts to ~70°F instead of 67°F. Leave at 0 if the room reaches its target
             accurately.
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label" htmlFor="room-deadband-override">
+            Deadband override ({unitLabel})
+          </label>
+          <input
+            id="room-deadband-override"
+            className="form-control"
+            type="number"
+            step="0.1"
+            min="0"
+            placeholder={`Inherit thermostat (${thermoDeadbandDisplay}${unitLabel})`}
+            value={deadbandOverride}
+            onChange={(e) => setDeadbandOverride(e.target.value)}
+          />
+          <div className="form-hint">
+            Replaces the thermostat&rsquo;s deadband for <strong>this room only</strong> — the ±
+            tolerance around the target within which the room is &ldquo;at target&rdquo; and calls
+            for no heating or cooling. Leave blank to inherit the thermostat&rsquo;s deadband (
+            {thermoDeadbandDisplay}
+            {unitLabel}).
+            <br />
+            <strong>Example:</strong> a 70{unitLabel} target with a 1{unitLabel} override means the
+            room only calls for cooling above 71{unitLabel} and for heating below 69{unitLabel}. A
+            smaller value holds the room tighter to target (more cycling); a larger value is more
+            relaxed (less cycling). This is <em>not</em> the widened pre-cool/pre-heat deadband
+            below.
           </div>
         </div>
 

--- a/smart_vent/frontend/src/pages/Schedules.test.tsx
+++ b/smart_vent/frontend/src/pages/Schedules.test.tsx
@@ -17,6 +17,7 @@ const mockRooms: api.Room[] = [
     include_thermostat_sensor: false,
     presence_holdover_hours: 2,
     temp_offset: 0,
+    deadband_override: null,
     notes: "",
     system_wide_temp: null,
     ambient_suppression_enabled: false,


### PR DESCRIPTION
Closes #277.

## What changed

Rooms can now override their thermostat's **deadband** — the ±°F tolerance band around a room's target within which the room is "at target" and calls for no HVAC. When unset (`null`, the default) a room inherits the thermostat's deadband, so existing rooms are completely unaffected.

### Not the widened pre-cool/pre-heat deadband
This is the room's **base** everyday deadband and is deliberately distinct from `ambient_suppression_deadband` (#248), the *widened coasting* band used only by the "Skip presence heating/cooling when the weather will do it for me" feature. The override applies whether or not pre-cool/pre-heat is enabled; the suppression vote still clamps the widened band with `max()` against whatever base deadband is in effect, so the two compose cleanly.

## How it works
- New nullable `Room.deadband_override` (°F delta) + DB column and migration (`null` preserves current behavior on upgrade).
- The engine resolves an **effective deadband per room** (`_effective_deadband`: override if set, else thermostat deadband) and uses it in:
  - `_infer_mode_from_room_temps` — whether a room demands heat/cool/off when deciding to start a cycle.
  - `_filter_rooms_for_mode` — whether a room joins or is excluded from a cycle.
- The thermostat-wide ambient sanity check (compares against *all* room targets) keeps using the thermostat's own deadband — the override is per-room and must not move a thermostat-wide guard.
- `_is_at_target` (the running-cycle vent-close comparison) is a pure target comparison and already doesn't use the deadband, so it's unchanged.

## Backward compatibility / upgrade safety
Existing installs that upgrade and **don't touch this feature keep operating exactly as before**, with no action required:
- The migration is `ALTER TABLE rooms ADD COLUMN deadband_override REAL` — nullable, no default — so every existing room row is back-filled with `NULL`.
- `NULL` → `Room.deadband_override = None` → `_effective_deadband` returns the **thermostat's** deadband. Cycle start/join decisions are byte-for-byte the prior behavior.
- A re-save of an untouched room preserves `NULL` (no override is invented); fresh installs default identically.
- Covered by dedicated upgrade tests in `test_db_migration.py` that build a pre-#277 `rooms` table, insert a room, run `init_db` (applies the ALTER), and assert the legacy room loads as `None` and inherits the thermostat deadband.

## UI
A "Deadband override" control on the Rooms settings modal (per the repo's "every API knob needs a UI control" rule). Blank = inherit, with the inherited thermostat value shown as the placeholder. Stored in display units like the other delta fields and submitted as the raw value — the backend converts at the write boundary (no #231 double-conversion).

## Celsius support
Fully handled, end to end:
- Registered as a **`delta_nullable`** temperature field (Python `TEMPERATURE_FIELDS` + TS manifest + parity-test regex), so the backend converts it via `_delta_to_f` (delta math, no −32 offset): e.g. `1 °C → 1.8 °F`.
- Stored and broadcast in °F; the frontend renders via `toDisplayDelta` and the form holds display units, submitting the raw value.
- Validation bound (0–10 °F) and the form's range check are expressed unit-aware via `toDisplayDelta(10)`.
- Covered by Celsius tests on every layer (see below).

## Test plan
- **Backend**
  - `_effective_deadband` resolver: `None` inherits, a value overrides, `0.0` is honored (not treated as unset).
  - Engine: a wide override suppresses demand for a room inside its band that the thermostat band would flag; a narrow override demands HVAC for a room the thermostat band treats as at-target; filter excludes an opposite-demand room produced by the override.
  - Routes: create/update set + clear (`null`); non-numeric and out-of-range rejected; **Celsius** delta conversion (`1 °C → 1.8 °F`) on create and update.
  - **Upgrade**: legacy room migrates to `None`, inherits the thermostat deadband, re-save preserves `NULL`, fresh install matches.
- **Frontend**
  - Payload carries the raw display value when set and `null` when blank.
  - **Celsius #231 contract**: the PUT body carries the user's raw °C value, not a pre-converted °F.
- **e2e** round-trip carries `deadband_override` under both °F and °C stacks (`// @covers: deadband_override`); temperature-field manifest parity enforced.

### Verification
- Backend: 781 passed, coverage 93.15% (gate 92.5%); ruff format/lint + mypy clean.
- Frontend: 250 passed, prettier clean, `tsc --noEmit` clean.
