### PR TITLE
Honor per-room deadband_override in overflow candidate selection (#305)

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -36,6 +36,7 @@ from ..units import to_f
 from .room_manager import (
     ActiveRoom,
     OverflowCandidate,
+    _effective_deadband,
     _seconds_since_schedule_end,
     expire_holdovers,
     get_active_rooms,
@@ -3330,22 +3331,6 @@ def _climate_temp_to_f(value: Any, unit: str) -> float | None:
         return to_f(float(value), unit)
     except (ValueError, TypeError):
         return None
-
-
-def _effective_deadband(room: Room, thermostat_deadband: float) -> float:
-    """Deadband (±°F) governing this room's start-cycle / join-cycle vote.
-
-    Rooms may override the thermostat's deadband (Issue #277). ``None`` on the
-    room means inherit the thermostat value, so rooms without an override are
-    unaffected. The override only widens/narrows the at-target tolerance band
-    used when deciding whether a room demands HVAC — it is unrelated to the
-    pre-cool/pre-heat ``ambient_suppression_deadband`` (the widened coasting
-    band), which the suppression vote still clamps with ``max()`` against
-    whatever deadband is passed here.
-    """
-    if room.deadband_override is not None:
-        return room.deadband_override
-    return thermostat_deadband
 
 
 def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:

--- a/smart_vent/backend/engine/room_manager.py
+++ b/smart_vent/backend/engine/room_manager.py
@@ -403,6 +403,22 @@ class OverflowCandidate:
     headroom: float | None = None  # populated only for tier 3
 
 
+def _effective_deadband(room: Room, thermostat_deadband: float) -> float:
+    """Deadband (±°F) governing this room's at-target band.
+
+    Rooms may override the thermostat's deadband (Issue #277). ``None`` on the
+    room means inherit the thermostat value, so rooms without an override are
+    unaffected. The override only widens/narrows the at-target tolerance band
+    used when deciding whether a room demands HVAC — it is unrelated to the
+    pre-cool/pre-heat ``ambient_suppression_deadband`` (the widened coasting
+    band), which the suppression vote still clamps with ``max()`` against
+    whatever deadband is passed here.
+    """
+    if room.deadband_override is not None:
+        return room.deadband_override
+    return thermostat_deadband
+
+
 async def get_overflow_candidates(
     conn: aiosqlite.Connection,
     thermostat_entity_id: str,
@@ -455,20 +471,23 @@ async def get_overflow_candidates(
         return []
 
     # Tier 1: room is past its setpoint by more than the deadband AND the
-    # supply air is still moving it the right way.
+    # supply air is still moving it the right way. Each room's own deadband
+    # override governs its band (Issue #305), consistent with the rest of the
+    # engine's at-target checks.
     tier1: list[OverflowCandidate] = []
     for c in pool:
         if c.effective_setpoint is None:
             continue
+        db_f = _effective_deadband(c.room, deadband_f)
         if hvac_mode == "cooling":
             if (
-                c.current_temp > c.effective_setpoint + deadband_f
+                c.current_temp > c.effective_setpoint + db_f
                 and c.current_temp > active_cycle_target_f
             ):
                 tier1.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 1))
         else:  # heating
             if (
-                c.current_temp < c.effective_setpoint - deadband_f
+                c.current_temp < c.effective_setpoint - db_f
                 and c.current_temp < active_cycle_target_f
             ):
                 tier1.append(OverflowCandidate(c.room, c.current_temp, c.effective_setpoint, 1))
@@ -498,15 +517,16 @@ async def get_overflow_candidates(
     for c in pool:
         if c.effective_setpoint is None:
             continue
+        db_f = _effective_deadband(c.room, deadband_f)
         if hvac_mode == "cooling":
             # In cooling we are pushing the room cooler; the opposite trigger
             # is its "would call for heat" threshold = setpoint - deadband.
-            opposite_trigger = c.effective_setpoint - deadband_f
+            opposite_trigger = c.effective_setpoint - db_f
             headroom = c.current_temp - opposite_trigger
         else:
             # In heating we are pushing the room warmer; the opposite trigger
             # is its "would call for cool" threshold = setpoint + deadband.
-            opposite_trigger = c.effective_setpoint + deadband_f
+            opposite_trigger = c.effective_setpoint + db_f
             headroom = opposite_trigger - c.current_temp
         if headroom > 0:
             headroom_pool.append(

--- a/smart_vent/backend/tests/test_room_manager.py
+++ b/smart_vent/backend/tests/test_room_manager.py
@@ -685,6 +685,77 @@ class TestGetOverflowCandidates:
         await conn.close()
 
     @pytest.mark.asyncio
+    async def test_per_room_deadband_override_reclassifies_tier(self):
+        """Issue #305: a room's deadband_override governs its overflow tier
+        thresholds, not the thermostat default deadband. A room with a WIDE
+        override that sits just past its setpoint is inside its own deadband
+        (tier 2), even though the thermostat's narrow default would (wrongly)
+        place it outside the deadband (tier 1)."""
+        conn = await _setup_db()
+        await db.upsert_thermostat_config(
+            conn, ThermostatConfig(thermostat_entity_id=THERMO_ID, deadband=0.5)
+        )
+        room = Room(
+            id="r1",
+            name="Office",
+            thermostat_entity_id=THERMO_ID,
+            system_wide_temp=70.0,
+            deadband_override=2.0,
+        )
+        await db.upsert_room(conn, room)
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # 71.0 is past setpoint 70 but inside the room's wide 2.0 deadband
+            # (≤ 70 + 2.0). With the thermostat's 0.5 deadband it would be tier 1.
+            get_avg_temp=self._temp_map({"r1": 71.0}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 2
+        await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_per_room_deadband_override_affects_tier3_headroom(self):
+        """Issue #305: the tier-3 headroom (distance to the opposite-direction
+        trigger) must use the room's own deadband. A wide override gives the room
+        positive headroom and makes it eligible where the thermostat default
+        would yield negative headroom and exclude it."""
+        conn = await _setup_db()
+        await db.upsert_thermostat_config(
+            conn, ThermostatConfig(thermostat_entity_id=THERMO_ID, deadband=0.5)
+        )
+        room = Room(
+            id="r1",
+            name="Office",
+            thermostat_entity_id=THERMO_ID,
+            system_wide_temp=70.0,
+            deadband_override=2.0,
+        )
+        await db.upsert_room(conn, room)
+        out = await get_overflow_candidates(
+            conn,
+            THERMO_ID,
+            hvac_mode="cooling",
+            active_room_ids=set(),
+            active_cycle_target_f=68.0,
+            deadband_f=0.5,
+            in_vacation=False,
+            # 69.0 is below setpoint 70 (no tier 1/2). Opposite trigger =
+            # setpoint - deadband: thermostat 0.5 → 69.5 (headroom -0.5, excluded);
+            # room override 2.0 → 68.0 (headroom +1.0, eligible tier 3).
+            get_avg_temp=self._temp_map({"r1": 69.0}),
+        )
+        assert [c.room.id for c in out] == ["r1"]
+        assert out[0].tier == 3
+        assert out[0].headroom == pytest.approx(1.0)
+        await conn.close()
+
+    @pytest.mark.asyncio
     async def test_tier2_when_no_tier1_qualifier(self):
         conn = await self._setup(
             rooms=[("r1", "Office", 70.0)],


### PR DESCRIPTION
## What & why

Fixes #305.

`get_overflow_candidates` (`backend/engine/room_manager.py`) was called with a single `deadband_f=tc.deadband` and applied that one value to every candidate room's tier-1/tier-3 thresholds (`effective_setpoint ± deadband_f`). Per-room deadband overrides (Issue #277, `room.deadband_override`) are honored everywhere else a room's at-target band is computed (start/join vote, `_filter_rooms_for_mode`, `_monitor_rooms`) but not here, so a room with a wider/narrower configured deadband got the thermostat default applied to its overflow eligibility and headroom — opened (or skipped) inconsistently with the rest of the engine.

## Fix

Resolve each candidate's deadband with `_effective_deadband(room, deadband_f)` inside the tier-1 and tier-3 loops (tier 2 has no deadband term). `_effective_deadband` moved from `cycle_engine.py` to `room_manager.py` (its natural home next to the room helpers) to avoid a circular import; `cycle_engine` re-imports it so existing `from backend.engine.cycle_engine import _effective_deadband` references and its two engine call sites are unchanged.

## Test plan

TDD — added two tests to `TestGetOverflowCandidates` (room_manager) covering both the eligibility band and the headroom:

- `test_per_room_deadband_override_reclassifies_tier`: a room with a **wide** override (2.0 °F vs thermostat 0.5 °F) sitting at setpoint+1 °F is correctly tier 2 (inside its own deadband), not tier 1 as the thermostat default would wrongly classify it.
- `test_per_room_deadband_override_affects_tier3_headroom`: the tier-3 opposite-direction headroom uses the room's own deadband — the wide override yields positive headroom (eligible) where the thermostat default yields negative headroom (excluded).

Existing overflow-candidate tests and the `_effective_deadband` unit tests (still importing from `cycle_engine`) pass.

- Full backend suite: 811 passed, coverage 93.20%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_