### PR TITLE
Gate per-room time-to-target on in-range cycle join (#289)

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -2027,7 +2027,7 @@ async def compute_room_metrics(
                 THEN (julianday(COALESCE(rcs.vent_closed_at, cl.ended_at)) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0 END), 0)) AS INTEGER) AS heating_seconds,
             CAST(ROUND(COALESCE(SUM(CASE WHEN cl.mode='cooling'
                 THEN (julianday(COALESCE(rcs.vent_closed_at, cl.ended_at)) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0 END), 0)) AS INTEGER) AS cooling_seconds,
-            AVG(CASE WHEN rcs.reached_at IS NOT NULL
+            AVG(CASE WHEN cl.id IS NOT NULL AND rcs.reached_at IS NOT NULL
                 THEN (julianday(rcs.reached_at) - julianday(COALESCE(rcs.joined_at, cl.started_at))) * 86400.0 END) AS avg_time_to_target_seconds
         FROM rooms r
         LEFT JOIN room_cycle_states rcs ON rcs.room_id = r.id

--- a/smart_vent/backend/tests/integration/test_metrics_phase2.py
+++ b/smart_vent/backend/tests/integration/test_metrics_phase2.py
@@ -360,6 +360,75 @@ class TestRoomMetrics:
         assert r["avg_time_to_target_seconds"] == pytest.approx(15 * 60.0)
 
     @pytest.mark.asyncio
+    async def test_avg_time_to_target_excludes_out_of_range_cycles(
+        self, client, today_iso, today_dt
+    ):
+        """Issue #289: a room_cycle_states row whose parent cycle falls outside
+        the selected date range must not leak into avg_time_to_target_seconds.
+
+        The date-range/thermostat filters live in the LEFT JOIN ... ON clause,
+        so an out-of-range rcs row survives with cl.* = NULL. Because the row
+        carries its own joined_at, COALESCE(rcs.joined_at, cl.started_at)
+        resolves even when cl is NULL, so the average must be gated on the join
+        actually succeeding (cl.id IS NOT NULL)."""
+        conn = await _conn(client)
+        room = Room(id="room1", name="Bedroom", thermostat_entity_id=THERMO_A)
+        await db.upsert_room(conn, room)
+
+        # In-range cycle today: reached target after 15 minutes.
+        await _seed_cycle(
+            conn,
+            cycle_id="inrange",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="inrange",
+                room_id=room.id,
+                target_temp=72.0,
+                joined_at=today_dt,
+                reached_at=today_dt + timedelta(minutes=15),
+                vent_closed_at=today_dt + timedelta(minutes=15),
+            ),
+        )
+
+        # Out-of-range cycle 10 days ago with its own joined_at/reached_at — must
+        # be excluded entirely from the today-only window.
+        old_dt = today_dt - timedelta(days=10)
+        await _seed_cycle(
+            conn,
+            cycle_id="outofrange",
+            started_at=old_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="outofrange",
+                room_id=room.id,
+                target_temp=72.0,
+                joined_at=old_dt,
+                reached_at=old_dt + timedelta(minutes=3),
+                vent_closed_at=old_dt + timedelta(minutes=3),
+            ),
+        )
+
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/rooms?start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        assert len(body["rooms"]) == 1
+        r = body["rooms"][0]
+        # Only the in-range 15-minute participation counts; the 3-minute
+        # out-of-range cycle must not drag the average down to 9 minutes.
+        assert r["participation_count"] == 1
+        assert r["avg_time_to_target_seconds"] == pytest.approx(15 * 60.0)
+
+    @pytest.mark.asyncio
     async def test_overflow_rooms_excluded_from_room_metrics(self, client, today_iso, today_dt):
         """Issue #254: overflow room_cycle_states rows must not inflate
         per-room participation or heating/cooling time."""


### PR DESCRIPTION
## What & why

Fixes #289.

`compute_room_metrics` (`backend/db.py`) puts the date-range and thermostat filters in the `LEFT JOIN cycle_logs cl ON …` clause. An `room_cycle_states` row whose parent cycle is outside the selected window (or belongs to a thermostat the room used to be on) therefore survives the join with `cl.*` = NULL.

The other aggregates are safe because they gate on `cl.mode` / `cl.id IS NOT NULL`, but `avg_time_to_target_seconds` only checked `rcs.reached_at IS NOT NULL`. For a room that joined mid-cycle (`joined_at` set — a normal engine path), `COALESCE(rcs.joined_at, cl.started_at)` resolves to `joined_at` even when `cl` is NULL, so out-of-range participations leaked into the average. Effect: every per-room metrics query mixed all-time joined-room data into the selected window.

## Fix

Gate the CASE on the join succeeding:

```sql
AVG(CASE WHEN cl.id IS NOT NULL AND rcs.reached_at IS NOT NULL THEN … END)
```

## Test plan

Added `test_avg_time_to_target_excludes_out_of_range_cycles` to `TestRoomMetrics` (TDD — failing first): seeds one in-range cycle (reached target after 15 min) and one cycle 10 days earlier (reached after 3 min), both with `joined_at`/`reached_at` set, then queries a today-only window. Before the fix the average was dragged to 9 min; after the fix it is exactly 15 min and `participation_count` stays 1.

- Full backend suite: 810 passed, coverage 93.20%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_