### PR TITLE
Retry transient _tick_engine failures instead of silently dropping the zone (#286)

### DIFF
--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -28,6 +28,13 @@ log = logging.getLogger(__name__)
 
 BroadcastFn = Callable[[str, dict], Coroutine]
 
+# A single engine tick is retried a few times before giving up, so a transient
+# failure — most likely `sqlite3.OperationalError: database is locked` while the
+# MCP server briefly holds a write lock on the shared DB file — doesn't silently
+# drop a whole 60s control cycle for the zone. (Issue #286)
+_TICK_MAX_ATTEMPTS = 3
+_TICK_RETRY_BACKOFF_S = 0.2
+
 
 class Scheduler:
     def __init__(
@@ -490,26 +497,51 @@ class Scheduler:
         await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _tick_engine(self, tid: str, engine: CycleEngine) -> None:
-        rooms = await db.get_rooms_for_thermostat(self._db_conn, tid)
-        await engine.load_room_sensors(self._db_conn, [r.id for r in rooms])
-        try:
-            await engine.tick(self._db_conn)
-        except Exception as exc:
-            log.exception("Tick error for %s: %s", tid, exc)
-            # Mirror to event logger so the UI Live Feed surfaces tick crashes
-            # (vent service errors, HA unavailability, anything else). Without
-            # this, errors only land in container logs and the user has no way
-            # to notice from inside the app.
-            if self._event_logger:
-                try:
-                    await self._event_logger.log(
-                        "error",
-                        "engine",
-                        f"Tick error for {tid}: {exc}",
-                        {"thermostat": tid, "error": str(exc)},
+        # The whole body — the pre-tick DB reads AND the tick — runs under the
+        # retry loop. Previously the reads sat outside the try/except, so a
+        # transient failure there propagated into _tick_all's
+        # gather(return_exceptions=True) and was discarded with zero log output,
+        # silently leaving the zone uncontrolled. Retry a few times (transient
+        # locks clear in milliseconds) before giving up and surfacing the error
+        # to container logs and the UI Live Feed. (Issue #286)
+        for attempt in range(1, _TICK_MAX_ATTEMPTS + 1):
+            try:
+                rooms = await db.get_rooms_for_thermostat(self._db_conn, tid)
+                await engine.load_room_sensors(self._db_conn, [r.id for r in rooms])
+                await engine.tick(self._db_conn)
+                return
+            except Exception as exc:
+                if attempt < _TICK_MAX_ATTEMPTS:
+                    log.warning(
+                        "Tick attempt %d/%d failed for %s: %s — retrying",
+                        attempt,
+                        _TICK_MAX_ATTEMPTS,
+                        tid,
+                        exc,
                     )
-                except Exception:
-                    log.exception("Failed to write tick error to event logger for %s", tid)
+                    await asyncio.sleep(_TICK_RETRY_BACKOFF_S * attempt)
+                    continue
+                # Retries exhausted — log loudly and mirror to the event logger
+                # so the UI Live Feed surfaces tick crashes (vent service errors,
+                # HA unavailability, DB locks, anything else). Without this,
+                # errors only land in container logs and the user has no way to
+                # notice from inside the app.
+                log.exception(
+                    "Tick failed for %s after %d attempts: %s",
+                    tid,
+                    _TICK_MAX_ATTEMPTS,
+                    exc,
+                )
+                if self._event_logger:
+                    try:
+                        await self._event_logger.log(
+                            "error",
+                            "engine",
+                            f"Tick failed for {tid} after {_TICK_MAX_ATTEMPTS} attempts: {exc}",
+                            {"thermostat": tid, "error": str(exc), "attempts": _TICK_MAX_ATTEMPTS},
+                        )
+                    except Exception:
+                        log.exception("Failed to write tick error to event logger for %s", tid)
 
     # ------------------------------------------------------------------
     # HA state change dispatch

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -24,7 +24,7 @@ import pytest
 
 from backend import db
 from backend.models import Room
-from backend.scheduler import Scheduler
+from backend.scheduler import _TICK_MAX_ATTEMPTS, Scheduler
 
 from .integration.fake_ha import FakeHomeAssistant
 
@@ -716,13 +716,90 @@ class TestTickEngine:
         engine.load_room_sensors = AsyncMock()
         engine.tick = AsyncMock(side_effect=RuntimeError("set_cover_position failed"))
 
-        await sched._tick_engine(THERMO_A, engine)
+        with patch("asyncio.sleep", AsyncMock()):  # skip retry backoff
+            await sched._tick_engine(THERMO_A, engine)
 
         events = await db.get_event_logs(conn, category="engine", limit=10)
-        tick_errors = [e for e in events if e["level"] == "error" and "Tick error" in e["message"]]
+        tick_errors = [e for e in events if e["level"] == "error" and "Tick failed" in e["message"]]
         assert len(tick_errors) == 1
         assert THERMO_A in tick_errors[0]["message"]
         assert "set_cover_position failed" in tick_errors[0]["message"]
+        # Logged only once, after all retries are exhausted — not per attempt.
+        assert engine.tick.await_count == _TICK_MAX_ATTEMPTS
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_pretick_db_error_is_retried_then_recovers(self):
+        """A transient pre-tick failure (e.g. 'database is locked') must be
+        retried, not silently dropped — the zone keeps being controlled. The
+        pre-tick reads used to sit outside the try, so the exception vanished
+        into _tick_all's gather(return_exceptions=True). (Issue #286)"""
+        ha = _make_ha()
+        sched = _make_scheduler(ha)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        engine = sched._engines[THERMO_A]
+        engine.load_room_sensors = AsyncMock()
+        engine.tick = AsyncMock()
+
+        real_get_rooms = db.get_rooms_for_thermostat
+        calls = {"n": 0}
+
+        async def flaky_get_rooms(c, tid):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("database is locked")
+            return await real_get_rooms(c, tid)
+
+        with (
+            patch("asyncio.sleep", AsyncMock()),
+            patch.object(db, "get_rooms_for_thermostat", flaky_get_rooms),
+        ):
+            await sched._tick_engine(THERMO_A, engine)
+
+        assert calls["n"] == 2  # failed once, retried and succeeded
+        engine.tick.assert_awaited_once_with(conn)
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_pretick_db_error_exhausts_retries_and_logs(self):
+        """A persistent pre-tick failure surfaces to the Live Feed after the
+        retries are exhausted, rather than being swallowed silently. (#286)"""
+        from backend.event_logger import EventLogger
+
+        ha = _make_ha()
+        event_logger = EventLogger()
+        sched = Scheduler(ha=ha, db_path=":memory:", event_logger=event_logger)
+        conn = await _setup_db()
+        sched._db_conn = conn
+        event_logger.set_conn(conn)
+        sched._vent_ctrl = MagicMock()
+
+        await _insert_room(conn, "r1", "Room 1", THERMO_A)
+        await sched._sync_engines()
+        engine = sched._engines[THERMO_A]
+        engine.load_room_sensors = AsyncMock()
+        engine.tick = AsyncMock()
+
+        async def always_locked(c, tid):
+            raise RuntimeError("database is locked")
+
+        with (
+            patch("asyncio.sleep", AsyncMock()),
+            patch.object(db, "get_rooms_for_thermostat", always_locked),
+        ):
+            await sched._tick_engine(THERMO_A, engine)  # must not raise
+
+        engine.tick.assert_not_awaited()  # pre-tick read never succeeded
+        events = await db.get_event_logs(conn, category="engine", limit=10)
+        tick_errors = [e for e in events if e["level"] == "error" and "Tick failed" in e["message"]]
+        assert len(tick_errors) == 1
+        assert "database is locked" in tick_errors[0]["message"]
+        assert f"after {_TICK_MAX_ATTEMPTS} attempts" in tick_errors[0]["message"]
         await conn.close()
 
 


### PR DESCRIPTION
Fixes #286.

## Problem
In `_tick_engine`, the pre-tick DB reads sat **outside** the `try/except` — only `engine.tick()` was guarded:

```python
async def _tick_engine(self, tid, engine):
    rooms = await db.get_rooms_for_thermostat(self._db_conn, tid)        # OUTSIDE try
    await engine.load_room_sensors(self._db_conn, [r.id for r in rooms])  # OUTSIDE try
    try:
        await engine.tick(self._db_conn)
    except Exception as exc:
        log.exception(...)
```

If `get_rooms_for_thermostat` or `load_room_sensors` raised — e.g. `sqlite3.OperationalError: database is locked`, more likely now the MCP server (#282/#284) is a second writer on the shared DB file — the exception propagated into `_tick_all`'s `asyncio.gather(..., return_exceptions=True)`, whose result is **discarded**. The zone silently stopped being controlled with zero log output and nothing in the Live Feed.

## Fix
The whole body now runs inside a **bounded retry loop** (`_TICK_MAX_ATTEMPTS = 3`, short escalating backoff). Transient locks clear in milliseconds, so a retry recovers the cycle rather than dropping it for a full 60s. Only after the retries are exhausted does it `log.exception()` and mirror a single `"Tick failed … after N attempts"` error to the event logger so the UI Live Feed surfaces it. A successful attempt returns immediately.

This matches the requested approach: a `try/catch` that retries a few times before giving up and logging. The engine is designed to be ticked repeatedly (every 60s and on every state change), so re-running a tick on a transient failure is safe.

## Test plan
All green locally (Python 3.12 venv): **`pytest backend/tests/`** → **807 passed**, coverage **93.26%** (≥ 92.5% gate); `ruff check` + `ruff format --check` clean; `mypy backend/` clean.

New/updated tests in `TestTickEngine`:
- `test_pretick_db_error_is_retried_then_recovers` — a pre-tick `database is locked` that clears on the 2nd attempt still reaches `engine.tick` (zone stays controlled).
- `test_pretick_db_error_exhausts_retries_and_logs` — a persistent pre-tick failure logs a single error to the event logger and does **not** propagate; `engine.tick` is never reached.
- `test_tick_exception_written_to_event_logger` updated for the new message and asserts the error is logged once after `_TICK_MAX_ATTEMPTS` attempts (not per attempt). Retry backoff is patched out so the tests stay fast.

## Note
Branched off `main`; independent of PR #309 (#285) — that change is in `_sync_engines`, this one is in `_tick_engine`, so they don't conflict.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YF7iUiofZSnbzTzHVo71QP)_