### PR TITLE
Keep strong references to fire-and-forget startup tasks (#304)

### DIFF
--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -196,15 +196,18 @@ def build_app(
                         "HA WebSocket not yet connected — retrying in background",
                     )
 
-            asyncio.create_task(_log_ha_state())
+            # Keep a strong reference — the event loop only holds weak refs, so
+            # an un-referenced task can be GC'd mid-await (Issue #304).
+            app["ha_log_task"] = asyncio.create_task(_log_ha_state())
 
     async def on_shutdown(app: web.Application) -> None:
         await scheduler.stop()
         if start_ha:
             await ha.stop()
-        task = app.get("ha_task")
-        if task:
-            task.cancel()
+        for key in ("ha_task", "ha_log_task"):
+            task = app.get(key)
+            if task:
+                task.cancel()
 
     app.on_startup.append(on_startup)
     app.on_shutdown.append(on_shutdown)

--- a/smart_vent/backend/scheduler.py
+++ b/smart_vent/backend/scheduler.py
@@ -58,6 +58,18 @@ class Scheduler:
         self._unit_override: str = ""  # non-empty when locked by env var / config
         self._vacation_mode: bool = False
         self._vacation_return_at: datetime | None = None
+        # Strong references to fire-and-forget background tasks. The event loop
+        # only holds weak references, so without this a task can be
+        # garbage-collected mid-await and silently never finish (Issue #304).
+        self._bg_tasks: set[asyncio.Task] = set()
+
+    def _spawn_bg(self, coro: Coroutine) -> asyncio.Task:
+        """Create a background task and keep a strong reference until it
+        completes, so it cannot be garbage-collected while still running."""
+        task = asyncio.create_task(coro)
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
+        return task
 
     # ------------------------------------------------------------------
     # Startup / shutdown
@@ -86,7 +98,7 @@ class Scheduler:
         else:
             self._active_unit = await db.get_system_setting(self._db_conn, "temperature_unit", "F")
             # Resolve the real unit from HA once it connects and overwrite the DB.
-            asyncio.get_event_loop().create_task(self._startup_resolve_unit())
+            self._spawn_bg(self._startup_resolve_unit())
 
         # Wire logger's DB connection
         if self._event_logger:
@@ -157,6 +169,10 @@ class Scheduler:
 
     async def stop(self) -> None:
         self._apscheduler.shutdown(wait=False)
+        # Cancel any still-pending background tasks before closing the DB they
+        # may be using (Issue #304).
+        for task in list(self._bg_tasks):
+            task.cancel()
         if self._db_conn:
             await self._db_conn.close()
         log.info("Scheduler stopped")

--- a/smart_vent/backend/tests/test_main_coverage.py
+++ b/smart_vent/backend/tests/test_main_coverage.py
@@ -167,6 +167,23 @@ class TestBuildAppStartHa:
         finally:
             os.unlink(db)
 
+    async def test_startup_tracks_ha_log_task(self):
+        """Issue #304: the _log_ha_state background task must be kept referenced
+        (the event loop only holds weak references) so it can't be GC'd while it
+        waits up to 60 s on ha.wait_connected."""
+        fake_ha = FakeHomeAssistant()
+        fd, db = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            app = build_app(fake_ha, db, frontend_dist=None, start_ha=True)
+            server = TestServer(app)
+            async with TestClient(server) as c:
+                await c.start_server()
+                assert "ha_log_task" in c.app
+                assert isinstance(c.app["ha_log_task"], asyncio.Task)
+        finally:
+            os.unlink(db)
+
 
 # ---------------------------------------------------------------------------
 # Security headers middleware — error response path

--- a/smart_vent/backend/tests/test_scheduler.py
+++ b/smart_vent/backend/tests/test_scheduler.py
@@ -1065,3 +1065,41 @@ class TestCheckUnitChange:
             assert await sched.get_unit_change_ack_required() is True
         finally:
             await sched.stop()
+
+
+class TestBackgroundTasks:
+    """Issue #304: fire-and-forget startup tasks must keep a strong reference so
+    the event loop's weak references don't let them be garbage-collected mid-run."""
+
+    async def test_spawn_bg_tracks_then_cleans_up(self):
+        sched = _make_scheduler()
+        ran = asyncio.Event()
+
+        async def work():
+            ran.set()
+
+        task = sched._spawn_bg(work())
+        # Strong reference held immediately so it can't be GC'd before running.
+        assert task in sched._bg_tasks
+        await task
+        assert ran.is_set()
+        # The done callback removes the (now-finished) task from the set.
+        assert task not in sched._bg_tasks
+
+    async def test_startup_unit_resolution_task_is_tracked(self, tmp_path):
+        fake_ha = FakeHomeAssistant()
+        sched = Scheduler(ha=fake_ha, db_path=str(tmp_path / "bg.db"))
+        gate = asyncio.Event()
+
+        async def slow_resolve():
+            await gate.wait()
+
+        sched._startup_resolve_unit = slow_resolve
+        with patch.dict(os.environ, {"TEMPERATURE_UNIT": ""}):
+            await sched.start()
+        try:
+            # The pending unit-resolution task is held strongly, not GC-eligible.
+            assert any(not t.done() for t in sched._bg_tasks)
+        finally:
+            gate.set()
+            await sched.stop()


### PR DESCRIPTION
## What & why

Fixes #304.

Two startup background tasks were created without keeping a reference. The asyncio event loop holds only **weak** references to tasks, so either could be garbage-collected before completing:

- `scheduler.py` — `asyncio.get_event_loop().create_task(self._startup_resolve_unit())` (also used the deprecated `get_event_loop()`). `_startup_resolve_unit` waits up to 60 s on `ha.wait_connected()`; if collected during that wait, the HA unit is never resolved/persisted and the stale DB value stays active.
- `main.py` — `asyncio.create_task(_log_ha_state())`.

## Fix

- `Scheduler` gains `self._bg_tasks: set[asyncio.Task]` and a `_spawn_bg(coro)` helper that adds the task to the set and removes it via `add_done_callback`. The unit-resolution task now goes through `_spawn_bg` (using `asyncio.create_task`, not `get_event_loop()`), and `stop()` cancels any still-pending background tasks before closing the DB.
- `main.py` stores the `_log_ha_state` task in `app["ha_log_task"]` and cancels it (alongside `ha_task`) on shutdown.

## Test plan

TDD — written failing first:

- `test_scheduler.py::TestBackgroundTasks::test_spawn_bg_tracks_then_cleans_up` — a spawned task is held in `_bg_tasks` while pending and removed once done.
- `test_scheduler.py::TestBackgroundTasks::test_startup_unit_resolution_task_is_tracked` — after `start()`, the pending unit-resolution task is strongly referenced.
- `test_main_coverage.py::TestBuildAppStartHa::test_startup_tracks_ha_log_task` — with `start_ha=True`, `app["ha_log_task"]` is a tracked `asyncio.Task`.

- Full backend suite: 834 passed, coverage 93.32%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---

**Update:** rebased onto current `main` (post #311–#319 merges) to resolve a merge conflict in `test_scheduler.py` — the merged #288 PR had appended unit-change tests to the same `TestCheckUnitChange` region where this branch added `TestBackgroundTasks`. Both test sets are preserved; full suite re-run green after the rebase.