### PR TITLE
Apply overshoot histogram thermostat fallback per (cycle, room) (#290)

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -1928,6 +1928,7 @@ async def compute_overshoot_histogram(
     sql = f"""
         SELECT cl.id AS cycle_id, cl.mode,
                rcs.room_id, rcs.target_temp,
+               s.room_id AS sample_room_id,
                s.room_temp, s.thermostat_temp
         FROM cycle_logs cl
         JOIN room_cycle_states rcs ON rcs.cycle_id = cl.id
@@ -1939,7 +1940,12 @@ async def compute_overshoot_histogram(
     async with conn.execute(sql, params) as cur:
         rows = await cur.fetchall()
 
-    # Walk samples, tracking per-(cycle_id, room_id) extremes.
+    # Walk samples, tracking per-(cycle_id, room_id) extremes. Room-level samples
+    # (the join's `s.room_id = rcs.room_id` arm) and thermostat-level samples
+    # (the `s.room_id IS NULL` arm) are tracked separately so the thermostat-level
+    # fallback is applied per (cycle, room): a room's overshoot is computed from
+    # its own samples whenever it has any, and only falls back to thermostat-level
+    # samples when it produced no room-level temperature (Issue #290).
     extremes: dict[tuple[str, str], dict] = {}
     for r in rows:
         key = (r["cycle_id"], r["room_id"])
@@ -1948,18 +1954,29 @@ async def compute_overshoot_histogram(
             {
                 "mode": r["mode"],
                 "target": float(r["target_temp"]),
-                "min_temp": None,
-                "max_temp": None,
+                "room_min": None,
+                "room_max": None,
+                "thermo_min": None,
+                "thermo_max": None,
             },
         )
-        temp = r["room_temp"] if r["room_temp"] is not None else r["thermostat_temp"]
+        if r["sample_room_id"] is not None:
+            # Room-level sample: prefer the room temperature, falling back to the
+            # thermostat reading captured in the same row when the room sensor was
+            # unavailable at that tick.
+            temp = r["room_temp"] if r["room_temp"] is not None else r["thermostat_temp"]
+            lo_key, hi_key = "room_min", "room_max"
+        else:
+            # Thermostat-level sample (room_id IS NULL): fallback only.
+            temp = r["thermostat_temp"]
+            lo_key, hi_key = "thermo_min", "thermo_max"
         if temp is None:
             continue
         t = float(temp)
-        if ext["min_temp"] is None or t < ext["min_temp"]:
-            ext["min_temp"] = t
-        if ext["max_temp"] is None or t > ext["max_temp"]:
-            ext["max_temp"] = t
+        if ext[lo_key] is None or t < ext[lo_key]:
+            ext[lo_key] = t
+        if ext[hi_key] is None or t > ext[hi_key]:
+            ext[hi_key] = t
 
     bins = [0] * max_bins
     overshoots: list[float] = []
@@ -1967,10 +1984,16 @@ async def compute_overshoot_histogram(
     overshot = 0
     for ext in extremes.values():
         target = ext["target"]
-        if ext["mode"] == "cooling" and ext["min_temp"] is not None:
-            os = max(target - ext["min_temp"], 0.0)
-        elif ext["mode"] == "heating" and ext["max_temp"] is not None:
-            os = max(ext["max_temp"] - target, 0.0)
+        # Prefer room-level extremes; fall back to thermostat-level samples only
+        # for rooms that produced no room-level temperature.
+        if ext["room_min"] is not None or ext["room_max"] is not None:
+            min_temp, max_temp = ext["room_min"], ext["room_max"]
+        else:
+            min_temp, max_temp = ext["thermo_min"], ext["thermo_max"]
+        if ext["mode"] == "cooling" and min_temp is not None:
+            os = max(target - min_temp, 0.0)
+        elif ext["mode"] == "heating" and max_temp is not None:
+            os = max(max_temp - target, 0.0)
         else:
             continue
         overshoots.append(os)

--- a/smart_vent/backend/tests/integration/test_metrics_phase2.py
+++ b/smart_vent/backend/tests/integration/test_metrics_phase2.py
@@ -316,6 +316,99 @@ class TestPhase4BackendAdditions:
         assert body["max_overshoot_f"] == pytest.approx(2.0)
         assert body["overshot_count"] == 1
 
+    @pytest.mark.asyncio
+    async def test_overshoot_histogram_room_level_not_contaminated_by_thermostat(
+        self, client, today_iso, today_dt
+    ):
+        """Issue #290: a room that has its own room-level samples must not pick up
+        thermostat-level (room_id IS NULL) samples in its overshoot extremes.
+
+        Here the bedroom never dropped below its 72°F target (room_temp stayed at
+        72), so its overshoot is 0. A thermostat-level sample reads 70°F (2°F below
+        target). The old join (s.room_id = rcs.room_id OR s.room_id IS NULL) folded
+        that thermostat reading into every room, registering a phantom 2°F overshoot
+        for the bedroom. The fallback must be per-(cycle, room): thermostat-level
+        samples apply only to rooms with no room-level temperature."""
+        conn = await _conn(client)
+        await db.upsert_room(
+            conn, Room(id="bedroom", name="Bedroom", thermostat_entity_id=THERMO_A)
+        )
+        await _seed_cycle(
+            conn,
+            cycle_id="oh290",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="oh290",
+                room_id="bedroom",
+                target_temp=72.0,
+                joined_at=today_dt,
+                reached_at=today_dt + timedelta(minutes=10),
+            ),
+        )
+        # Room-level sample: bedroom held exactly at target → no overshoot.
+        await db.insert_cycle_temp_sample(
+            conn, "oh290", "bedroom", today_dt + timedelta(minutes=12), 72.0, 70.0, 72.0
+        )
+        # Thermostat-level sample 2°F below target — must NOT count for the bedroom.
+        await db.insert_cycle_temp_sample(
+            conn, "oh290", None, today_dt + timedelta(minutes=12), None, 70.0, 72.0
+        )
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/overshoot-histogram"
+            f"?start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        # The bedroom participated with zero overshoot — it lands in the [0,1)
+        # bucket, not the [2,3) bucket the thermostat contamination would have hit.
+        assert body["total_room_cycles"] == 1
+        assert body["overshot_count"] == 0
+        assert body["max_overshoot_f"] == pytest.approx(0.0)
+        assert body["counts"][2] == 0
+
+    @pytest.mark.asyncio
+    async def test_overshoot_histogram_thermostat_fallback_when_no_room_samples(
+        self, client, today_iso, today_dt
+    ):
+        """Issue #290: a room with NO room-level samples still falls back to the
+        thermostat-level samples (the documented behaviour is preserved)."""
+        conn = await _conn(client)
+        await db.upsert_room(
+            conn, Room(id="noroom", name="NoSensor", thermostat_entity_id=THERMO_A)
+        )
+        await _seed_cycle(
+            conn,
+            cycle_id="oh290b",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+            mode="cooling",
+        )
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id="oh290b",
+                room_id="noroom",
+                target_temp=72.0,
+                joined_at=today_dt,
+                reached_at=today_dt + timedelta(minutes=10),
+            ),
+        )
+        # Only a thermostat-level sample exists (room had no usable sensor).
+        await db.insert_cycle_temp_sample(
+            conn, "oh290b", None, today_dt + timedelta(minutes=12), None, 70.0, 72.0
+        )
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/overshoot-histogram"
+            f"?start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        assert body["overshot_count"] == 1
+        assert body["max_overshoot_f"] == pytest.approx(2.0)
+
 
 class TestRoomMetrics:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Fixes #290.

`compute_overshoot_histogram` (`backend/db.py`) joins `cycle_temp_samples` with `AND (s.room_id = rcs.room_id OR s.room_id IS NULL)` and then, per row, used `room_temp` falling back to `thermostat_temp`. The docstring says room-level samples are used, "falling back to thermostat-level," but the join unconditionally pulled thermostat-level samples (`s.room_id IS NULL`) into **every** room's extremes — even rooms that have their own samples. So a room's per-(cycle, room) min/max tracked the union of room temps and thermostat temps, and any zone whose thermostat reads colder/hotter than the room got a phantom overshoot.

## Fix

Track room-level and thermostat-level extremes **separately** per (cycle, room), distinguished by `s.room_id AS sample_room_id`:

- Room-level samples (`sample_room_id IS NOT NULL`) keep the existing within-row `room_temp` → `thermostat_temp` fallback (handles a room sensor being briefly unavailable at a tick).
- Thermostat-level samples (`room_id IS NULL`) feed a separate fallback bucket.

When computing the overshoot, a room uses its own room-level extremes whenever it produced any, and only falls back to thermostat-level samples when it had no room-level temperature at all — exactly the documented behaviour.

## Test plan

TDD — added two tests to `TestPhase4BackendAdditions` (the first written failing first):

- `test_overshoot_histogram_room_level_not_contaminated_by_thermostat` — a bedroom held at target (room_temp 72, target 72) with a thermostat-level sample at 70 °F no longer registers a phantom 2 °F overshoot; `overshot_count` 0, `max_overshoot_f` 0, `counts[2]` 0.
- `test_overshoot_histogram_thermostat_fallback_when_no_room_samples` — a room with **no** room-level samples still falls back to the thermostat-level sample (2 °F overshoot), preserving the documented fallback.

Existing `test_overshoot_histogram` and `test_overflow_rooms_excluded_from_overshoot` still pass.

- Full backend suite: 811 passed, coverage 93.21%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_