### PR TITLE
Abort in-flight cycle when a thermostat's engine is removed (#285)

### DIFF
--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -399,6 +399,28 @@ class Scheduler:
 
         for tid in list(self._engines):
             if tid not in thermostat_ids:
+                # The thermostat's last room was removed. Abort any in-flight
+                # cycle first — otherwise the HA thermostat keeps the engine's
+                # overshoot setpoint (HVAC runs on), vents stay in their cycle
+                # positions, and the open cycle_log row is never closed, showing
+                # a permanently "Active" cycle. The _reset_and_reevaluate orphan
+                # safety net can't catch this engine because it only scans
+                # engines still in the map. Abort + close before del. (#285)
+                eng = self._engines[tid]
+                try:
+                    await eng.force_abort(self._db_conn, reason="thermostat removed")
+                except Exception as exc:
+                    log.error("force_abort failed while removing engine %s: %s", tid, exc)
+                try:
+                    closed = await db.close_open_cycle_logs(self._db_conn, tid)
+                    if closed:
+                        log.warning(
+                            "Closed %d orphaned cycle log(s) for removed thermostat %s",
+                            closed,
+                            tid,
+                        )
+                except Exception as exc:
+                    log.error("Cycle-log cleanup failed while removing engine %s: %s", tid, exc)
                 del self._engines[tid]
                 log.info("CycleEngine removed for %s", tid)
 

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -123,6 +123,54 @@ class TestSyncEngines:
         await conn.close()
 
     @pytest.mark.asyncio
+    async def test_removed_engine_with_running_cycle_is_aborted(self):
+        """Removing a thermostat's last room must abort its in-flight cycle —
+        otherwise the HA thermostat keeps the overshoot setpoint. (Issue #285)"""
+        from backend.engine.cycle_engine import CycleState
+
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        engine = sched._engines[THERMO_A]
+        engine._state = CycleState.RUNNING
+        engine.force_abort = AsyncMock()
+
+        await db.delete_room(conn, "r1")
+        await sched._sync_engines()
+
+        engine.force_abort.assert_called_once()
+        assert engine.force_abort.call_args.kwargs.get("reason")
+        assert THERMO_A not in sched._engines
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_removed_engine_closes_open_cycle_log(self):
+        """A removed thermostat's open cycle_log must be closed so it doesn't
+        show as a permanently 'Active' cycle in the UI/metrics. (Issue #285)"""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        await _insert_open_cycle(conn, THERMO_A)
+        assert await db.get_open_cycle_logs(conn, THERMO_A)  # open before removal
+
+        await db.delete_room(conn, "r1")
+        await sched._sync_engines()
+
+        assert await db.get_open_cycle_logs(conn, THERMO_A) == []  # closed on removal
+        assert THERMO_A not in sched._engines
+        await conn.close()
+
+    @pytest.mark.asyncio
     async def test_idempotent_sync(self):
         """Running _sync_engines twice with same rooms doesn't duplicate."""
         ha = _make_ha()


### PR DESCRIPTION
Fixes #285.

## Problem
When the last room referencing a thermostat is deleted (`routes.py` → `refresh()` → `refresh_engines()` → `_sync_engines()`), the engine was dropped from `self._engines` with **no `force_abort()` and no `close_open_cycle_logs()`**:

```python
for tid in list(self._engines):
    if tid not in thermostat_ids:
        del self._engines[tid]
        log.info("CycleEngine removed for %s", tid)
```

If a cycle was ACTIVE at that moment:
- the HA thermostat kept the engine's overshoot setpoint indefinitely (HVAC keeps running toward it),
- vents stayed in their cycle positions (some closed),
- the open `cycle_log` row (`ended_at IS NULL`) was never closed, so the UI/metrics showed a permanently **"Active"** cycle. The `_reset_and_reevaluate` orphan-closing safety net can't catch it — it only iterates engines still in `self._engines`.

## Fix
`_sync_engines` now aborts and closes out the cycle **before** deleting the engine, mirroring `_reset_and_reevaluate`:

```python
await eng.force_abort(self._db_conn, reason="thermostat removed")
await db.close_open_cycle_logs(self._db_conn, tid)
del self._engines[tid]
```

Both steps are best-effort (wrapped in try/except and logged) so that a failure to abort still removes the stale engine from the map rather than leaving it orphaned.

## Test plan
All green locally (Python 3.12 venv): **`pytest backend/tests/`** → **807 passed**, coverage **93.18%** (≥ 92.5% gate); `ruff check` + `ruff format --check` clean; `mypy backend/` clean.

New tests in `TestSyncEngines`:
- `test_removed_engine_with_running_cycle_is_aborted` — an engine in `RUNNING` state gets `force_abort(reason=...)` invoked on removal, and is dropped from the map.
- `test_removed_engine_closes_open_cycle_log` — an open `cycle_log` for the removed thermostat is closed (`get_open_cycle_logs` empty afterward), exercising the safety-net path independent of in-memory engine state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YF7iUiofZSnbzTzHVo71QP)_