### PR TITLE
Fix metric-HA support, MCP startup crash, and WebSocket reconnect leak (#280–#283)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -11,12 +11,12 @@ State machine:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from enum import Enum
+from typing import Any
 
 import aiosqlite
 
@@ -32,6 +32,7 @@ from ..models import (
     ThermostatConfig,
     ZoneStatus,
 )
+from ..units import to_f
 from .room_manager import (
     ActiveRoom,
     OverflowCandidate,
@@ -189,8 +190,14 @@ class CycleEngine:
         if thermo_state:
             hvac_action = thermo_state.get("attributes", {}).get("hvac_action", "unknown")
             hvac_mode = thermo_state.get("state", "unknown")
-            current_temp = thermo_state.get("attributes", {}).get("current_temperature")
-            setpoint = thermo_state.get("attributes", {}).get("temperature")
+            current_temp = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
+            setpoint = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("temperature"),
+                self._ha.ha_temp_unit,
+            )
         else:
             hvac_action = hvac_mode = "unknown"
             current_temp = setpoint = None
@@ -381,9 +388,11 @@ class CycleEngine:
             if inferred == "off":
                 # All rooms within deadband — reset setpoint to ambient so the HVAC
                 # goes idle, then skip starting a new cycle.
-                ambient = thermo_state.get("attributes", {}).get("current_temperature")
-                if ambient is not None:
-                    ambient_f = float(ambient)
+                ambient_f = _climate_temp_to_f(
+                    thermo_state.get("attributes", {}).get("current_temperature"),
+                    self._ha.ha_temp_unit,
+                )
+                if ambient_f is not None:
                     try:
                         await self._ha.set_thermostat_temperature(
                             self.thermostat_entity_id, ambient_f
@@ -445,9 +454,11 @@ class CycleEngine:
                                 "cooling_lockout_below_f": threshold,
                             },
                         )
-                    ambient = thermo_state.get("attributes", {}).get("current_temperature")
-                    if ambient is not None:
-                        ambient_f = float(ambient)
+                    ambient_f = _climate_temp_to_f(
+                        thermo_state.get("attributes", {}).get("current_temperature"),
+                        self._ha.ha_temp_unit,
+                    )
+                    if ambient_f is not None:
                         try:
                             await self._ha.set_thermostat_temperature(
                                 self.thermostat_entity_id, ambient_f
@@ -1281,9 +1292,11 @@ class CycleEngine:
         # means the HVAC satisfies itself immediately and goes idle.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
-            ambient = thermo_state.get("attributes", {}).get("current_temperature")
-            if ambient is not None:
-                ambient_f = float(ambient)
+            ambient_f = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
+            if ambient_f is not None:
                 try:
                     await self._ha.set_thermostat_temperature(
                         self.thermostat_entity_id,
@@ -1452,9 +1465,11 @@ class CycleEngine:
         # this block is skipped — there is nothing to command.
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
-            ambient = thermo_state.get("attributes", {}).get("current_temperature")
-            if ambient is not None:
-                ambient_f = float(ambient)
+            ambient_f = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
+            if ambient_f is not None:
                 try:
                     await self._ha.set_thermostat_temperature(
                         self.thermostat_entity_id,
@@ -1700,10 +1715,10 @@ class CycleEngine:
         # Read thermostat ambient once — used for both the fallback and sanity check.
         thermo_ambient: float | None = None
         if thermo_state:
-            t = thermo_state.get("attributes", {}).get("current_temperature")
-            if t is not None:
-                with contextlib.suppress(ValueError, TypeError):
-                    thermo_ambient = float(t)
+            thermo_ambient = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
 
         needs_cool = 0
         needs_heat = 0
@@ -1809,10 +1824,10 @@ class CycleEngine:
         """
         thermo_ambient: float | None = None
         if thermo_state:
-            t = thermo_state.get("attributes", {}).get("current_temperature")
-            if t is not None:
-                with contextlib.suppress(ValueError, TypeError):
-                    thermo_ambient = float(t)
+            thermo_ambient = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
 
         filtered: dict[str, ActiveRoom] = {}
         for room_id, ar in active_rooms.items():
@@ -1963,22 +1978,21 @@ class CycleEngine:
         return ("allowed", outside)
 
     def _read_thermo_temp_and_setpoint(self) -> tuple[float | None, float | None]:
-        """Read (current_temperature, temperature) from the thermostat state."""
+        """Read (current_temperature, temperature) from the thermostat state, in °F.
+
+        Both attributes are reported in HA's configured system unit; they are
+        normalised to the engine's internal °F via ``_climate_temp_to_f``
+        (Issue #280). Missing/unparseable values come back as ``None``.
+        """
         state = self._ha.get_state(self.thermostat_entity_id)
         if not state:
             return (None, None)
         attrs = state.get("attributes", {})
-        cur = attrs.get("current_temperature")
-        sp = attrs.get("temperature")
-        try:
-            cur_f = float(cur) if cur is not None else None
-        except (ValueError, TypeError):
-            cur_f = None
-        try:
-            sp_f = float(sp) if sp is not None else None
-        except (ValueError, TypeError):
-            sp_f = None
-        return (cur_f, sp_f)
+        unit = self._ha.ha_temp_unit
+        return (
+            _climate_temp_to_f(attrs.get("current_temperature"), unit),
+            _climate_temp_to_f(attrs.get("temperature"), unit),
+        )
 
     def _snapshot_vent_states_json(self, vents: list[RoomVent]) -> str | None:
         if not vents:
@@ -2105,10 +2119,14 @@ class CycleEngine:
         if room.include_thermostat_sensor:
             thermo = self._ha.get_state(room.thermostat_entity_id)
             if thermo:
-                t = thermo.get("attributes", {}).get("current_temperature")
-                if t is not None:
-                    with contextlib.suppress(ValueError, TypeError):
-                        readings.append(float(t))
+                # The thermostat probe reports in HA's system unit; normalise to
+                # °F so it is not mixed with already-°F sensor readings. (#280)
+                t_f = _climate_temp_to_f(
+                    thermo.get("attributes", {}).get("current_temperature"),
+                    self._ha.ha_temp_unit,
+                )
+                if t_f is not None:
+                    readings.append(t_f)
 
         if not readings:
             return None
@@ -2191,10 +2209,14 @@ class CycleEngine:
         # reading by at least overshoot_delta.  (Issue #48 Bug 1)
         thermo_state = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state:
-            ambient_raw = thermo_state.get("attributes", {}).get("current_temperature")
-            if ambient_raw is not None:
+            # Thermostat ambient is reported in HA's system unit; normalise to °F
+            # before comparing against the °F-derived setpoint. (Issue #280)
+            ambient = _climate_temp_to_f(
+                thermo_state.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
+            if ambient is not None:
                 try:
-                    ambient = float(ambient_raw)
                     if hvac_mode == "cooling":
                         ambient_bound = ambient - tc.overshoot_delta
                         if setpoint > ambient_bound:
@@ -2346,7 +2368,10 @@ class CycleEngine:
         # This gives operators a heartbeat to confirm the reconciler is active.
         thermo_state_now = self._ha.get_state(self.thermostat_entity_id) or {}
         ha_mode_now = thermo_state_now.get("state", "unknown")
-        ha_setpoint_now = thermo_state_now.get("attributes", {}).get("temperature")
+        ha_setpoint_now = _climate_temp_to_f(
+            thermo_state_now.get("attributes", {}).get("temperature"),
+            self._ha.ha_temp_unit,
+        )
         log.info(
             "Reconcile %s: engine_state=%s ha_mode=%s ha_setpoint=%s "
             "cycle_ha_mode=%s last_setpoint_sent=%s",
@@ -2503,11 +2528,16 @@ class CycleEngine:
                                 )
                             needs_reassert = True
 
-                    # Re-assert setpoint if it drifted externally.
+                    # Re-assert setpoint if it drifted externally. The HA
+                    # setpoint is in the system unit; normalise to °F so drift is
+                    # not falsely detected on metric installs. (Issue #280)
                     if self._last_setpoint_sent is not None:
-                        current_sp = thermo_state.get("attributes", {}).get("temperature")
+                        current_sp = _climate_temp_to_f(
+                            thermo_state.get("attributes", {}).get("temperature"),
+                            self._ha.ha_temp_unit,
+                        )
                         if current_sp is not None:
-                            drift = abs(float(current_sp) - self._last_setpoint_sent)
+                            drift = abs(current_sp - self._last_setpoint_sent)
                             if drift > 0.1:  # tolerance for float rounding in HA
                                 log.warning(
                                     "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
@@ -2696,10 +2726,14 @@ class CycleEngine:
         # Fix: close the stale cycle and stay IDLE; the next tick infers fresh.
         thermo_state_now = self._ha.get_state(self.thermostat_entity_id)
         if thermo_state_now and self._active_rooms:
-            raw = thermo_state_now.get("attributes", {}).get("current_temperature")
-            if raw is not None:
+            # Thermostat ambient is in HA's system unit; normalise to °F to
+            # compare against the °F room targets. (Issue #280)
+            ambient_now = _climate_temp_to_f(
+                thermo_state_now.get("attributes", {}).get("current_temperature"),
+                self._ha.ha_temp_unit,
+            )
+            if ambient_now is not None:
                 try:
-                    ambient_now = float(raw)
                     all_targets = [ar.target_temp for ar in self._active_rooms.values()]
                     contradicts = (
                         to_restore.mode == "heating" and ambient_now > max(all_targets)
@@ -2816,10 +2850,15 @@ class CycleEngine:
             return
 
         # Single-setpoint mode: turn off unless a bound is breached.
-        current_temp = thermo_state.get("attributes", {}).get("current_temperature")
+        # current_temperature is reported in HA's system unit; normalise to °F so
+        # it compares correctly against the °F min/max setpoints. (Issue #280)
+        current_temp_f = _climate_temp_to_f(
+            thermo_state.get("attributes", {}).get("current_temperature"),
+            self._ha.ha_temp_unit,
+        )
         current_hvac_mode = thermo_state.get("state", "off")
 
-        if current_temp is None:
+        if current_temp_f is None:
             if current_hvac_mode != "off":
                 try:
                     await self._ha.set_thermostat_hvac_mode(self.thermostat_entity_id, "off")
@@ -2830,8 +2869,6 @@ class CycleEngine:
                         exc,
                     )
             return
-
-        current_temp_f = float(current_temp)
 
         if current_temp_f < tc.min_setpoint:
             # Too cold — heat to the minimum bound.
@@ -3274,6 +3311,25 @@ class CycleEngine:
                 except Exception as exc:
                     log.debug("Failed to finalize overflow room state: %s", exc)
         self._overflow_room_states = {}
+
+
+def _climate_temp_to_f(value: Any, unit: str) -> float | None:
+    """Normalise a climate-entity temperature reading to °F.
+
+    Climate entities (``current_temperature``, ``temperature``) report in HA's
+    configured system unit — ``HAClient.ha_temp_unit`` — unlike sensor entities,
+    which the HA client already normalises via their per-entity
+    ``unit_of_measurement``. The engine reasons entirely in °F, so every climate
+    read must pass through here. Returns ``None`` for missing/unparseable
+    values. For an °F install (``unit != "C"``) this is identity beyond a 2dp
+    round, so imperial behaviour is unchanged. (Issue #280)
+    """
+    if value is None:
+        return None
+    try:
+        return to_f(float(value), unit)
+    except (ValueError, TypeError):
+        return None
 
 
 def _effective_deadband(room: Room, thermostat_deadband: float) -> float:

--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -57,6 +57,12 @@ class HAClient:
         self._running = False
         # Cache of entity states: entity_id → state dict
         self._state_cache: dict[str, dict] = {}
+        # HA's configured system temperature unit ("F"/"C"). Climate entities
+        # report and accept temperatures in this unit (unlike sensors, which
+        # carry a per-entity unit_of_measurement). Resolved from /api/config on
+        # connect and refreshed by get_temperature_unit(); defaults to "F" so
+        # imperial installs and pre-connect reads behave unchanged. (Issue #280)
+        self.ha_temp_unit: str = "F"
         # Developer mode: intercept all HA writes and log instead
         self.dev_mode: bool = False
         self._dev_logger: Any | None = None  # EventLogger, set externally
@@ -172,10 +178,18 @@ class HAClient:
         return states
 
     async def get_temperature_unit(self) -> str:
-        """Return 'F' or 'C' based on HA's configured unit_system.
+        """Return 'F' or 'C' based on HA's configured unit system.
 
-        Reads /api/config from HA. 'imperial' → 'F', 'metric' → 'C'.
-        Falls back to 'F' for any unexpected value.
+        Reads ``/api/config`` from HA. HA returns ``unit_system`` as an
+        **object** — e.g. ``{"length": "km", "temperature": "°C", ...}`` — never
+        the bare string ``"metric"``/``"imperial"``. The temperature unit is read
+        from its ``temperature`` member: ``"°C"`` → ``"C"``, anything else
+        (including a missing value or a legacy string shape) → ``"F"``.
+
+        The resolved unit is cached on :attr:`ha_temp_unit` so the climate
+        read/write path can normalise temperatures without a per-call REST hit.
+        (Issue #281 — the previous ``== "metric"`` check never matched the object
+        shape, so auto-detect could never return Celsius.)
         """
         assert self._session is not None
         ws_url = self._ha_url.replace("ws://", "http://").replace("wss://", "https://")
@@ -185,8 +199,24 @@ class HAClient:
         ) as resp:
             resp.raise_for_status()
             cfg = await resp.json()
-        unit_system = cfg.get("unit_system", "imperial")
-        return "C" if unit_system == "metric" else "F"
+        unit_system = cfg.get("unit_system") or {}
+        temp = unit_system.get("temperature") if isinstance(unit_system, dict) else None
+        unit = "C" if temp == "°C" else "F"
+        self.ha_temp_unit = unit
+        return unit
+
+    def _setpoint_to_native(self, value_f: float) -> float:
+        """Convert a stored °F setpoint to the climate entity's native unit.
+
+        Climate entities accept ``temperature`` in HA's configured system unit.
+        On a metric install that is °C, so a stored °F setpoint must be converted
+        back before it is sent to ``climate.set_temperature`` — otherwise HA
+        interprets the raw °F number as °C and drives the HVAC to a wildly wrong
+        target. Identity for °F installs. (Issue #280)
+        """
+        if self.ha_temp_unit == "C":
+            return round((value_f - 32) * 5 / 9, 2)
+        return value_f
 
     async def call_service(
         self,
@@ -210,7 +240,12 @@ class HAClient:
         temperature: float,
         hvac_mode: str | None = None,
     ) -> None:
-        service_data: dict = {"entity_id": entity_id, "temperature": temperature}
+        # Stored setpoints are °F; convert to the climate entity's native unit
+        # (°C on a metric HA) so HA does not misread the number. (Issue #280)
+        service_data: dict = {
+            "entity_id": entity_id,
+            "temperature": self._setpoint_to_native(temperature),
+        }
         if hvac_mode is not None:
             service_data["hvac_mode"] = hvac_mode
         if self.dev_mode:
@@ -277,14 +312,15 @@ class HAClient:
                 )
             return
         log.info("Setting %s range → %.1f–%.1f°F", entity_id, low, high)
+        # Stored bounds are °F; convert to the entity's native unit. (Issue #280)
         await self.call_service(
             "climate",
             "set_temperature",
             {
                 "entity_id": entity_id,
                 "hvac_mode": "heat_cool",
-                "target_temp_low": low,
-                "target_temp_high": high,
+                "target_temp_low": self._setpoint_to_native(low),
+                "target_temp_high": self._setpoint_to_native(high),
             },
         )
 
@@ -400,6 +436,13 @@ class HAClient:
                     await self.fetch_states()
                 except Exception as exc:
                     log.warning("Could not pre-fetch states: %s", exc)
+                # Resolve HA's system temperature unit so the climate read/write
+                # path can normalise to °F, independent of the display-unit
+                # override that may pin the UI to a different unit. (Issue #280)
+                try:
+                    await self.get_temperature_unit()
+                except Exception as exc:
+                    log.debug("Could not resolve HA temperature unit on connect: %s", exc)
                 await self._subscribe_state_changed()
                 self._connected.set()
                 log.info("HA WebSocket connected and subscribed")

--- a/smart_vent/backend/mcp_server.py
+++ b/smart_vent/backend/mcp_server.py
@@ -26,8 +26,7 @@ import asyncio
 import os
 
 import aiosqlite
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
+from mcp.server.fastmcp import FastMCP
 
 from . import db
 from .main import _migrate_db_filename
@@ -37,9 +36,23 @@ DATA_DIR = os.environ.get("DATA_DIR", "/data")
 DB_PATH = os.path.join(DATA_DIR, "app.db")
 
 
-async def main() -> None:
-    server = Server("plenum")
+def build_server(conn: aiosqlite.Connection) -> FastMCP:
+    """Create the FastMCP server and register every tool module against *conn*.
 
+    Split out from :func:`main` so tests can build and introspect the server
+    (e.g. assert the tools registered) without standing up the stdio transport.
+    """
+    # FastMCP — not the low-level Server — owns the `@server.tool()` decorator
+    # that auto-generates each tool's JSON schema from its type hints. The
+    # low-level Server has no `.tool()` and raised AttributeError at startup,
+    # killing the whole MCP integration before it served a request. (Issue #282)
+    mcp = FastMCP("plenum")
+    for module in (rooms, schedules, thermostats, status, ha_entities):
+        module.register(mcp, conn)
+    return mcp
+
+
+async def main() -> None:
     os.makedirs(DATA_DIR, exist_ok=True)
     _migrate_db_filename(DATA_DIR)
 
@@ -48,14 +61,11 @@ async def main() -> None:
     conn.row_factory = aiosqlite.Row
     await db.init_db(conn)
 
-    # Register all tool modules
-    for module in (rooms, schedules, thermostats, status, ha_entities):
-        module.register(server, conn)
-
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, server.create_initialization_options())
-
-    await conn.close()
+    mcp = build_server(conn)
+    try:
+        await mcp.run_stdio_async()
+    finally:
+        await conn.close()
 
 
 if __name__ == "__main__":

--- a/smart_vent/backend/mcp_tools/ha_entities.py
+++ b/smart_vent/backend/mcp_tools/ha_entities.py
@@ -15,11 +15,11 @@ try:
     _SSL_CONTEXT: ssl.SSLContext | None = ssl.create_default_context(cafile=certifi.where())
 except ImportError:
     _SSL_CONTEXT = None
-from mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 
-def register(server: Server, conn: aiosqlite.Connection) -> None:
+def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
 
     @server.tool()
     async def list_ha_entities(domain: str) -> list[TextContent]:

--- a/smart_vent/backend/mcp_tools/rooms.py
+++ b/smart_vent/backend/mcp_tools/rooms.py
@@ -6,14 +6,14 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import aiosqlite
-from mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from .. import db
 from ..models import Room, RoomOverride, RoomPresenceSensor, RoomSensor, RoomVent
 
 
-def register(server: Server, conn: aiosqlite.Connection) -> None:
+def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
 
     @server.tool()
     async def list_rooms() -> list[TextContent]:

--- a/smart_vent/backend/mcp_tools/schedules.py
+++ b/smart_vent/backend/mcp_tools/schedules.py
@@ -6,14 +6,14 @@ import json
 from datetime import time
 
 import aiosqlite
-from mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from .. import db
 from ..models import Schedule
 
 
-def register(server: Server, conn: aiosqlite.Connection) -> None:
+def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
 
     @server.tool()
     async def list_schedules(room_id: str) -> list[TextContent]:

--- a/smart_vent/backend/mcp_tools/status.py
+++ b/smart_vent/backend/mcp_tools/status.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import json
 
 import aiosqlite
-from mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from .. import db
 
 
-def register(server: Server, conn: aiosqlite.Connection) -> None:
+def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
 
     @server.tool()
     async def get_system_status() -> list[TextContent]:

--- a/smart_vent/backend/mcp_tools/thermostats.py
+++ b/smart_vent/backend/mcp_tools/thermostats.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import json
 
 import aiosqlite
-from mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from .. import db
 
 
-def register(server: Server, conn: aiosqlite.Connection) -> None:
+def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
 
     @server.tool()
     async def list_thermostat_configs() -> list[TextContent]:

--- a/smart_vent/backend/tests/integration/fake_ha.py
+++ b/smart_vent/backend/tests/integration/fake_ha.py
@@ -40,6 +40,10 @@ class FakeHomeAssistant:
         self.calls: list[ServiceCall] = []
         self.dev_mode: bool = False
         self._dev_logger: Any | None = None
+        # HA's configured system temperature unit, mirroring HAClient. Climate
+        # reads/writes in the engine normalise against this. Default "F";
+        # Celsius integration tests set it to "C" and seed °C climate states.
+        self.ha_temp_unit: str = "F"
 
     # ------------------------------------------------------------------
     # Test helpers
@@ -153,8 +157,8 @@ class FakeHomeAssistant:
         return list(self._state.values())
 
     async def get_temperature_unit(self) -> str:
-        """Return the simulated HA temperature unit (always 'F' in tests)."""
-        return "F"
+        """Return the simulated HA system temperature unit (default 'F')."""
+        return self.ha_temp_unit
 
     async def call_service(
         self, domain: str, service: str, service_data: dict | None = None

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -24,6 +24,7 @@ import pytest
 from backend.engine.cycle_engine import (
     CycleEngine,
     CycleState,
+    _climate_temp_to_f,
     _effective_deadband,
     _is_at_target,
 )
@@ -2898,3 +2899,55 @@ class TestDoTickAbortGuards:
         # The vacation hold ran in the same tick.
         engine._ha.set_thermostat_hvac_mode.assert_awaited_once_with(THERMO_ID, "off")
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #280: climate-entity temperatures are reported/accepted in HA's system
+# unit; the engine must normalise them to its internal °F. These exercise a
+# *raw* °C current_temperature rather than pre-converting it in the mock.
+# ---------------------------------------------------------------------------
+
+
+class TestClimateTempToF:
+    def test_none_returns_none(self):
+        assert _climate_temp_to_f(None, "C") is None
+
+    def test_unparseable_returns_none(self):
+        assert _climate_temp_to_f("unavailable", "C") is None
+
+    def test_fahrenheit_is_identity(self):
+        assert _climate_temp_to_f(69.8, "F") == 69.8
+
+    def test_celsius_converts_to_f(self):
+        assert _climate_temp_to_f(21.0, "C") == 69.8
+
+    def test_non_c_unit_treated_as_fahrenheit(self):
+        # A test double / unexpected value that is not the string "C" must not
+        # convert — protects MagicMock-based engine tests where ha_temp_unit is
+        # auto-created and never equals "C".
+        assert _climate_temp_to_f(70.0, MagicMock()) == 70.0
+
+
+class TestMetricClimateReads:
+    def test_read_thermo_temp_normalises_celsius_to_f(self):
+        ha = _make_ha(ambient=21.0)  # thermostat reports 21 in HA's native unit
+        ha.ha_temp_unit = "C"
+        engine = _make_engine(ha)
+        cur, sp = engine._read_thermo_temp_and_setpoint()
+        assert cur == pytest.approx(69.8, abs=0.05)
+        assert sp == pytest.approx(69.8, abs=0.05)
+
+    def test_thermostat_probe_average_consistent_with_celsius(self):
+        # include_thermostat_sensor mixes the thermostat probe with room sensors.
+        # On a metric HA the probe is °C; the sensor (via get_numeric_state) is
+        # already °F. The average must be taken in a single unit (°F).
+        ha = _make_ha(ambient=20.0)  # probe reads 20°C → 68°F
+        ha.ha_temp_unit = "C"
+        ha.get_numeric_state.return_value = 68.0  # a room sensor already in °F
+        engine = _make_engine(ha)
+        room = _make_room()
+        room.include_thermostat_sensor = True
+        engine._sensor_map = {room.id: ["sensor.bedroom"]}
+        avg = engine._get_avg_temp(room)
+        # Both contributions are 68°F → average 68°F, not a °C/°F mash-up.
+        assert avg == pytest.approx(68.0, abs=0.05)

--- a/smart_vent/backend/tests/test_ha_client.py
+++ b/smart_vent/backend/tests/test_ha_client.py
@@ -439,6 +439,30 @@ class TestNonDevMode:
         payload = client._ws.send_json.call_args[0][0]
         assert payload["service_data"]["hvac_mode"] == "cool"
 
+    async def test_set_thermostat_imperial_sends_fahrenheit_unchanged(self):
+        # Default ha_temp_unit is "F" → the stored °F value goes out verbatim.
+        client = _make_auto_resolving_client()
+        await client.set_thermostat_temperature("climate.main", 69.8)
+        payload = client._ws.send_json.call_args[0][0]
+        assert payload["service_data"]["temperature"] == 69.8
+
+    async def test_set_thermostat_metric_converts_to_celsius(self):
+        # On a metric HA the stored °F setpoint must be converted to °C before
+        # it is sent, else HA reads the raw °F number as °C. (Issue #280)
+        client = _make_auto_resolving_client()
+        client.ha_temp_unit = "C"
+        await client.set_thermostat_temperature("climate.main", 69.8)
+        payload = client._ws.send_json.call_args[0][0]
+        assert payload["service_data"]["temperature"] == 21.0  # (69.8-32)*5/9
+
+    async def test_set_thermostat_range_metric_converts_to_celsius(self):
+        client = _make_auto_resolving_client()
+        client.ha_temp_unit = "C"
+        await client.set_thermostat_temperature_range("climate.main", 62.0, 80.0)
+        sd = client._ws.send_json.call_args[0][0]["service_data"]
+        assert sd["target_temp_low"] == round((62.0 - 32) * 5 / 9, 2)
+        assert sd["target_temp_high"] == round((80.0 - 32) * 5 / 9, 2)
+
     async def test_call_service_returns_result(self):
         client = _make_auto_resolving_client()
         result = await client.call_service("cover", "open_cover", {"entity_id": "cover.v1"})

--- a/smart_vent/backend/tests/test_ha_client_internals.py
+++ b/smart_vent/backend/tests/test_ha_client_internals.py
@@ -225,6 +225,7 @@ class TestConnect:
         client._handshake = AsyncMock()
         client._subscribe_state_changed = AsyncMock()
         client.fetch_states = AsyncMock(return_value=[])
+        client.get_temperature_unit = AsyncMock(return_value="F")
 
         async def capturing_read_loop():
             connected_during_read.append(client._connected.is_set())
@@ -256,6 +257,7 @@ class TestConnect:
         client._handshake = AsyncMock()
         client._subscribe_state_changed = AsyncMock()
         client.fetch_states = AsyncMock(side_effect=RuntimeError("http error"))
+        client.get_temperature_unit = AsyncMock(return_value="F")
 
         async def capturing_read_loop():
             connected_during_read.append(client._connected.is_set())
@@ -284,41 +286,52 @@ class TestConnect:
 
 
 class TestGetTemperatureUnit:
-    async def test_imperial_returns_F(self):
+    """HA's /api/config returns ``unit_system`` as an OBJECT, e.g.
+    ``{"length": "km", "temperature": "°C", ...}`` — never the bare string
+    ``"metric"``/``"imperial"``. These fixtures use the real object shape so the
+    parsing is exercised the way HA actually responds. (Issue #281)
+    """
+
+    @staticmethod
+    def _client_with_config(cfg: object) -> HAClient:
         client = HAClient("ws://ha.local", "tok")
         mock_resp = AsyncMock()
         mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_resp.__aexit__ = AsyncMock(return_value=False)
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json = AsyncMock(return_value={"unit_system": "imperial"})
+        mock_resp.json = AsyncMock(return_value=cfg)
         mock_session = MagicMock()
         mock_session.get = MagicMock(return_value=mock_resp)
         client._session = mock_session
+        return client
+
+    async def test_imperial_returns_F(self):
+        client = self._client_with_config({"unit_system": {"temperature": "°F", "length": "mi"}})
         assert await client.get_temperature_unit() == "F"
 
     async def test_metric_returns_C(self):
-        client = HAClient("ws://ha.local", "tok")
-        mock_resp = AsyncMock()
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=False)
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json = AsyncMock(return_value={"unit_system": "metric"})
-        mock_session = MagicMock()
-        mock_session.get = MagicMock(return_value=mock_resp)
-        client._session = mock_session
+        client = self._client_with_config({"unit_system": {"temperature": "°C", "length": "km"}})
         assert await client.get_temperature_unit() == "C"
 
-    async def test_unknown_system_defaults_to_F(self):
-        client = HAClient("ws://ha.local", "tok")
-        mock_resp = AsyncMock()
-        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-        mock_resp.__aexit__ = AsyncMock(return_value=False)
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json = AsyncMock(return_value={"unit_system": "custom_system"})
-        mock_session = MagicMock()
-        mock_session.get = MagicMock(return_value=mock_resp)
-        client._session = mock_session
+    async def test_unknown_temperature_defaults_to_F(self):
+        client = self._client_with_config({"unit_system": {"temperature": "?"}})
         assert await client.get_temperature_unit() == "F"
+
+    async def test_missing_unit_system_defaults_to_F(self):
+        client = self._client_with_config({})
+        assert await client.get_temperature_unit() == "F"
+
+    async def test_legacy_string_shape_defaults_to_F(self):
+        # Defensive: a non-dict unit_system (legacy/misconfigured) must not crash
+        # and falls back to °F rather than mis-detecting.
+        client = self._client_with_config({"unit_system": "metric"})
+        assert await client.get_temperature_unit() == "F"
+
+    async def test_result_is_cached_on_ha_temp_unit(self):
+        client = self._client_with_config({"unit_system": {"temperature": "°C", "length": "km"}})
+        assert client.ha_temp_unit == "F"  # default before resolution
+        await client.get_temperature_unit()
+        assert client.ha_temp_unit == "C"  # cached for the climate read/write path
 
     async def test_wss_url_converted_to_https(self):
         client = HAClient("wss://ha.example.com", "tok")
@@ -327,7 +340,7 @@ class TestGetTemperatureUnit:
         mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
         mock_resp.__aexit__ = AsyncMock(return_value=False)
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json = AsyncMock(return_value={"unit_system": "imperial"})
+        mock_resp.json = AsyncMock(return_value={"unit_system": {"temperature": "°F"}})
 
         def capture_get(url, **kwargs):
             captured_urls.append(url)

--- a/smart_vent/backend/tests/test_mcp_server.py
+++ b/smart_vent/backend/tests/test_mcp_server.py
@@ -1,0 +1,100 @@
+"""Smoke tests for the MCP server (Issue #282).
+
+The MCP integration is excluded from coverage (see ``pyproject.toml``), so
+nothing else imports ``mcp_server`` or actually registers the tools. The
+low-level ``mcp.server.Server`` has no ``@server.tool()`` decorator — only
+``FastMCP`` does — so the previous wiring raised ``AttributeError`` the moment
+the first tool module registered, killing the server before it served a
+request. These tests build the real server and assert every tool registers and
+is callable, so that regression can't slip back in unnoticed.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+from mcp.server.fastmcp import FastMCP
+
+from backend import db
+from backend.mcp_server import build_server
+
+# The full set of tools every tool module is expected to register. If a tool is
+# added/removed/renamed, update this set deliberately.
+EXPECTED_TOOLS = {
+    # rooms.py
+    "list_rooms",
+    "get_room",
+    "create_room",
+    "update_room",
+    "delete_room",
+    "add_sensor",
+    "remove_sensor",
+    "add_vent",
+    "remove_vent",
+    "add_presence_sensor",
+    "remove_presence_sensor",
+    "set_room_override",
+    "clear_room_override",
+    # schedules.py
+    "list_schedules",
+    "create_schedule",
+    "update_schedule",
+    "delete_schedule",
+    # thermostats.py
+    "list_thermostat_configs",
+    "set_thermostat_config",
+    # status.py
+    "get_system_status",
+    "get_cycle_logs",
+    # ha_entities.py
+    "list_ha_entities",
+}
+
+
+class TestMcpServerBuild:
+    async def test_build_server_registers_all_tools(self):
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+        try:
+            server = build_server(conn)
+            assert isinstance(server, FastMCP)
+
+            tools = await server.list_tools()
+            names = {t.name for t in tools}
+            assert names == EXPECTED_TOOLS
+
+            # FastMCP auto-generates an object input schema from each tool's
+            # type hints — the capability the low-level Server lacked.
+            for t in tools:
+                assert t.inputSchema.get("type") == "object"
+        finally:
+            await conn.close()
+
+    async def test_create_argument_schema_is_generated(self):
+        """create_room's schema must reflect its typed parameters."""
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+        try:
+            server = build_server(conn)
+            tools = {t.name: t for t in await server.list_tools()}
+            props = tools["create_room"].inputSchema.get("properties", {})
+            assert "name" in props
+            assert "thermostat_entity_id" in props
+        finally:
+            await conn.close()
+
+    async def test_list_rooms_tool_is_callable(self):
+        """A read tool round-trips through FastMCP.call_tool and returns text."""
+        conn = await aiosqlite.connect(":memory:")
+        conn.row_factory = aiosqlite.Row
+        await db.init_db(conn)
+        try:
+            server = build_server(conn)
+            content, _structured = await server.call_tool("list_rooms", {})
+            assert content
+            assert content[0].type == "text"
+            # Empty DB → an empty JSON array of rooms.
+            assert content[0].text.strip() == "[]"
+        finally:
+            await conn.close()

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -794,6 +794,23 @@ class TestStartupResolveUnit:
         finally:
             await sched.stop()
 
+    async def test_blank_env_var_does_not_lock_and_auto_detects(self, tmp_path):
+        # run.sh exports TEMPERATURE_UNIT="" when the add-on option is left blank
+        # ("leave blank to auto-detect"). An empty string must behave like unset
+        # — auto-detect from HA — not be treated as an override lock to °F.
+        # (Issue #281 root cause 2)
+        fake_ha = FakeHomeAssistant()
+        fake_ha.ha_temp_unit = "C"  # a metric Home Assistant
+        sched = Scheduler(ha=fake_ha, db_path=str(tmp_path / "blank.db"))
+        with patch.dict(os.environ, {"TEMPERATURE_UNIT": ""}):
+            await sched.start()
+        try:
+            assert sched._unit_override == ""  # blank is not a lock
+            await asyncio.sleep(0.05)  # let _startup_resolve_unit run
+            assert sched.get_temperature_unit() == "C"  # resolved from HA, not °F
+        finally:
+            await sched.stop()
+
     async def test_ha_failure_does_not_crash(self, tmp_path):
         fake_ha = FakeHomeAssistant()
         fake_ha.get_temperature_unit = AsyncMock(side_effect=RuntimeError("HA down"))

--- a/smart_vent/frontend/src/api.test.ts
+++ b/smart_vent/frontend/src/api.test.ts
@@ -754,9 +754,10 @@ describe("API Client", () => {
     });
   });
 
-  it("connectWS sets up WebSocket connection", () => {
+  it("connectWS reconnects while live but not after an intentional dispose", () => {
     let messageHandler: (e: { data: string }) => void = () => {};
     let closeHandler: () => void = () => {};
+    let constructCount = 0;
 
     const mockWS = {
       addEventListener: vi.fn((event: string, handler: (e: { data: string }) => void) => {
@@ -769,6 +770,7 @@ describe("API Client", () => {
     vi.stubGlobal(
       "WebSocket",
       vi.fn(function () {
+        constructCount += 1;
         return mockWS;
       })
     );
@@ -779,25 +781,30 @@ describe("API Client", () => {
       const callback = vi.fn();
       const cleanup = api.connectWS(callback);
 
+      expect(constructCount).toBe(1);
       expect(mockWS.addEventListener).toHaveBeenCalledWith("message", expect.any(Function));
       expect(mockWS.addEventListener).toHaveBeenCalledWith("close", expect.any(Function));
 
-      // Test message receipt
+      // Message receipt
       messageHandler({ data: JSON.stringify({ type: "test", data: {} }) });
       expect(callback).toHaveBeenCalledWith({ type: "test", data: {} });
 
-      // Test malformed message
+      // Malformed messages are ignored
       messageHandler({ data: "not json" });
       expect(callback).toHaveBeenCalledTimes(1);
 
-      // Test reconnect on close
+      // An unexpected close while still live reconnects after 3s
       closeHandler();
       vi.advanceTimersByTime(3000);
-      // Should have called connectWS again (which calls addEventListener again)
-      expect(mockWS.addEventListener).toHaveBeenCalledTimes(4); // 2 more for reconnect
+      expect(constructCount).toBe(2);
 
+      // After dispose, the socket is closed AND a subsequent close event must
+      // NOT spawn a replacement — otherwise zombie sockets accumulate. (#283)
       cleanup();
       expect(mockWS.close).toHaveBeenCalled();
+      closeHandler();
+      vi.advanceTimersByTime(10000);
+      expect(constructCount).toBe(2);
     } finally {
       vi.useRealTimers();
       vi.unstubAllGlobals();

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -839,20 +839,40 @@ export type WSHandler = (event: WSEvent) => void;
 
 export function connectWS(onMessage: WSHandler): () => void {
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  const ws = new WebSocket(`${proto}//${location.host}${BASE}/ws`);
+  const url = `${proto}//${location.host}${BASE}/ws`;
 
-  ws.addEventListener("message", (e) => {
-    try {
-      onMessage(JSON.parse(e.data));
-    } catch {
-      // ignore malformed messages
-    }
-  });
+  // Track liveness in the closure so an intentional dispose stops the auto
+  // reconnect. The old version returned `() => ws.close()`, but closing the
+  // socket fired the `close` listener which *unconditionally* scheduled a new
+  // connectWS() — whose disposer was discarded, so it reconnected forever.
+  // Each Dashboard visit / Logs filter change leaked a zombie socket that kept
+  // re-running its handler (duplicated requests, duplicated feed rows). (#283)
+  let closed = false;
+  let ws: WebSocket;
 
-  ws.addEventListener("close", () => {
-    // Reconnect after 3 seconds
-    setTimeout(() => connectWS(onMessage), 3000);
-  });
+  const open = () => {
+    ws = new WebSocket(url);
 
-  return () => ws.close();
+    ws.addEventListener("message", (e) => {
+      try {
+        onMessage(JSON.parse(e.data));
+      } catch {
+        // ignore malformed messages
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      // Only reconnect if the caller has not disposed this connection.
+      if (!closed) {
+        setTimeout(open, 3000);
+      }
+    });
+  };
+
+  open();
+
+  return () => {
+    closed = true;
+    ws.close();
+  };
 }

--- a/smart_vent/run.sh
+++ b/smart_vent/run.sh
@@ -38,7 +38,11 @@ HA_TOKEN_CFG=$(get_config 'ha_token' '')
 USE_WSS=$(get_config 'use_wss' 'false')
 SSL_VERIFY=$(get_config 'ssl_verify' 'true')
 TIMEZONE=$(get_config 'timezone' 'UTC')
-TEMPERATURE_UNIT=$(get_config 'temperature_unit' 'F')
+# Default to EMPTY (not 'F') so a blank add-on option means "auto-detect from
+# Home Assistant". An empty TEMPERATURE_UNIT lets the backend resolve the unit
+# from HA's /api/config and the last-known DB value; exporting 'F' here would be
+# treated as a hard override lock in the scheduler, defeating auto-detect. (#281)
+TEMPERATURE_UNIT=$(get_config 'temperature_unit' '')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #280, #281, #282, #283 — the four HIGH-severity findings from the logic audit.

## #280 — Engine read/wrote climate temperatures without °C↔°F normalization
Climate entities report **and accept** temperatures in HA's configured *system* unit, unlike sensors (which carry a per-entity `unit_of_measurement` the HA client already normalizes). The engine treated `current_temperature` / `temperature` as raw °F and sent stored-°F setpoints straight to `climate.set_temperature`. On a metric HA that means:
- A thermostat reporting `21` (°C) was read as "21 °F" — corrupting mode inference, the ambient sanity-check, `include_thermostat_sensor` averaging, ambient clamping, and the cooling-lockout comparison.
- A `69.8` °F setpoint was sent and interpreted by HA as **69.8 °C** → a real runaway-heating hazard.

**Fix:** `HAClient` resolves and caches HA's system unit as `ha_temp_unit` (from `/api/config`, on connect). Outgoing setpoints/ranges are converted to the entity's native unit at the write boundary (`_setpoint_to_native`), and every engine climate read is normalized to °F via the new `_climate_temp_to_f(value, unit)` helper. **Imperial installs are unchanged** — the conversion is identity when `ha_temp_unit == "F"`, and the helper is MagicMock-safe (a unit attribute that isn't the string `"C"` is treated as °F).

## #281 — Temperature-unit auto-detection could never return Celsius (two root causes)
1. `get_temperature_unit()` compared `unit_system` against the string `"metric"`, but HA returns it as an **object** `{"temperature": "°C", …}`, so it always returned `"F"`. Now reads `unit_system["temperature"]` (`"°C"` → `"C"`), with a defensive `isinstance` guard for legacy/misconfigured shapes.
2. `run.sh` defaulted a blank `temperature_unit` option to `'F'`, which the scheduler treats as a hard override **lock** (so "leave blank to auto-detect" actually pinned °F forever). Now defaults to `''`, so blank flows through as auto-detect.

## #282 — MCP server crashed at startup
`mcp_server.py` used the low-level `mcp.server.Server`, which has **no `@server.tool()` decorator** (that belongs to `FastMCP`) — the first registration raised `AttributeError` and the integration never served a request. Migrated `mcp_server.py` and all five tool modules to `FastMCP`, running via `run_stdio_async()`. Registration is now split into `build_server(conn)` so it can be tested.

## #283 — `connectWS` reconnected after an intentional close
The returned disposer only closed the *current* socket; closing it fired the `close` listener, which **unconditionally** scheduled a new `connectWS` whose disposer was discarded — reconnecting forever. Each Dashboard visit / Logs filter change leaked a zombie socket that re-issued requests and duplicated live-feed rows. Liveness is now tracked in the closure so disposing stops the auto-reconnect.

## Test plan
All green locally (Python 3.12 venv, Node 22):

- **Backend** — `pytest backend/tests/` → **798 passed**, coverage **93.25%** (≥ 92.5% gate); `ruff check` + `ruff format --check` clean; `mypy backend/` clean.
- **Frontend** — `vitest run` → **251 passed**; `eslint` 0 errors; `prettier --check` clean; `test:coverage` thresholds pass.

New/updated tests:
- `get_temperature_unit` fixtures rebuilt to HA's real **object** `unit_system` shape, plus caching + legacy-string-shape defense (#281).
- °C write-conversion tests for `set_thermostat_temperature` / `_range`, and raw-°C engine read tests (`_read_thermo_temp_and_setpoint`, `include_thermostat_sensor` averaging) that exercise a real °C `current_temperature` rather than pre-converting it in the mock (#280).
- Scheduler test that a **blank** `TEMPERATURE_UNIT` auto-detects from HA instead of locking to °F (#281).
- MCP build/registration + callable smoke test (`test_mcp_server.py`) so the dead-import can't regress (#282).
- `connectWS` test asserting reconnect-while-live **and** no-reconnect-after-dispose (#283).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YF7iUiofZSnbzTzHVo71QP)_