### PR TITLE
Make unit-change banner dismiss stick and clear after applying restart (#288)

### DIFF
--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -251,8 +251,21 @@ class Scheduler:
         return val == "1"
 
     async def ack_unit_change(self) -> None:
-        """Clear the unit-change acknowledgement flag."""
+        """Clear the unit-change acknowledgement flag and record which HA unit was
+        acknowledged, so the per-tick check does not immediately re-raise the
+        banner for the same still-pending change (Issue #288). The mismatch is
+        only truly resolved by the restart that applies the new unit."""
         await db.set_system_setting(self._db_conn, "unit_change_ack_required", "0")
+        try:
+            acked_unit = await self._ha.get_temperature_unit()
+        except Exception:
+            return
+        await db.set_system_setting(self._db_conn, "unit_change_acked_unit", acked_unit)
+
+    async def _clear_unit_change_banner(self) -> None:
+        """Reset all unit-change banner bookkeeping (flag + acknowledged unit)."""
+        await db.set_system_setting(self._db_conn, "unit_change_ack_required", "0")
+        await db.set_system_setting(self._db_conn, "unit_change_acked_unit", "")
 
     # ------------------------------------------------------------------
     # Vacation mode
@@ -312,10 +325,23 @@ class Scheduler:
             return
         self._active_unit = unit
         await db.set_system_setting(self._db_conn, "temperature_unit", unit)
+        # The stored unit now matches HA, so any pending unit-change banner is
+        # resolved by this (re)start — clear it even if the user never dismissed
+        # it before restarting (Issue #288).
+        await self._clear_unit_change_banner()
         log.info("Temperature unit resolved from HA on startup: %s", unit)
 
     async def _check_unit_change(self) -> None:
-        """Called on each tick: detect HA unit changes and set the ack flag."""
+        """Called on each tick: detect HA unit changes and set the ack flag.
+
+        The stored ``temperature_unit`` is only rewritten at startup (the running
+        session's active unit is locked then), so a live HA unit change stays
+        mismatched until the user restarts. To keep the dismiss meaningful we
+        record the acknowledged HA unit and don't re-raise the banner for it; we
+        re-flag only when HA moves to a unit that has not been acknowledged. Once
+        the mismatch resolves (HA matches stored — e.g. after the applying
+        restart) the banner bookkeeping is cleared. (Issue #288)
+        """
         if not self._ha._connected.is_set():
             return
         if self._unit_override in ("F", "C"):
@@ -325,7 +351,12 @@ class Scheduler:
         except Exception:
             return
         stored = await db.get_system_setting(self._db_conn, "temperature_unit", "F")
-        if ha_unit != stored:
+        if ha_unit == stored:
+            # No pending change (or it has been applied) — clear stale banner state.
+            await self._clear_unit_change_banner()
+            return
+        acked = await db.get_system_setting(self._db_conn, "unit_change_acked_unit", "")
+        if ha_unit != acked:
             await db.set_system_setting(self._db_conn, "unit_change_ack_required", "1")
             log.info(
                 "Temperature unit change detected: stored=%s HA=%s — ack required",

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -947,6 +947,26 @@ class TestStartupResolveUnit:
         finally:
             await sched.stop()
 
+    async def test_clears_stuck_ack_flag_when_unit_now_matches(self, tmp_path):
+        """Issue #288: the restart that applies the new unit must clear a banner
+        the user never dismissed — once the resolved unit matches stored, the
+        ack flag is cleared."""
+        fake_ha = FakeHomeAssistant()
+        fake_ha.ha_temp_unit = "C"
+        sched = Scheduler(ha=fake_ha, db_path=str(tmp_path / "stuck.db"))
+        await sched.start()
+        try:
+            await asyncio.sleep(0.05)  # let the start-up resolution settle
+            # Pre-restart stuck state: banner up, stored still on the old unit.
+            await db.set_system_setting(sched._db_conn, "temperature_unit", "F")
+            await db.set_system_setting(sched._db_conn, "unit_change_ack_required", "1")
+            # The applying restart resolves the unit from HA (now C).
+            await sched._startup_resolve_unit()
+            assert sched.get_temperature_unit() == "C"
+            assert await sched.get_unit_change_ack_required() is False
+        finally:
+            await sched.stop()
+
 
 class TestCheckUnitChange:
     async def test_change_detected_sets_ack_flag(self, tmp_path):
@@ -1000,5 +1020,48 @@ class TestCheckUnitChange:
         await sched.start()
         try:
             await sched._check_unit_change()  # must not raise
+        finally:
+            await sched.stop()
+
+    async def test_ack_not_undone_by_next_tick(self, tmp_path):
+        """Issue #288: dismissing the banner must stick. The next tick sees the
+        same (already-acknowledged) HA unit and must NOT re-raise the flag."""
+        fake_ha = FakeHomeAssistant()
+        sched = Scheduler(ha=fake_ha, db_path=str(tmp_path / "ack1.db"))
+        await sched.start()
+        try:
+            await asyncio.sleep(0.05)  # _startup_resolve_unit → stored = "F"
+            fake_ha.get_temperature_unit = AsyncMock(return_value="C")
+            await sched._check_unit_change()
+            assert await sched.get_unit_change_ack_required() is True
+            # User dismisses.
+            await sched.ack_unit_change()
+            assert await sched.get_unit_change_ack_required() is False
+            # Next tick — same C unit, still acknowledged → must stay dismissed.
+            await sched._check_unit_change()
+            assert await sched.get_unit_change_ack_required() is False
+        finally:
+            await sched.stop()
+
+    async def test_reflags_on_genuinely_new_change_after_resolution(self, tmp_path):
+        """Once the mismatch resolves (HA matches stored), the ack marker clears
+        so a later, genuinely new change re-raises the banner."""
+        fake_ha = FakeHomeAssistant()
+        sched = Scheduler(ha=fake_ha, db_path=str(tmp_path / "reflag.db"))
+        await sched.start()
+        try:
+            await asyncio.sleep(0.05)  # stored = "F"
+            fake_ha.get_temperature_unit = AsyncMock(return_value="C")
+            await sched._check_unit_change()
+            await sched.ack_unit_change()
+            assert await sched.get_unit_change_ack_required() is False
+            # HA returns to F (matches stored) — mismatch resolved, marker cleared.
+            fake_ha.get_temperature_unit = AsyncMock(return_value="F")
+            await sched._check_unit_change()
+            assert await sched.get_unit_change_ack_required() is False
+            # HA switches to C again — a new change must re-raise the banner.
+            fake_ha.get_temperature_unit = AsyncMock(return_value="C")
+            await sched._check_unit_change()
+            assert await sched.get_unit_change_ack_required() is True
         finally:
             await sched.stop()


### PR DESCRIPTION
## What & why

Fixes #288. (Now reachable end-to-end since the detection bug #281 is fixed.)

`_check_unit_change` runs every tick and set `unit_change_ack_required=1` whenever HA's unit differed from the stored `temperature_unit` (which is only rewritten at startup). Two consequences:

1. **Dismiss was futile** — `POST /api/settings/ack-unit-change` set the flag to 0, but the next 60 s tick re-detected `ha_unit != stored` and set it back to 1. The banner reappeared on every page load until restart.
2. **Stuck after restart** — the restart that applies the new unit (`_startup_resolve_unit` updates `temperature_unit`) never cleared `unit_change_ack_required`, so a user who restarted without dismissing kept seeing the banner even though the unit was now correct.

## Fix

- **`ack_unit_change`** now records the acknowledged HA unit in `unit_change_acked_unit` (in addition to clearing the flag).
- **`_check_unit_change`** re-raises the banner only when `ha_unit != stored` **and** `ha_unit != acked` — so a dismiss sticks for that unit, and a genuinely new change still re-flags. When `ha_unit == stored` (mismatch resolved, e.g. after the applying restart) it clears the banner bookkeeping.
- **`_startup_resolve_unit`** clears the banner state after bringing `temperature_unit` in line with HA, so a restart applied without dismissing first doesn't leave the banner stuck.
- Added a small `_clear_unit_change_banner()` helper used by both paths.

No new UI is needed — the dismiss control (`UnitChangeBanner` → `POST /api/settings/ack-unit-change`) already exists; `unit_change_acked_unit` is internal bookkeeping.

## Test plan

TDD — added to `test_scheduler.py` (the first two written failing first):

- `TestCheckUnitChange::test_ack_not_undone_by_next_tick` — after dismiss, a subsequent tick with the same HA unit keeps the flag cleared.
- `TestStartupResolveUnit::test_clears_stuck_ack_flag_when_unit_now_matches` — a stuck flag is cleared once `_startup_resolve_unit` brings the stored unit in line with HA.
- `TestCheckUnitChange::test_reflags_on_genuinely_new_change_after_resolution` — once the mismatch resolves, a later new change re-raises the banner.

Existing unit-change/temperature-unit tests still pass.

- Full backend suite: 812 passed, coverage 93.17%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_