### PR TITLE
Convert MCP write-tool temperatures from display unit to °F (#284)

### DIFF
--- a/smart_vent/backend/mcp_tools/_units.py
+++ b/smart_vent/backend/mcp_tools/_units.py
@@ -1,0 +1,52 @@
+"""Temperature-unit handling for MCP write tools (Issue #284).
+
+The MCP server runs as its own process with no live ``Scheduler``, so it cannot
+call ``scheduler.get_temperature_unit()`` the way the REST handlers do. Instead
+the active *display* unit is read from the persisted
+``system_settings.temperature_unit`` row, which the add-on's scheduler writes on
+startup and whenever HA's unit changes.
+
+MCP temperature inputs are interpreted in that unit — mirroring the REST write
+boundary and the UI — and converted to the internal °F storage representation
+via the shared :mod:`backend.units` helpers, exactly as ``routes.py`` does with
+``_to_f`` / ``_delta_to_f``. Storing the raw value (the previous behaviour) would
+record "21" as 21 °F (≈ −6 °C) in a Celsius household — the same data-corruption
+class as the #231 double-conversion bug.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from .. import db
+from ..units import from_f, from_f_delta
+
+
+async def active_unit(conn: aiosqlite.Connection) -> str:
+    """Return the active display unit ('F' or 'C').
+
+    Persisted by the scheduler in ``system_settings``; defaults to 'F' (so a
+    fresh DB or an imperial install converts as identity, unchanged behaviour).
+    """
+    return await db.get_system_setting(conn, "temperature_unit", "F")
+
+
+def echo_abs(value_f: float, unit: str) -> str:
+    """Echo a stored absolute °F temperature in the active unit for tool output.
+
+    e.g. ``"21.0°C (69.8°F stored)"`` in Celsius, ``"70.0°F"`` in Fahrenheit.
+    """
+    if unit == "C":
+        return f"{from_f(value_f, 'C')}°C ({value_f}°F stored)"
+    return f"{value_f}°F"
+
+
+def echo_delta(value_f: float, unit: str) -> str:
+    """Echo a stored °F delta (deadband/overshoot) in the active unit.
+
+    Deltas scale without the 32° offset, so ``echo_delta`` uses ``from_f_delta``.
+    e.g. ``"1.1°C (2.0°F stored)"`` in Celsius, ``"2.0°F"`` in Fahrenheit.
+    """
+    if unit == "C":
+        return f"{from_f_delta(value_f, 'C')}°C ({value_f}°F stored)"
+    return f"{value_f}°F"

--- a/smart_vent/backend/mcp_tools/rooms.py
+++ b/smart_vent/backend/mcp_tools/rooms.py
@@ -11,6 +11,8 @@ from mcp.types import TextContent
 
 from .. import db
 from ..models import Room, RoomOverride, RoomPresenceSensor, RoomSensor, RoomVent
+from ..units import to_f
+from ._units import active_unit, echo_abs
 
 
 def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
@@ -71,17 +73,26 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         include_thermostat_sensor: bool = False,
         notes: str = "",
     ) -> list[TextContent]:
-        """Create a new room."""
+        """Create a new room.
+
+        system_wide_temp: fixed target in the configured display unit (°C/°F),
+        stored as °F. Omit to follow schedules instead of a fixed target.
+        """
+        unit = await active_unit(conn)
+        sys_temp_f = to_f(system_wide_temp, unit) if system_wide_temp is not None else None
         room = Room.create(
             name=name,
             thermostat_entity_id=thermostat_entity_id,
-            system_wide_temp=system_wide_temp,
+            system_wide_temp=sys_temp_f,
             presence_holdover_hours=presence_holdover_hours,
             include_thermostat_sensor=include_thermostat_sensor,
             notes=notes,
         )
         await db.upsert_room(conn, room)
-        return [TextContent(type="text", text=f"Created room '{name}' with id={room.id}")]
+        suffix = (
+            f" (system_wide_temp {echo_abs(sys_temp_f, unit)})" if sys_temp_f is not None else ""
+        )
+        return [TextContent(type="text", text=f"Created room '{name}' with id={room.id}{suffix}")]
 
     @server.tool()
     async def update_room(
@@ -93,7 +104,11 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         include_thermostat_sensor: bool | None = None,
         notes: str | None = None,
     ) -> list[TextContent]:
-        """Update fields on an existing room."""
+        """Update fields on an existing room.
+
+        system_wide_temp is given in the configured display unit (°C/°F) and
+        stored as °F.
+        """
         room = await db.get_room(conn, room_id)
         if not room:
             return [TextContent(type="text", text=f"Room {room_id} not found")]
@@ -102,7 +117,7 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         if thermostat_entity_id is not None:
             room.thermostat_entity_id = thermostat_entity_id
         if system_wide_temp is not None:
-            room.system_wide_temp = system_wide_temp
+            room.system_wide_temp = to_f(system_wide_temp, await active_unit(conn))
         if presence_holdover_hours is not None:
             room.presence_holdover_hours = presence_holdover_hours
         if include_thermostat_sensor is not None:
@@ -163,18 +178,24 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
     async def set_room_override(
         room_id: str, target_temp: float, duration_hours: float = 2.0
     ) -> list[TextContent]:
-        """Set a manual temperature override for a room."""
+        """Set a manual temperature override for a room.
+
+        target_temp is given in the configured display unit (°C/°F) and stored
+        as °F, matching the UI and the REST API.
+        """
+        unit = await active_unit(conn)
+        target_f = to_f(target_temp, unit)
         override = RoomOverride(
             room_id=room_id,
-            target_temp=target_temp,
+            target_temp=target_f,
             expires_at=datetime.now(UTC) + timedelta(hours=duration_hours),
         )
         await db.set_room_override(conn, override)
         return [
             TextContent(
                 type="text",
-                text=f"Override set: room {room_id} → {target_temp}°F for {duration_hours}h "
-                f"(expires {override.expires_at.isoformat()})",
+                text=f"Override set: room {room_id} → {echo_abs(target_f, unit)} "
+                f"for {duration_hours}h (expires {override.expires_at.isoformat()})",
             )
         ]
 

--- a/smart_vent/backend/mcp_tools/schedules.py
+++ b/smart_vent/backend/mcp_tools/schedules.py
@@ -11,6 +11,8 @@ from mcp.types import TextContent
 
 from .. import db
 from ..models import Schedule
+from ..units import to_f
+from ._units import active_unit, echo_abs
 
 
 def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
@@ -44,21 +46,24 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         Create a schedule block for a room.
         days_of_week: list of ints 0–6 (0=Monday, 6=Sunday)
         start_time / end_time: 'HH:MM' format
-        target_temp: target temperature in °F
+        target_temp: target temperature in the configured display unit (°C/°F),
+          stored as °F (same convention as the UI and the REST API).
         """
+        unit = await active_unit(conn)
+        target_f = to_f(target_temp, unit)
         s = Schedule.create(
             room_id=room_id,
             days_of_week=days_of_week,
             start_time=time.fromisoformat(start_time),
             end_time=time.fromisoformat(end_time),
-            target_temp=target_temp,
+            target_temp=target_f,
         )
         await db.upsert_schedule(conn, s)
         return [
             TextContent(
                 type="text",
                 text=f"Created schedule {s.id} for room {room_id}: "
-                f"days={days_of_week} {start_time}–{end_time} @ {target_temp}°F",
+                f"days={days_of_week} {start_time}–{end_time} @ {echo_abs(target_f, unit)}",
             )
         ]
 
@@ -71,7 +76,10 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         end_time: str | None = None,
         target_temp: float | None = None,
     ) -> list[TextContent]:
-        """Update an existing schedule block. room_id is required to locate the schedule."""
+        """Update an existing schedule block. room_id is required to locate the schedule.
+
+        target_temp is given in the configured display unit (°C/°F), stored as °F.
+        """
         schedules = await db.get_schedules_for_room(conn, room_id)
         s = next((x for x in schedules if x.id == schedule_id), None)
         if not s:
@@ -83,7 +91,7 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         if end_time is not None:
             s.end_time = time.fromisoformat(end_time)
         if target_temp is not None:
-            s.target_temp = target_temp
+            s.target_temp = to_f(target_temp, await active_unit(conn))
         await db.upsert_schedule(conn, s)
         return [TextContent(type="text", text=f"Updated schedule {schedule_id}")]
 

--- a/smart_vent/backend/mcp_tools/thermostats.py
+++ b/smart_vent/backend/mcp_tools/thermostats.py
@@ -9,6 +9,8 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 from .. import db
+from ..units import delta_to_f, to_f
+from ._units import active_unit, echo_abs, echo_delta
 
 
 def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
@@ -33,32 +35,43 @@ def register(server: FastMCP, conn: aiosqlite.Connection) -> None:
         """
         Configure safety limits for a thermostat zone.
 
-        min_setpoint / max_setpoint: absolute setpoint bounds (°F)
-        deadband: ±°F tolerance to consider a room 'at target' (0 = exact match)
+        Temperatures are given in the configured display unit (°C/°F) and stored
+        as °F, matching the UI and the REST API.
+
+        min_setpoint / max_setpoint: absolute setpoint bounds (display unit)
+        deadband: ± tolerance (delta, display unit) to consider a room 'at target'
         max_vent_closed_min: reopen vents after N minutes closed (0 = disabled, for bypass dampers)
         min_open_vents: always keep at least N vents open (0 = allow all closed)
-        overshoot_delta: how far past target to set thermostat to drive the HVAC (default 2°F)
+        overshoot_delta: how far past target to set thermostat to drive the HVAC
+          (delta, display unit; default 2°F)
         cycle_timeout_hours: abort a cycle after N hours (default 3)
         """
+        unit = await active_unit(conn)
         tc = await db.get_thermostat_config(conn, thermostat_entity_id)
+        changed: list[str] = []
         if min_setpoint is not None:
-            tc.min_setpoint = min_setpoint
+            tc.min_setpoint = to_f(min_setpoint, unit)
+            changed.append(f"min_setpoint={echo_abs(tc.min_setpoint, unit)}")
         if max_setpoint is not None:
-            tc.max_setpoint = max_setpoint
+            tc.max_setpoint = to_f(max_setpoint, unit)
+            changed.append(f"max_setpoint={echo_abs(tc.max_setpoint, unit)}")
         if deadband is not None:
-            tc.deadband = deadband
+            tc.deadband = delta_to_f(deadband, unit)
+            changed.append(f"deadband={echo_delta(tc.deadband, unit)}")
         if max_vent_closed_min is not None:
             tc.max_vent_closed_min = max_vent_closed_min
         if min_open_vents is not None:
             tc.min_open_vents = min_open_vents
         if overshoot_delta is not None:
-            tc.overshoot_delta = overshoot_delta
+            tc.overshoot_delta = delta_to_f(overshoot_delta, unit)
+            changed.append(f"overshoot_delta={echo_delta(tc.overshoot_delta, unit)}")
         if cycle_timeout_hours is not None:
             tc.cycle_timeout_hours = cycle_timeout_hours
         await db.upsert_thermostat_config(conn, tc)
+        temp_note = f" ({', '.join(changed)})" if changed else ""
         return [
             TextContent(
                 type="text",
-                text=f"Updated config for {thermostat_entity_id}: {tc.__dict__}",
+                text=f"Updated config for {thermostat_entity_id}{temp_note}: {tc.__dict__}",
             )
         ]

--- a/smart_vent/backend/tests/test_mcp_server.py
+++ b/smart_vent/backend/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ from mcp.server.fastmcp import FastMCP
 
 from backend import db
 from backend.mcp_server import build_server
+from backend.models import Room
 
 # The full set of tools every tool module is expected to register. If a tool is
 # added/removed/renamed, update this set deliberately.
@@ -96,5 +97,136 @@ class TestMcpServerBuild:
             assert content[0].type == "text"
             # Empty DB → an empty JSON array of rooms.
             assert content[0].text.strip() == "[]"
+        finally:
+            await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #284: MCP write tools must convert temperature inputs from the active
+# display unit to °F storage, mirroring the REST write boundary. The MCP process
+# has no Scheduler, so the unit comes from system_settings.temperature_unit.
+# ---------------------------------------------------------------------------
+
+
+async def _conn_with_unit(unit: str) -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    await db.set_system_setting(conn, "temperature_unit", unit)
+    return conn
+
+
+async def _seed_room(conn: aiosqlite.Connection) -> Room:
+    room = Room.create(name="Bedroom", thermostat_entity_id="climate.x")
+    await db.upsert_room(conn, room)
+    return room
+
+
+class TestMcpTemperatureConversion:
+    async def test_create_room_converts_system_wide_temp_from_celsius(self):
+        conn = await _conn_with_unit("C")
+        try:
+            server = build_server(conn)
+            await server.call_tool(
+                "create_room",
+                {"name": "Bedroom", "thermostat_entity_id": "climate.x", "system_wide_temp": 21.0},
+            )
+            rooms = await db.get_all_rooms(conn)
+            assert len(rooms) == 1
+            assert rooms[0].system_wide_temp == 69.8  # 21°C → 69.8°F
+        finally:
+            await conn.close()
+
+    async def test_create_room_fahrenheit_is_identity(self):
+        conn = await _conn_with_unit("F")
+        try:
+            server = build_server(conn)
+            await server.call_tool(
+                "create_room",
+                {"name": "Den", "thermostat_entity_id": "climate.x", "system_wide_temp": 70.0},
+            )
+            rooms = await db.get_all_rooms(conn)
+            assert rooms[0].system_wide_temp == 70.0
+        finally:
+            await conn.close()
+
+    async def test_update_room_converts_system_wide_temp_from_celsius(self):
+        conn = await _conn_with_unit("C")
+        try:
+            room = await _seed_room(conn)
+            server = build_server(conn)
+            await server.call_tool("update_room", {"room_id": room.id, "system_wide_temp": 21.0})
+            updated = await db.get_room(conn, room.id)
+            assert updated is not None
+            assert updated.system_wide_temp == 69.8
+        finally:
+            await conn.close()
+
+    async def test_set_room_override_converts_target_from_celsius(self):
+        conn = await _conn_with_unit("C")
+        try:
+            room = await _seed_room(conn)
+            server = build_server(conn)
+            await server.call_tool("set_room_override", {"room_id": room.id, "target_temp": 21.0})
+            ov = await db.get_room_override(conn, room.id)
+            assert ov is not None
+            assert ov.target_temp == 69.8
+        finally:
+            await conn.close()
+
+    async def test_create_schedule_converts_target_from_celsius(self):
+        conn = await _conn_with_unit("C")
+        try:
+            room = await _seed_room(conn)
+            server = build_server(conn)
+            await server.call_tool(
+                "create_schedule",
+                {
+                    "room_id": room.id,
+                    "days_of_week": [0, 1, 2],
+                    "start_time": "08:00",
+                    "end_time": "22:00",
+                    "target_temp": 21.0,
+                },
+            )
+            scheds = await db.get_schedules_for_room(conn, room.id)
+            assert len(scheds) == 1
+            assert scheds[0].target_temp == 69.8
+        finally:
+            await conn.close()
+
+    async def test_set_thermostat_config_converts_absolute_and_delta(self):
+        conn = await _conn_with_unit("C")
+        try:
+            server = build_server(conn)
+            await server.call_tool(
+                "set_thermostat_config",
+                {
+                    "thermostat_entity_id": "climate.x",
+                    "min_setpoint": 16.0,
+                    "max_setpoint": 27.0,
+                    "deadband": 1.0,
+                    "overshoot_delta": 2.0,
+                },
+            )
+            tc = await db.get_thermostat_config(conn, "climate.x")
+            assert tc.min_setpoint == 60.8  # 16°C → 60.8°F (absolute)
+            assert tc.max_setpoint == 80.6  # 27°C → 80.6°F (absolute)
+            assert tc.deadband == 1.8  # 1°C delta → 1.8°F (no 32° offset)
+            assert tc.overshoot_delta == 3.6  # 2°C delta → 3.6°F
+        finally:
+            await conn.close()
+
+    async def test_set_thermostat_config_fahrenheit_is_identity(self):
+        conn = await _conn_with_unit("F")
+        try:
+            server = build_server(conn)
+            await server.call_tool(
+                "set_thermostat_config",
+                {"thermostat_entity_id": "climate.y", "min_setpoint": 60.0, "deadband": 2.0},
+            )
+            tc = await db.get_thermostat_config(conn, "climate.y")
+            assert tc.min_setpoint == 60.0
+            assert tc.deadband == 2.0
         finally:
             await conn.close()


### PR DESCRIPTION
Fixes #284.

## Problem
Every REST write endpoint converts temperature fields at the boundary via `_to_f` / `_delta_to_f` (using the active unit), but the MCP tools wrote the **raw** input straight into the °F-storage DB with no unit handling. In a Celsius household an agent mirroring the UI ("set the bedroom to 21") stored **21 °F (≈ −6 °C)** — the same data-corruption class as the #231 double-conversion bug. The `create_room`/`update_room` (`system_wide_temp`) and `set_room_override` (`target_temp`) params didn't even carry a unit annotation.

(This was blocked by #282 — the MCP server didn't start at all — which is now fixed on `main` via #306.)

## Fix
The MCP server runs as its own process with **no live `Scheduler`**, so it can't call `scheduler.get_temperature_unit()`. New helper `mcp_tools/_units.py` reads the active display unit from the persisted `system_settings.temperature_unit` row (written by the add-on's scheduler) and routes inputs through the shared `units.to_f` / `units.delta_to_f`, exactly as `routes.py` does:

- **`rooms.py`** — `create_room`/`update_room` `system_wide_temp` (absolute), `set_room_override` `target_temp` (absolute)
- **`schedules.py`** — `create_schedule`/`update_schedule` `target_temp` (absolute)
- **`thermostats.py`** — `set_thermostat_config` `min_setpoint`/`max_setpoint` (absolute), `deadband`/`overshoot_delta` (delta — scaled, **no** 32° offset)

Temperature params are now documented as "the configured display unit (°C/°F), stored as °F", and tool responses echo both units (e.g. `21.0°C (69.8°F stored)`). The unit defaults to `"F"`, so imperial installs and a fresh DB convert as identity — **no behaviour change for °F users**.

Absolute vs delta is respected: `deadband`/`overshoot_delta` use `delta_to_f` (e.g. `1 °C → 1.8 °F`), not the absolute path that would wrongly add 32°.

## Test plan
All green locally (Python 3.12 venv):
- **`pytest backend/tests/`** → **805 passed**, coverage **93.25%** (≥ 92.5% gate); `ruff check` + `ruff format --check` clean; `mypy backend/` clean.

New `TestMcpTemperatureConversion` (in `test_mcp_server.py`) drives each write tool through `FastMCP.call_tool` under a **Celsius** unit and asserts the converted °F value persisted in the DB, plus °F-identity cases for `create_room` and `set_thermostat_config`:
- `create_room` / `update_room` `system_wide_temp`: 21 °C → 69.8 °F
- `set_room_override` `target_temp`: 21 °C → 69.8 °F
- `create_schedule` `target_temp`: 21 °C → 69.8 °F
- `set_thermostat_config`: `min_setpoint` 16 °C → 60.8 °F, `max_setpoint` 27 °C → 80.6 °F, `deadband` 1 °C → 1.8 °F, `overshoot_delta` 2 °C → 3.6 °F

## Notes
The MCP write boundary is deliberately **not** added to the REST `TEMPERATURE_FIELDS` parity manifest — that manifest enforces the REST/UI/E2E contract (each `ui: true` field needs an `@covers` E2E tag), and MCP tools aren't UI fields. The new in-process tests guard the MCP path instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YF7iUiofZSnbzTzHVo71QP)_