### PR TITLE
Fix event_log trim off-by-one that drops oldest row below cap (#299)

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -2236,7 +2236,7 @@ async def insert_event_log(
     # Periodic trim — avoid subquery overhead on every insert
     if rowid and rowid % _TRIM_EVERY == 0:
         await conn.execute(
-            """DELETE FROM event_log WHERE id <= (
+            """DELETE FROM event_log WHERE id < (
                 SELECT MIN(id) FROM (
                     SELECT id FROM event_log ORDER BY id DESC LIMIT ?
                 )

--- a/smart_vent/backend/tests/test_event_log_trim.py
+++ b/smart_vent/backend/tests/test_event_log_trim.py
@@ -1,0 +1,58 @@
+"""
+Tests for the event_log periodic trim in backend/db.insert_event_log (Issue #299).
+
+The trim must:
+  * never delete rows while the table is below _EVENT_LOG_MAX, and
+  * settle at exactly _EVENT_LOG_MAX rows in steady state (not _EVENT_LOG_MAX - 1).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from backend import db
+
+
+async def _fresh_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _count(conn: aiosqlite.Connection) -> int:
+    async with conn.execute("SELECT COUNT(*) AS c FROM event_log") as cur:
+        row = await cur.fetchone()
+    return int(row["c"])
+
+
+class TestEventLogTrim:
+    async def test_below_cap_does_not_drop_rows(self, monkeypatch) -> None:
+        # Trim fires on every insert; cap far above the number we insert, so the
+        # table is always under the cap and nothing should ever be deleted.
+        monkeypatch.setattr(db, "_TRIM_EVERY", 1)
+        monkeypatch.setattr(db, "_EVENT_LOG_MAX", 1000)
+        conn = await _fresh_db()
+        try:
+            for i in range(10):
+                await db.insert_event_log(
+                    conn, f"2026-01-01T00:00:{i:02d}", "info", "system", f"m{i}", None
+                )
+            assert await _count(conn) == 10
+        finally:
+            await conn.close()
+
+    async def test_steady_state_keeps_exactly_cap_rows(self, monkeypatch) -> None:
+        # With the cap reached, the table should settle at exactly the cap,
+        # not cap - 1 (the off-by-one from `id <=`).
+        monkeypatch.setattr(db, "_TRIM_EVERY", 1)
+        monkeypatch.setattr(db, "_EVENT_LOG_MAX", 5)
+        conn = await _fresh_db()
+        try:
+            for i in range(20):
+                await db.insert_event_log(
+                    conn, "2026-01-01T00:00:00", "info", "system", f"m{i}", None
+                )
+            assert await _count(conn) == 5
+        finally:
+            await conn.close()

--- a/smart_vent/backend/tests/test_event_log_trim.py
+++ b/smart_vent/backend/tests/test_event_log_trim.py
@@ -23,6 +23,7 @@ async def _fresh_db() -> aiosqlite.Connection:
 async def _count(conn: aiosqlite.Connection) -> int:
     async with conn.execute("SELECT COUNT(*) AS c FROM event_log") as cur:
         row = await cur.fetchone()
+    assert row is not None
     return int(row["c"])
 
 


### PR DESCRIPTION
## What & why

Fixes #299.

The periodic `event_log` trim in `insert_event_log` (`backend/db.py`) used `id <=` against `MIN(id)` of the newest `_EVENT_LOG_MAX` rows:

```sql
DELETE FROM event_log WHERE id <= (
    SELECT MIN(id) FROM (SELECT id FROM event_log ORDER BY id DESC LIMIT ?)
)
```

`MIN(id)` of the newest N rows is the oldest row of the **kept** set, so `id <=` deleted it too:

- At/above the cap it kept `_EVENT_LOG_MAX - 1` rows instead of `_EVENT_LOG_MAX`.
- **Below the cap** the subquery returns every row, `MIN(id)` is simply the oldest event, and the statement deleted it — so a quiet install silently lost its oldest event-log entry on every `_TRIM_EVERY`-th insert, forever, even though the cap is never reached.

## Fix

Change `id <=` to `id <`. Below the cap the delete now matches nothing; at steady state the table settles at exactly `_EVENT_LOG_MAX` rows.

## Test plan

Added `backend/tests/test_event_log_trim.py` (TDD — written failing first, against a real in-memory SQLite via `init_db`):

- `test_below_cap_does_not_drop_rows` — with the trim firing on every insert and the cap far above the row count, no row is ever deleted.
- `test_steady_state_keeps_exactly_cap_rows` — once the cap is reached, the table holds exactly `_EVENT_LOG_MAX` rows (not cap − 1).

Both failed before the change and pass after.

- Full backend suite: 811 passed, coverage 93.24% (≥ 92.5% threshold).
- `ruff check` / `ruff format --check`: clean.
- `mypy backend/ --ignore-missing-imports`: clean (a follow-up commit guards the test helper's `fetchone()` result against `None` to satisfy mypy).