### PR TITLE
Delete backup temp DB snapshot after serving it (#298)

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -2233,16 +2233,24 @@ async def backup_db(request: web.Request) -> web.Response:
         src.backup(dst)
         src.close()
         dst.close()
+        # Read the snapshot into the response body so the temp file can be
+        # deleted immediately. Serving it via FileResponse would stream the file
+        # after this handler returns, leaving the snapshot on disk forever — a
+        # disk leak that accumulated a full DB copy per download (CWE-459 /
+        # Issue #298).
+        with open(tmp_path, "rb") as f:
+            data = f.read()
         headers = {
             "Content-Disposition": 'attachment; filename="app.db"',
             "Content-Type": "application/octet-stream",
         }
-        return web.FileResponse(tmp_path, headers=headers)  # type: ignore[return-value]
+        return web.Response(body=data, headers=headers)
     except Exception:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
         log.exception("Backup failed")
         return error("Backup failed", 500)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 @docs(tags=["system"], summary="Restore a database from backup")

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -1040,6 +1040,24 @@ class TestBackupRestore:
         body = await resp.read()
         assert body[:16] == b"SQLite format 3\x00"
 
+    async def test_backup_does_not_leak_temp_file(self, client, tmp_path, monkeypatch):
+        """Issue #298: the temporary DB snapshot must be deleted after the
+        response — a backup download must not leave a full copy of the database
+        (rooms, schedules, settings, …) on disk indefinitely."""
+        import tempfile as _tempfile
+
+        backup_dir = tmp_path / "backuptmp"
+        backup_dir.mkdir()
+        monkeypatch.setattr(_tempfile, "tempdir", str(backup_dir))
+
+        resp = await client.get("/api/backup")
+        assert resp.status == 200
+        body = await resp.read()
+        assert body[:16] == b"SQLite format 3\x00"
+
+        leftover = list(backup_dir.glob("*.db"))
+        assert leftover == [], f"backup leaked temp snapshot(s): {leftover}"
+
     async def test_restore_non_sqlite_file_rejected(self, client):
         data = io.BytesIO(b"not a sqlite database content here!!")
         form_data = {"file": data}


### PR DESCRIPTION
## What & why

Fixes #298.

`backup_db` (`backend/api/routes.py`) wrote a full `sqlite3.backup()` snapshot to a `NamedTemporaryFile(delete=False)` and served it via `web.FileResponse`. On the **success** path the temp `.db` was streamed after the handler returned and then **never removed** — only the error path unlinked it. Every backup download left a full copy of the database (rooms, schedules, settings, and HA-token-adjacent config) in the system temp dir indefinitely; repeated downloads accumulated copies until the container was recycled.

## Fix

Read the snapshot bytes into the response body (`web.Response(body=…)`) so the temp file is no longer needed once the handler returns, and unlink it in a `finally` so it is cleaned up on **both** the success and error paths. `sqlite3.backup()` is still used to capture WAL-mode writes; the DB is bounded by the log-retention purges, so reading the snapshot into memory for the download is fine.

## Test plan

TDD — added `test_backup_does_not_leak_temp_file` (failing first): points `tempfile.tempdir` at a fresh directory, downloads `/api/backup` (asserting the SQLite header round-trips), then asserts **no `*.db` snapshot remains** in that directory. Failed before the change (FileResponse left the file); passes after. Existing `test_backup_returns_file` / restore round-trip tests still pass.

- Full backend suite: 810 passed, coverage 93.24%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_