### PR TITLE
Validate thermostat-config numeric fields on the API write boundary (#295)

### DIFF
--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -110,6 +110,39 @@ def _validate_deadband_override(val, unit: str) -> tuple[web.Response | None, fl
     return None, val_f
 
 
+# Safety-critical thermostat-config numeric fields (Issue #295). Each maps to a
+# (minimum, inclusive) lower bound; the engine does arithmetic on these every
+# tick (timedeltas, deadband comparisons), so a non-numeric or negative value
+# stored verbatim raises TypeError / inverts comparisons and can silently kill
+# the zone. ``cycle_timeout_hours`` must be strictly positive — a zero hard
+# timeout would instantly time out every cycle. Bounds mirror the Thermostats
+# page input ``min`` attributes.
+_THERMO_NUMERIC_BOUNDS: dict[str, tuple[float, bool]] = {
+    "deadband": (0.0, True),  # >= 0  (negative inverts the at-target comparison)
+    "overshoot_delta": (0.0, True),
+    "max_vent_closed_min": (0.0, True),
+    "cycle_timeout_hours": (0.0, False),  # > 0
+    "reconciliation_interval_min": (0.0, True),
+    "min_cycle_runtime_min": (0.0, True),
+    "min_cycle_offtime_min": (0.0, True),
+}
+
+
+def _validate_thermostat_numeric(field: str, val: object) -> web.Response | None:
+    """Reject a non-numeric or out-of-range thermostat-config numeric field.
+
+    Returns an error response, or ``None`` when the value is acceptable.
+    """
+    lo, inclusive = _THERMO_NUMERIC_BOUNDS[field]
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        return error(f"{field} must be a number")
+    if inclusive and val < lo:
+        return error(f"{field} must be >= {lo:g}")
+    if not inclusive and val <= lo:
+        return error(f"{field} must be > {lo:g}")
+    return None
+
+
 def _validate_ambient_suppression(
     body: dict, unit: str, tc_deadband_f: float, feature_enabled: bool
 ) -> tuple[web.Response | None, dict]:
@@ -893,6 +926,9 @@ async def create_thermostat(request: web.Request) -> web.Response:
                 val = body[field]
                 setattr(tc, field, _to_f(val, unit) if val is not None else None)
             elif field in ("deadband", "overshoot_delta"):
+                err = _validate_thermostat_numeric(field, body[field])
+                if err is not None:
+                    return err
                 setattr(tc, field, _delta_to_f(body[field], unit))
             elif field == "vacation_hvac_mode":
                 if body[field] not in ("range", "single"):
@@ -929,6 +965,15 @@ async def create_thermostat(request: web.Request) -> web.Response:
                 if not isinstance(val, int) or isinstance(val, bool) or val < 0:
                     return error("unavailable_abort_after_min must be a non-negative integer")
                 setattr(tc, field, val)
+            elif field in _THERMO_NUMERIC_BOUNDS:
+                # cycle_timeout_hours / max_vent_closed_min / *_min fields — the
+                # engine does timedelta/interval arithmetic on these, so reject
+                # non-numeric and out-of-range values rather than store them and
+                # crash a later tick (Issue #295).
+                err = _validate_thermostat_numeric(field, body[field])
+                if err is not None:
+                    return err
+                setattr(tc, field, body[field])
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)
@@ -1007,6 +1052,9 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
                 val = body[field]
                 setattr(tc, field, _to_f(val, unit) if val is not None else None)
             elif field in ("deadband", "overshoot_delta"):
+                err = _validate_thermostat_numeric(field, body[field])
+                if err is not None:
+                    return err
                 setattr(tc, field, _delta_to_f(body[field], unit))
             elif field == "vacation_hvac_mode":
                 if body[field] not in ("range", "single"):
@@ -1043,6 +1091,15 @@ async def upsert_thermostat(request: web.Request) -> web.Response:
                 if not isinstance(val, int) or isinstance(val, bool) or val < 0:
                     return error("unavailable_abort_after_min must be a non-negative integer")
                 setattr(tc, field, val)
+            elif field in _THERMO_NUMERIC_BOUNDS:
+                # cycle_timeout_hours / max_vent_closed_min / *_min fields — the
+                # engine does timedelta/interval arithmetic on these, so reject
+                # non-numeric and out-of-range values rather than store them and
+                # crash a later tick (Issue #295).
+                err = _validate_thermostat_numeric(field, body[field])
+                if err is not None:
+                    return err
+                setattr(tc, field, body[field])
             else:
                 setattr(tc, field, body[field])
     await db.upsert_thermostat_config(conn, tc)

--- a/smart_vent/backend/tests/integration/test_routes_coverage.py
+++ b/smart_vent/backend/tests/integration/test_routes_coverage.py
@@ -575,6 +575,79 @@ class TestThermostats:
             )
             assert resp.status == 400, f"fraction {bad!r} should be rejected"
 
+    # Issue #295: safety-critical numeric fields must be validated, not stored
+    # verbatim (a string or negative value otherwise crashes the engine tick).
+    _SAFETY_NUMERIC_FIELDS = (
+        "deadband",
+        "overshoot_delta",
+        "max_vent_closed_min",
+        "cycle_timeout_hours",
+        "reconciliation_interval_min",
+        "min_cycle_runtime_min",
+        "min_cycle_offtime_min",
+    )
+
+    async def test_create_thermostat_rejects_non_numeric_safety_fields(self, client):
+        base = {"thermostat_entity_id": "climate.bad", "total_vents_count": 6}
+        for field in self._SAFETY_NUMERIC_FIELDS:
+            resp = await client.post("/api/thermostats", json={**base, field: "nope"})
+            assert resp.status == 400, f"{field}='nope' must be rejected"
+
+    async def test_create_thermostat_rejects_negative_safety_fields(self, client):
+        base = {"thermostat_entity_id": "climate.bad", "total_vents_count": 6}
+        for field in self._SAFETY_NUMERIC_FIELDS:
+            resp = await client.post("/api/thermostats", json={**base, field: -1})
+            assert resp.status == 400, f"{field}=-1 must be rejected"
+
+    async def test_create_thermostat_rejects_zero_cycle_timeout(self, client):
+        # A zero hard-timeout would instantly time out every cycle.
+        resp = await client.post(
+            "/api/thermostats",
+            json={
+                "thermostat_entity_id": "climate.bad",
+                "total_vents_count": 6,
+                "cycle_timeout_hours": 0,
+            },
+        )
+        assert resp.status == 400
+
+    async def test_update_thermostat_rejects_invalid_safety_fields(self, client):
+        await client.post(
+            "/api/thermostats",
+            json={"thermostat_entity_id": "climate.up", "total_vents_count": 6},
+        )
+        for field in self._SAFETY_NUMERIC_FIELDS:
+            resp = await client.put("/api/thermostats/climate.up", json={field: "nope"})
+            assert resp.status == 400, f"PUT {field}='nope' must be rejected"
+            resp = await client.put("/api/thermostats/climate.up", json={field: -2})
+            assert resp.status == 400, f"PUT {field}=-2 must be rejected"
+
+    async def test_safety_numeric_fields_persist_valid_values(self, client):
+        resp = await client.post(
+            "/api/thermostats",
+            json={
+                "thermostat_entity_id": "climate.ok",
+                "total_vents_count": 6,
+                "deadband": 1.0,
+                "overshoot_delta": 1.5,
+                "max_vent_closed_min": 10,
+                "cycle_timeout_hours": 2.0,
+                "reconciliation_interval_min": 5,
+                "min_cycle_runtime_min": 3,
+                "min_cycle_offtime_min": 4,
+            },
+        )
+        assert resp.status == 201
+        data = await resp.json()
+        # Default unit is °F, so delta conversion is identity.
+        assert data["deadband"] == 1.0
+        assert data["overshoot_delta"] == 1.5
+        assert data["max_vent_closed_min"] == 10
+        assert data["cycle_timeout_hours"] == 2.0
+        assert data["reconciliation_interval_min"] == 5
+        assert data["min_cycle_runtime_min"] == 3
+        assert data["min_cycle_offtime_min"] == 4
+
     async def test_create_thermostat_airflow_fields_persist(self, client):
         """All three airflow fields round-trip through POST → GET."""
         resp = await client.post(


### PR DESCRIPTION
## What & why

Fixes #295.

`setup_aiohttp_apispec` is wired without the validation middleware, so `@request_schema` is documentation-only and request bodies are not validated against their schemas. Several thermostat-config fields then fell through the generic `else: setattr(tc, field, body[field])` in both `create_thermostat` and `upsert_thermostat` with **no type/range check** — `cycle_timeout_hours`, `max_vent_closed_min`, `reconciliation_interval_min`, `min_cycle_runtime_min`, `min_cycle_offtime_min` were stored verbatim, and `deadband`/`overshoot_delta` were converted but unbounded. A string or negative value would then crash the engine tick (`timedelta(hours=…)`, deadband comparisons) — and, per #286, that exception was swallowed, silently killing the zone. A negative deadband also inverts the at-target comparison.

## Fix

Added `_validate_thermostat_numeric(field, val)` plus a `_THERMO_NUMERIC_BOUNDS` table (mirroring the existing `min_open_vents_fraction` / `unavailable_abort_after_min` validation pattern, and the Thermostats-page input `min` attributes):

| field | bound |
|---|---|
| `deadband`, `overshoot_delta`, `max_vent_closed_min`, `reconciliation_interval_min`, `min_cycle_runtime_min`, `min_cycle_offtime_min` | `>= 0` |
| `cycle_timeout_hours` | `> 0` (a zero hard timeout would instantly time out every cycle) |

Non-numeric (incl. `bool`) and out-of-range values are rejected with a 400 in **both** `create_thermostat` and `upsert_thermostat`. `deadband`/`overshoot_delta` are now validated before the `_delta_to_f` conversion. These fields already have UI controls (Thermostats page SAFETY_FIELDS), so no new UI is needed.

## Test plan

TDD — added to `TestThermostats` (rejection tests written failing first):

- `test_create_thermostat_rejects_non_numeric_safety_fields` / `…_rejects_negative_safety_fields` / `…_rejects_zero_cycle_timeout`.
- `test_update_thermostat_rejects_invalid_safety_fields` (PUT, non-numeric and negative).
- `test_safety_numeric_fields_persist_valid_values` — valid values still round-trip through POST → response.

- Full backend suite: 814 passed, coverage 93.23%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_