### PR TITLE
Preserve role/joined_at on room_cycle_states upsert and stop overflow state leaks (#300)

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -1164,7 +1164,9 @@ async def upsert_room_cycle_state(conn: aiosqlite.Connection, rcs: RoomCycleStat
              reached_at=excluded.reached_at,
              vent_closed_at=excluded.vent_closed_at,
              temp_at_end=excluded.temp_at_end,
-             trigger_detail=COALESCE(excluded.trigger_detail, room_cycle_states.trigger_detail)
+             trigger_detail=COALESCE(excluded.trigger_detail, room_cycle_states.trigger_detail),
+             role=excluded.role,
+             joined_at=COALESCE(room_cycle_states.joined_at, excluded.joined_at)
         """,
         (
             rcs.cycle_id,

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -792,6 +792,14 @@ class CycleEngine:
                 )
                 self._room_cycle_states[room_id] = rcs
                 await db.upsert_room_cycle_state(conn, rcs)
+                # If this room was being held open as overflow, it is now a full
+                # active participant. Evict it from the overflow bookkeeping so
+                # the overflow management / cycle-end finalize don't later
+                # overwrite its active data point with overflow close state
+                # (Issue #300). The DB row's role was just flipped to 'active' by
+                # the upsert above.
+                self._overflow_room_states.pop(room_id, None)
+                self._overflow_room_ids.discard(room_id)
                 # Open vents for newly added room
                 vents = self._room_vents.get(room_id, [])
                 await self._vent.open_room_vents(vents)
@@ -2775,6 +2783,11 @@ class CycleEngine:
                         self._active_rooms = {}
                         self._room_cycle_states = {}
                         self._room_vents = {}
+                        # Overflow bookkeeping was repopulated from DB just above;
+                        # clear it too so a discarded cycle's overflow rooms don't
+                        # leak into the next freshly-started cycle (Issue #300).
+                        self._overflow_room_states = {}
+                        self._overflow_room_ids = set()
                         return
                 except (ValueError, TypeError):
                     pass

--- a/smart_vent/backend/tests/test_cycle_diagnostics.py
+++ b/smart_vent/backend/tests/test_cycle_diagnostics.py
@@ -391,3 +391,67 @@ class TestVentEvents:
         assert any(e.action == "force_reopened_max_closed" for e in events)
 
         await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Overflow room promoted to active (Issue #300)
+# ---------------------------------------------------------------------------
+
+
+class TestOverflowPromotion:
+    @pytest.mark.asyncio
+    async def test_overflow_room_promoted_to_active_is_evicted(self):
+        """A room held open as overflow that then starts demanding HVAC and joins
+        the running cycle must be removed from the overflow bookkeeping, and its
+        DB row's role flipped to 'active' (so the cycle-end finalize can't later
+        overwrite its active data point with overflow close state)."""
+        conn, room = await _setup_db_and_room()
+        # A second room that will start as overflow, then get promoted.
+        ov = Room(id="ov1", name="Overflow", thermostat_entity_id=THERMO_ID)
+        await db.upsert_room(conn, ov)
+        await db.add_room_vent(conn, RoomVent.create(ov.id, "cover.ov1_vent"))
+
+        engine = _make_engine()
+        await engine.load_room_sensors(conn, [room.id, ov.id])
+
+        # Start a cycle with just the active room.
+        await engine._start_or_update_cycle(
+            conn,
+            {room.id: ActiveRoom(room=room, target_temp=72.0, source="schedule")},
+            "cooling",
+        )
+        assert engine.cycle_state == CycleState.RUNNING
+
+        # Simulate ov1 being held open as overflow during a minimum-runtime hold.
+        ov_rcs = RoomCycleState(
+            cycle_id=engine._cycle_log.id,
+            room_id=ov.id,
+            target_temp=70.0,
+            temp_at_start=73.0,
+            joined_at=datetime.now(UTC),
+            role="overflow",
+        )
+        engine._overflow_room_states[ov.id] = ov_rcs
+        engine._overflow_room_ids.add(ov.id)
+        await db.upsert_room_cycle_state(conn, ov_rcs)
+
+        # ov1 now starts demanding and is added to the running cycle.
+        await engine._start_or_update_cycle(
+            conn,
+            {
+                room.id: ActiveRoom(room=room, target_temp=72.0, source="schedule"),
+                ov.id: ActiveRoom(room=ov, target_temp=70.0, source="schedule"),
+            },
+            "cooling",
+        )
+
+        # Evicted from the in-memory overflow tracking.
+        assert ov.id not in engine._overflow_room_states
+        assert ov.id not in engine._overflow_room_ids
+        # And it is a normal active participant now.
+        assert ov.id in engine._room_cycle_states
+        states = await db.get_room_cycle_states(conn, engine._cycle_log.id)
+        ov_state = next(s for s in states if s.room_id == ov.id)
+        assert ov_state.role == "active"
+
+        await conn.close()

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -2398,6 +2398,51 @@ class TestRestoreFromDb:
         assert remaining == []
         await conn.close()
 
+    @pytest.mark.asyncio
+    async def test_discard_clears_overflow_state(self):
+        """Issue #300: when a restored cycle is discarded as stale, the overflow
+        bookkeeping repopulated from the DB must be cleared too, so it does not
+        leak into the next freshly-started cycle."""
+        from backend import db
+
+        conn = await self._fresh_db()
+        await db.upsert_thermostat_config(conn, _make_tc())
+        room = Room.create(name="Test Room", thermostat_entity_id=THERMO_ID)
+        room.id = "r1"
+        await db.upsert_room(conn, room)
+        overflow_room = Room.create(name="Overflow", thermostat_entity_id=THERMO_ID)
+        overflow_room.id = "ov1"
+        await db.upsert_room(conn, overflow_room)
+
+        # Persisted HEATING cycle targeting 74, but ambient now 80 → discard path.
+        rooms_json = json.dumps({"r1": {"name": "Test Room", "target": 74.0, "source": "schedule"}})
+        cycle = CycleLog.create(
+            thermostat_entity_id=THERMO_ID, mode="heating", rooms_json=rooms_json
+        )
+        await db.insert_cycle_log(conn, cycle)
+        # A still-open overflow room participation persisted on the same cycle.
+        await db.upsert_room_cycle_state(
+            conn,
+            RoomCycleState(
+                cycle_id=cycle.id,
+                room_id="ov1",
+                target_temp=70.0,
+                temp_at_start=72.0,
+                joined_at=datetime.now(UTC),
+                role="overflow",
+            ),
+        )
+
+        ha = _make_ha(ambient=80.0)
+        engine = _make_engine(ha)
+        await engine.restore_from_db(conn)
+
+        # Cycle discarded; overflow tracking cleared, not carried forward.
+        assert engine._state == CycleState.IDLE
+        assert engine._overflow_room_states == {}
+        assert engine._overflow_room_ids == set()
+        await conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Ambient-aware presence suppression / pre-cool (Issue #248, Phase 2)

--- a/smart_vent/backend/tests/test_room_cycle_state_upsert.py
+++ b/smart_vent/backend/tests/test_room_cycle_state_upsert.py
@@ -1,0 +1,127 @@
+"""
+Tests for upsert_room_cycle_state ON CONFLICT semantics (Issue #300).
+
+When a room that was opened as overflow (role='overflow') is later promoted to a
+full active participant, the engine re-inserts a RoomCycleState with the default
+role='active'. The ON CONFLICT(cycle_id, room_id) update must:
+  * update `role` (so the promoted room is no longer mislabeled overflow), and
+  * preserve the original `joined_at` (COALESCE), only setting it when previously
+    NULL.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from backend import db
+from backend.models import CycleLog, Room, RoomCycleState
+
+
+async def _fresh_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await db.init_db(conn)
+    return conn
+
+
+async def _seed_cycle(conn: aiosqlite.Connection, cycle_id: str = "c1") -> None:
+    await db.upsert_room(conn, Room(id="r1", name="Bedroom", thermostat_entity_id="climate.t"))
+    log_ = CycleLog(
+        id=cycle_id,
+        thermostat_entity_id="climate.t",
+        started_at=datetime(2026, 1, 1, 9, 0, tzinfo=UTC),
+        mode="cooling",
+        rooms_json="{}",
+    )
+    await db.insert_cycle_log(conn, log_)
+
+
+async def _get_rcs(conn: aiosqlite.Connection, cycle_id: str, room_id: str) -> RoomCycleState:
+    states = await db.get_room_cycle_states(conn, cycle_id)
+    return next(s for s in states if s.room_id == room_id)
+
+
+class TestUpsertRoomCycleStateConflict:
+    async def test_conflict_updates_role_overflow_to_active(self) -> None:
+        conn = await _fresh_db()
+        try:
+            await _seed_cycle(conn)
+            t1 = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1",
+                    room_id="r1",
+                    target_temp=70.0,
+                    joined_at=t1,
+                    temp_at_start=75.0,
+                    role="overflow",
+                ),
+            )
+            # Engine promotes the room to active mid-cycle: a fresh active state
+            # is upserted onto the existing overflow row.
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1",
+                    room_id="r1",
+                    target_temp=72.0,
+                    joined_at=datetime(2026, 1, 1, 11, 0, tzinfo=UTC),
+                    role="active",
+                ),
+            )
+            rcs = await _get_rcs(conn, "c1", "r1")
+            assert rcs.role == "active"
+            # temp_at_start is intentionally preserved (overflow re-open path).
+            assert rcs.temp_at_start == 75.0
+        finally:
+            await conn.close()
+
+    async def test_conflict_preserves_original_joined_at(self) -> None:
+        conn = await _fresh_db()
+        try:
+            await _seed_cycle(conn)
+            t1 = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+            t2 = datetime(2026, 1, 1, 11, 0, tzinfo=UTC)
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1", room_id="r1", target_temp=70.0, joined_at=t1, role="overflow"
+                ),
+            )
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1", room_id="r1", target_temp=72.0, joined_at=t2, role="active"
+                ),
+            )
+            rcs = await _get_rcs(conn, "c1", "r1")
+            # Original join time is kept, not overwritten by the promotion's time.
+            assert rcs.joined_at == t1
+        finally:
+            await conn.close()
+
+    async def test_conflict_sets_joined_at_when_previously_null(self) -> None:
+        conn = await _fresh_db()
+        try:
+            await _seed_cycle(conn)
+            # Room present at cycle start has joined_at=None.
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1", room_id="r1", target_temp=72.0, joined_at=None, role="active"
+                ),
+            )
+            t2 = datetime(2026, 1, 1, 11, 0, tzinfo=UTC)
+            await db.upsert_room_cycle_state(
+                conn,
+                RoomCycleState(
+                    cycle_id="c1", room_id="r1", target_temp=72.0, joined_at=t2, role="active"
+                ),
+            )
+            rcs = await _get_rcs(conn, "c1", "r1")
+            assert rcs.joined_at == t2
+        finally:
+            await conn.close()


### PR DESCRIPTION
## What & why

Fixes #300. Three related defects around overflow-room bookkeeping.

### A. `upsert_room_cycle_state` ON CONFLICT dropped `role` and `joined_at`
The `ON CONFLICT(cycle_id, room_id) DO UPDATE` clause (`backend/db.py`) updated `target_temp/reached_at/vent_closed_at/temp_at_end/trigger_detail` but **not** `role` or `joined_at`. So when a room opened as overflow (`role='overflow'`) later started demanding HVAC and was added to the running cycle, the engine's fresh `role='active'` insert hit the conflict and the row **silently stayed `role='overflow'`** with a stale `joined_at` — excluding it from metrics, from `close_open_cycles_for_rooms`, mislabeling it in the Logs UI, and letting `_finalize_overflow_rooms` overwrite its `vent_closed_at`/`temp_at_end`.

Fix: add `role=excluded.role` and `joined_at=COALESCE(room_cycle_states.joined_at, excluded.joined_at)` (update role; preserve the original join time, set it only when previously NULL). `temp_at_start` is still intentionally not updated (the overflow re-open path relies on keeping it).

### A (engine). Evict promoted overflow rooms
When a room is promoted from overflow to active in `_start_or_update_cycle` (`backend/engine/cycle_engine.py`), it is now removed from `_overflow_room_states` / `_overflow_room_ids` so the overflow management and cycle-end finalize can't overwrite its active data point.

### B. Restore path leaked overflow state
`restore_from_db` repopulates `_overflow_room_states` / `_overflow_room_ids` from the DB, but the stale-mode "discard and stay IDLE" early-return cleared `_room_cycle_states` / `_active_rooms` / `_room_vents` and **not** the overflow dicts — so they carried into the next freshly-started cycle. They are now cleared in that reset block too.

## Test plan

TDD — all tests written failing first:

- `backend/tests/test_room_cycle_state_upsert.py` (new): conflict updates `role` overflow→active; preserves the original `joined_at`; sets `joined_at` when previously NULL; keeps `temp_at_start`.
- `test_cycle_diagnostics.py::TestOverflowPromotion::test_overflow_room_promoted_to_active_is_evicted`: a room held as overflow then added to the running cycle is evicted from the overflow dicts and its DB row role becomes `active`.
- `test_cycle_engine.py::TestRestoreFromDb::test_discard_clears_overflow_state`: a discarded stale cycle clears the overflow bookkeeping.

- Full backend suite: 814 passed, coverage 93.20%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_