### PR TITLE
Refresh presence holdover for continuously-on occupancy sensors (#287)

### DIFF
--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -515,8 +515,35 @@ class Scheduler:
         await self._check_vacation_expiry()
         await self._check_unit_change()
         await self._sync_engines()
+        await self._refresh_continuous_presence()
         tasks = [self._tick_engine(tid, eng) for tid, eng in self._engines.items()]
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _refresh_continuous_presence(self) -> None:
+        """Refresh presence holdovers for rooms whose presence sensor currently
+        reads "on".
+
+        Presence is otherwise edge-triggered (``_on_state_change`` only fires on
+        a transition to "on"). Many occupancy sensors (mmWave, some PIR
+        aggregations) hold a single continuous "on" state while a room is
+        occupied and emit no further state_changed events, so without this the
+        holdover would expire mid-occupancy and the room would deactivate even
+        though it is still occupied (Issue #287). Runs before the engine ticks so
+        the refreshed holdover is visible when each tick resolves active rooms.
+        """
+        rooms = await db.get_all_rooms(self._db_conn)
+        for room in rooms:
+            if room.presence_holdover_hours <= 0:
+                continue
+            engine = self._engines.get(room.thermostat_entity_id)
+            if engine is None:
+                continue
+            presence_sensors = await db.get_room_presence_sensors(self._db_conn, room.id)
+            for ps in presence_sensors:
+                state = self._ha.get_state(ps.entity_id)
+                if state and state.get("state") == "on":
+                    await engine.handle_presence(self._db_conn, room)
+                    break
 
     async def _tick_engine(self, tid: str, engine: CycleEngine) -> None:
         # The whole body — the pre-tick DB reads AND the tick — runs under the

--- a/smart_vent/backend/tests/integration/test_presence_holdover_refresh.py
+++ b/smart_vent/backend/tests/integration/test_presence_holdover_refresh.py
@@ -1,0 +1,100 @@
+"""
+Regression test for Issue #287: presence holdover must be refreshed while an
+occupancy sensor stays continuously "on".
+
+Many presence/occupancy sensors (mmWave, some PIR aggregations) hold a single
+continuous `on` state for as long as a room is occupied, emitting no further
+state_changed events. Presence was edge-triggered only, so once the initial
+holdover elapsed the room went idle even though it was still occupied. The fix
+checks current presence-sensor state during the engine tick and refreshes the
+holdover for rooms whose sensor currently reads `on`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend import db
+
+
+@pytest.mark.asyncio
+async def test_continuous_presence_arms_holdover_on_tick(client, fake_ha, tick) -> None:
+    thermostat = "climate.test_thermostat"
+    presence = "binary_sensor.room_presence"
+
+    fake_ha.seed_state(
+        thermostat,
+        "cool",
+        {"current_temperature": 74.0, "temperature": 74.0, "hvac_action": "idle"},
+    )
+    # Sensor is already "on" before any subscription — no rising-edge event fires.
+    fake_ha.seed_state(presence, "on", {})
+
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Room",
+            "thermostat_entity_id": thermostat,
+            "presence_holdover_hours": 2.0,
+        },
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/presence", json={"entity_id": presence})
+
+    conn = client.app["scheduler"]._db_conn
+    # Precondition: no holdover yet (the rising edge never fired).
+    assert await db.get_holdover_state(conn, room_id) is None
+
+    await tick()
+
+    holdover = await db.get_holdover_state(conn, room_id)
+    assert holdover is not None, "continuous 'on' presence must arm the holdover on tick"
+    assert holdover.expires_at > datetime.now(UTC) + timedelta(hours=1)
+
+
+@pytest.mark.asyncio
+async def test_continuous_presence_extends_expiring_holdover(client, fake_ha, tick) -> None:
+    thermostat = "climate.test_thermostat"
+    presence = "binary_sensor.room_presence"
+
+    fake_ha.seed_state(
+        thermostat,
+        "cool",
+        {"current_temperature": 74.0, "temperature": 74.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(presence, "on", {})
+
+    resp = await client.post(
+        "/api/rooms",
+        json={
+            "name": "Room",
+            "thermostat_entity_id": thermostat,
+            "presence_holdover_hours": 2.0,
+        },
+    )
+    room_id = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/presence", json={"entity_id": presence})
+
+    conn = client.app["scheduler"]._db_conn
+    # Simulate a holdover about to expire (the room has been occupied for ~2h
+    # while the sensor emitted no further events).
+    from backend.models import PresenceHoldoverState
+
+    nearly_expired = datetime.now(UTC) + timedelta(seconds=30)
+    await db.upsert_holdover_state(
+        conn,
+        PresenceHoldoverState(
+            room_id=room_id,
+            last_detected_at=datetime.now(UTC) - timedelta(hours=2),
+            expires_at=nearly_expired,
+        ),
+    )
+
+    await tick()
+
+    holdover = await db.get_holdover_state(conn, room_id)
+    assert holdover is not None
+    # The still-"on" sensor must have pushed the expiry back out to ~2h.
+    assert holdover.expires_at > datetime.now(UTC) + timedelta(hours=1)


### PR DESCRIPTION
## What & why

Fixes #287.

Presence was **edge-triggered only**: `Scheduler._on_state_change` calls `_handle_presence_event` only when a `binary_sensor` *transitions* to `on`, which resets the holdover countdown. Many presence/occupancy sensors (mmWave, some PIR aggregations) hold a single continuous `on` state for as long as the room is occupied and emit no further `state_changed` events. Once the initial `presence_holdover_hours` elapsed, `expire_holdovers` dropped the holdover and the room went idle — its vents reopened and it stopped being conditioned — **even though it was still occupied**.

## Fix

Added `Scheduler._refresh_continuous_presence()`, called from `_tick_all` before the engines tick. It checks each room's presence sensors' *current* HA state and, for any reading `on`, refreshes that room's holdover via the existing `engine.handle_presence(...)` path (which resets the countdown to `now + presence_holdover_hours`). Running it before the per-engine ticks means the refreshed holdover is visible when each tick resolves active rooms. Rooms with `presence_holdover_hours <= 0` are skipped, and the refresh reuses the existing reset path (debug-level logging, no event-feed spam).

## Test plan

TDD — `backend/tests/integration/test_presence_holdover_refresh.py` (written failing first):

- `test_continuous_presence_arms_holdover_on_tick`: a sensor seeded `on` before any subscription (so no rising edge fires) has no holdover; after one tick the holdover is armed (~2 h out).
- `test_continuous_presence_extends_expiring_holdover`: a holdover about to expire (30 s) is pushed back out (~2 h) by the still-`on` sensor on the next tick.

Both failed before the change and pass after.

- Full backend suite: 811 passed, coverage 93.17%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_