### PR TITLE
Skip idle setpoint-to-ambient reset when already at ambient (#296)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -53,6 +53,11 @@ BroadcastFn = Callable[[str, dict], Coroutine]
 # averages so the engine never drives control decisions off stale data.
 SENSOR_STALE_AFTER_MIN: float = 30.0
 
+# Setpoint drift tolerance (°F). Two setpoints within this band are treated as
+# equal, so the engine neither re-commands an idle setpoint that already equals
+# ambient (Issue #296) nor flags reconcile drift for HA float-rounding noise.
+_SETPOINT_DRIFT_TOLERANCE_F: float = 0.1
+
 # Thermostat-unavailability tolerance (Issue #267): the abort threshold is the
 # per-thermostat ``unavailable_abort_after_min`` config field (default 5 min,
 # 0 = never abort), surfaced on the Thermostats page. See the availability
@@ -388,18 +393,7 @@ class CycleEngine:
             if inferred == "off":
                 # All rooms within deadband — reset setpoint to ambient so the HVAC
                 # goes idle, then skip starting a new cycle.
-                ambient_f = _climate_temp_to_f(
-                    thermo_state.get("attributes", {}).get("current_temperature"),
-                    self._ha.ha_temp_unit,
-                )
-                if ambient_f is not None:
-                    try:
-                        await self._ha.set_thermostat_temperature(
-                            self.thermostat_entity_id, ambient_f
-                        )
-                        self._last_setpoint_sent = ambient_f
-                    except Exception as exc:
-                        log.error("Failed to reset setpoint to ambient: %s: %r", exc, exc)
+                await self._reset_setpoint_to_ambient(thermo_state)
                 await self._maybe_reconcile(conn)
                 await self._maybe_broadcast()
                 return
@@ -454,18 +448,7 @@ class CycleEngine:
                                 "cooling_lockout_below_f": threshold,
                             },
                         )
-                    ambient_f = _climate_temp_to_f(
-                        thermo_state.get("attributes", {}).get("current_temperature"),
-                        self._ha.ha_temp_unit,
-                    )
-                    if ambient_f is not None:
-                        try:
-                            await self._ha.set_thermostat_temperature(
-                                self.thermostat_entity_id, ambient_f
-                            )
-                            self._last_setpoint_sent = ambient_f
-                        except Exception as exc:
-                            log.error("Failed to reset setpoint to ambient: %s: %r", exc, exc)
+                    await self._reset_setpoint_to_ambient(thermo_state)
                     await self._maybe_reconcile(conn)
                     await self._maybe_broadcast()
                     return
@@ -1994,6 +1977,35 @@ class CycleEngine:
             _climate_temp_to_f(attrs.get("temperature"), unit),
         )
 
+    async def _reset_setpoint_to_ambient(self, thermo_state: dict) -> None:
+        """Reset the thermostat setpoint to the current ambient so the HVAC goes
+        idle, but skip the ``climate.set_temperature`` call when the setpoint
+        already equals ambient within the drift tolerance.
+
+        Without this guard a house sitting within deadband re-commands the same
+        setpoint on every 60 s tick — continuous needless write traffic that can
+        hit cloud-thermostat rate limits and churns the HA recorder (Issue #296).
+        """
+        attrs = thermo_state.get("attributes", {})
+        unit = self._ha.ha_temp_unit
+        ambient_f = _climate_temp_to_f(attrs.get("current_temperature"), unit)
+        if ambient_f is None:
+            return
+        current_sp_f = _climate_temp_to_f(attrs.get("temperature"), unit)
+        if (
+            current_sp_f is not None
+            and abs(current_sp_f - ambient_f) <= _SETPOINT_DRIFT_TOLERANCE_F
+        ):
+            # Already at ambient — nothing to send. Keep the tracked value in
+            # sync so the reconciler treats the current setpoint as intended.
+            self._last_setpoint_sent = ambient_f
+            return
+        try:
+            await self._ha.set_thermostat_temperature(self.thermostat_entity_id, ambient_f)
+            self._last_setpoint_sent = ambient_f
+        except Exception as exc:
+            log.error("Failed to reset setpoint to ambient: %s: %r", exc, exc)
+
     def _snapshot_vent_states_json(self, vents: list[RoomVent]) -> str | None:
         if not vents:
             return None
@@ -2538,7 +2550,7 @@ class CycleEngine:
                         )
                         if current_sp is not None:
                             drift = abs(current_sp - self._last_setpoint_sent)
-                            if drift > 0.1:  # tolerance for float rounding in HA
+                            if drift > _SETPOINT_DRIFT_TOLERANCE_F:  # float rounding in HA
                                 log.warning(
                                     "Reconcile: thermostat %s setpoint drifted %.1f→%.1f — re-asserting",
                                     self.thermostat_entity_id,

--- a/smart_vent/backend/tests/integration/test_cycle_flow.py
+++ b/smart_vent/backend/tests/integration/test_cycle_flow.py
@@ -228,11 +228,14 @@ async def test_cycle_start_respects_deadband(client, fake_ha, tick) -> None:
         json={"overshoot_delta": 2.0, "deadband": 1.0},
     )
 
-    # 1. Inside deadband (72.5 <= 72.0 + 1.0) -> No cycle expected
+    # 1. Inside deadband (72.5 <= 72.0 + 1.0) -> No cycle expected.
+    # Seed the setpoint (70.0) different from ambient (75.0) so the idle
+    # reset-to-ambient is observable; if it already equalled ambient the engine
+    # would (correctly) skip the redundant call (Issue #296).
     fake_ha.seed_state(
         entities.thermostat,
         "cool",
-        {"current_temperature": 75.0, "temperature": 75.0, "hvac_action": "idle"},
+        {"current_temperature": 75.0, "temperature": 70.0, "hvac_action": "idle"},
     )
     fake_ha.seed_state(entities.sensor, "72.5", {"unit_of_measurement": "°F"})
 

--- a/smart_vent/backend/tests/integration/test_idle_setpoint_churn.py
+++ b/smart_vent/backend/tests/integration/test_idle_setpoint_churn.py
@@ -1,0 +1,74 @@
+"""
+Regression test for Issue #296: an IDLE engine whose rooms are all within
+deadband resets the thermostat setpoint to the current ambient so the HVAC
+goes idle — but it must not re-command that same setpoint on every tick.
+
+Before the fix, every 60 s tick fired a `climate.set_temperature` service call
+even though nothing changed, churning the HA recorder and risking vendor rate
+limits for cloud thermostats.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+async def _make_idle_room_at_target(client, fake_ha) -> None:
+    thermostat = "climate.test_thermostat"
+    sensor = "sensor.room_temp"
+    vent = "cover.room_vent"
+
+    # Thermostat ambient 72°F, but its setpoint is parked at 68°F (differs from
+    # ambient), so the first idle tick will reset it to ambient.
+    fake_ha.seed_state(
+        thermostat,
+        "cool",
+        {"current_temperature": 72.0, "temperature": 68.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(sensor, "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(vent, "open", {})
+
+    resp = await client.post(
+        "/api/rooms", json={"name": "Room", "thermostat_entity_id": thermostat}
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": vent, "control_method": "open_close"},
+    )
+    # Schedule active now targeting 72 — the room is "active" but already at
+    # target, so the engine infers mode "off".
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": 72.0,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_idle_setpoint_not_recommanded_every_tick(client, fake_ha, tick) -> None:
+    thermostat = "climate.test_thermostat"
+    await _make_idle_room_at_target(client, fake_ha)
+
+    # First tick: ambient 72 ≠ setpoint 68 → one reset to ambient.
+    await tick()
+    sets = [c for c in fake_ha.calls_for("set_temperature") if c.data["entity_id"] == thermostat]
+    assert len(sets) == 1, f"first idle tick should reset setpoint once; got {sets}"
+    assert sets[0].data["temperature"] == pytest.approx(72.0)
+
+    # Second tick: setpoint already equals ambient → no further service call.
+    await tick()
+    sets = [c for c in fake_ha.calls_for("set_temperature") if c.data["entity_id"] == thermostat]
+    assert len(sets) == 1, (
+        f"idle setpoint must not be re-commanded when already at ambient; got {sets}"
+    )

--- a/smart_vent/backend/tests/test_cycle_engine.py
+++ b/smart_vent/backend/tests/test_cycle_engine.py
@@ -121,6 +121,43 @@ def _make_engine(ha: MagicMock | None = None) -> CycleEngine:
 
 
 # ---------------------------------------------------------------------------
+# Issue #296: idle setpoint-to-ambient reset is idempotent
+# ---------------------------------------------------------------------------
+
+
+class TestResetSetpointToAmbient:
+    """_reset_setpoint_to_ambient must only call HA when the setpoint differs
+    from ambient, so an idle house within deadband does not churn HA every tick."""
+
+    @pytest.mark.asyncio
+    async def test_skips_call_when_setpoint_already_at_ambient(self):
+        ha = _make_ha(ambient=72.0)  # setpoint == current_temperature == 72
+        engine = _make_engine(ha)
+        await engine._reset_setpoint_to_ambient(ha.get_state.return_value)
+        ha.set_thermostat_temperature.assert_not_called()
+        # The tracked value is still kept in sync for the reconciler.
+        assert engine._last_setpoint_sent == pytest.approx(72.0)
+
+    @pytest.mark.asyncio
+    async def test_sends_call_when_setpoint_differs_from_ambient(self):
+        ha = _make_ha(ambient=72.0)
+        ha.get_state.return_value["attributes"]["temperature"] = 68.0
+        engine = _make_engine(ha)
+        await engine._reset_setpoint_to_ambient(ha.get_state.return_value)
+        ha.set_thermostat_temperature.assert_called_once()
+        assert ha.set_thermostat_temperature.call_args.args[1] == pytest.approx(72.0)
+        assert engine._last_setpoint_sent == pytest.approx(72.0)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_ambient_unreadable(self):
+        ha = _make_ha(ambient=72.0)
+        ha.get_state.return_value["attributes"]["current_temperature"] = None
+        engine = _make_engine(ha)
+        await engine._reset_setpoint_to_ambient(ha.get_state.return_value)
+        ha.set_thermostat_temperature.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Bug 1: Setpoint clamped against thermostat ambient
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

Fixes #296.

When the engine is IDLE and `_infer_mode_from_room_temps` returns `"off"` (every room within deadband), `_do_tick` reset the thermostat setpoint to the current ambient and returned — with **no "already at this value" guard**. So a house sitting comfortably within deadband fired a `climate.set_temperature` service call **every 60 s tick, indefinitely**. The same pattern repeated in the cooling-lockout branch. For cloud-backed thermostats (ecobee, Honeywell, Nest) that is continuous needless write traffic that can hit vendor rate limits and churns the HA recorder.

## Fix

Extracted the repeated "reset setpoint to ambient" logic into `_reset_setpoint_to_ambient(thermo_state)`, which:

- reads ambient and the current setpoint (both normalised to °F), and
- **skips** the `climate.set_temperature` call when the current setpoint already equals ambient within the drift tolerance (`_SETPOINT_DRIFT_TOLERANCE_F = 0.1 °F`), keeping `_last_setpoint_sent` in sync so the reconciler treats the current value as intended.

Both per-tick callers (idle "off" and cooling-lockout) now use this helper. The reconcile drift check now reuses the same named tolerance constant (was a bare `0.1`).

## Test plan

TDD — written failing first:

- `backend/tests/integration/test_idle_setpoint_churn.py` (new): an idle room at target with the setpoint parked away from ambient — first tick resets once, **second tick sends nothing** (was: a call every tick).
- `test_cycle_engine.py::TestResetSetpointToAmbient` (new, 3 unit tests): skips when already at ambient (and keeps `_last_setpoint_sent` synced); sends when the setpoint differs; no-ops when ambient is unreadable.
- Updated `test_cycle_flow.py::test_cycle_start_respects_deadband`: it had seeded the setpoint equal to ambient and asserted a redundant reset call still fired (the churn). Seeded the setpoint different from ambient so the idle reset stays observable while matching the new, correct no-redundant-write behavior.

- Full backend suite: 813 passed, coverage 93.24%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_