### PR TITLE
Harden HA WebSocket reconnect: pace clean closes and timeout the handshake/subscribe (#297)

### DIFF
--- a/smart_vent/backend/ha_client.py
+++ b/smart_vent/backend/ha_client.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import ssl
+import time
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
@@ -37,6 +38,23 @@ log = logging.getLogger(__name__)
 
 StateCallback = Callable[[str, dict], Coroutine]
 
+# Connection-lifecycle pacing (Issue #297).
+# Minimum delay between reconnect attempts — also applied after a *clean* close
+# so a peer that accepts then immediately drops the socket (e.g. during an HA
+# restart) can't be hammered with a zero-delay busy loop.
+_MIN_RECONNECT_DELAY_S = 1
+_MAX_RECONNECT_DELAY_S = 60
+# A connection that stayed up at least this long is treated as a real session,
+# so the backoff resets; shorter-lived connections keep the backoff growing.
+_STABLE_CONNECTION_S = 30
+# Hard timeout for the unguarded connect-phase receives (auth handshake and the
+# subscribe ack). Without it a half-open socket / hung proxy that never sends
+# `auth_required` would block start() forever and the reconnect loop would never
+# run again.
+_HANDSHAKE_TIMEOUT_S = 10
+# WebSocket heartbeat (ping) interval so a silently-dropped peer is detected.
+_WS_HEARTBEAT_S = 30
+
 
 class HAClient:
     """Async HA WebSocket client. Call `start()` once; it runs forever."""
@@ -54,6 +72,10 @@ class HAClient:
         self._listeners: dict[str, list[StateCallback]] = defaultdict(list)
         self._wildcard_listeners: list[StateCallback] = []
         self._connected = asyncio.Event()
+        # Monotonic timestamp of when the current connection became ready; used
+        # to decide whether a connection stayed up long enough to reset the
+        # reconnect backoff. (Issue #297)
+        self._connected_since: float | None = None
         self._running = False
         # Cache of entity states: entity_id → state dict
         self._state_cache: dict[str, dict] = {}
@@ -77,16 +99,30 @@ class HAClient:
         ssl_ctx: ssl.SSLContext | bool = (_SSL_CONTEXT or True) if self._ssl_verify else False
         connector = aiohttp.TCPConnector(ssl=ssl_ctx)
         self._session = aiohttp.ClientSession(connector=connector)
-        backoff = 1
+        backoff = _MIN_RECONNECT_DELAY_S
         while self._running:
+            self._connected_since = None
             try:
                 await self._connect()
-                backoff = 1
             except Exception as exc:
-                log.warning("HA WS disconnected: %s — retrying in %ds", exc, backoff)
-                self._connected.clear()
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 60)
+                log.warning("HA WS error: %s", exc)
+            self._connected.clear()
+            if not self._running:
+                break
+            # A clean close (the read loop ending) reaches here too — treat it
+            # like a failure for pacing. Reset the backoff only if the connection
+            # stayed up long enough to count as a real session; otherwise a peer
+            # that accepts then immediately closes would reset us to the minimum
+            # and spin: connect → auth → full state fetch → subscribe → close,
+            # with zero delay, hammering HA. (Issue #297)
+            if (
+                self._connected_since is not None
+                and time.monotonic() - self._connected_since >= _STABLE_CONNECTION_S
+            ):
+                backoff = _MIN_RECONNECT_DELAY_S
+            log.warning("HA WS disconnected — reconnecting in %ds", backoff)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _MAX_RECONNECT_DELAY_S)
 
     async def stop(self) -> None:
         self._running = False
@@ -428,7 +464,7 @@ class HAClient:
         ) + "/api/websocket"
         log.info("Connecting to %s", ws_url)
         try:
-            async with self._session.ws_connect(ws_url) as ws:
+            async with self._session.ws_connect(ws_url, heartbeat=_WS_HEARTBEAT_S) as ws:
                 self._ws = ws
                 await self._handshake()
                 # Populate state cache before signalling ready
@@ -445,6 +481,7 @@ class HAClient:
                     log.debug("Could not resolve HA temperature unit on connect: %s", exc)
                 await self._subscribe_state_changed()
                 self._connected.set()
+                self._connected_since = time.monotonic()
                 log.info("HA WebSocket connected and subscribed")
                 await self._read_loop()
         finally:
@@ -459,10 +496,13 @@ class HAClient:
 
     async def _handshake(self) -> None:
         assert self._ws is not None
-        msg = await self._ws.receive_json()
+        # Guard the connect-phase receives with a timeout: a peer that accepts
+        # the upgrade but never sends `auth_required` (hung proxy / half-open
+        # socket) would otherwise block start() forever. (Issue #297)
+        msg = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT_S)
         assert msg["type"] == "auth_required", f"Unexpected: {msg}"
         await self._ws.send_json({"type": "auth", "access_token": self._token})
-        msg = await self._ws.receive_json()
+        msg = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT_S)
         if msg["type"] != "auth_ok":
             raise ValueError(f"HA auth failed: {msg}")
         log.debug("HA auth OK (version=%s)", msg.get("ha_version"))
@@ -478,7 +518,7 @@ class HAClient:
                 "event_type": "state_changed",
             }
         )
-        resp = await self._ws.receive_json()
+        resp = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT_S)
         assert resp.get("success"), f"Subscribe failed: {resp}"
         self._sub_id = sub_id
 

--- a/smart_vent/backend/tests/test_ha_client_internals.py
+++ b/smart_vent/backend/tests/test_ha_client_internals.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -49,6 +50,25 @@ class TestHandshake:
         with pytest.raises(ValueError, match="auth failed"):
             await client._handshake()
 
+    async def test_handshake_times_out_on_silent_peer(self):
+        """Issue #297: a peer that accepts the upgrade but never sends
+        `auth_required` must not block forever — the receive is timeout-guarded."""
+        client = HAClient("ws://ha.local", "tok")
+        mock_ws = AsyncMock()
+
+        async def slow_receive():
+            await asyncio.sleep(0.3)  # longer than the patched handshake timeout
+            return {"type": "auth_required"}
+
+        mock_ws.receive_json = slow_receive
+        mock_ws.send_json = AsyncMock()
+        client._ws = mock_ws
+        with (
+            patch("backend.ha_client._HANDSHAKE_TIMEOUT_S", 0.05),
+            pytest.raises(TimeoutError),
+        ):
+            await client._handshake()
+
 
 # ---------------------------------------------------------------------------
 # _subscribe_state_changed()
@@ -78,6 +98,25 @@ class TestSubscribeStateChanged:
         client._ws = mock_ws
         client._msg_id = 0
         with pytest.raises(AssertionError):
+            await client._subscribe_state_changed()
+
+    async def test_subscribe_times_out_on_silent_peer(self):
+        """Issue #297: the subscribe ack receive is timeout-guarded too."""
+        client = HAClient("ws://ha.local", "tok")
+        mock_ws = AsyncMock()
+        mock_ws.send_json = AsyncMock()
+
+        async def slow_receive():
+            await asyncio.sleep(0.3)
+            return {"success": True, "id": 1}
+
+        mock_ws.receive_json = slow_receive
+        client._ws = mock_ws
+        client._msg_id = 0
+        with (
+            patch("backend.ha_client._HANDSHAKE_TIMEOUT_S", 0.05),
+            pytest.raises(TimeoutError),
+        ):
             await client._subscribe_state_changed()
 
 
@@ -185,6 +224,75 @@ class TestStart:
 
         assert call_count == 2
 
+    async def test_clean_close_paces_reconnect_without_busy_loop(self):
+        """Issue #297: a clean close (read loop ending) must still pace the
+        reconnect — a short-lived connection keeps the backoff growing instead
+        of resetting to the minimum with zero delay."""
+        client = HAClient("ws://ha.local", "tok")
+        sleeps: list[float] = []
+        count = 0
+
+        async def quick_clean_connect():
+            nonlocal count
+            count += 1
+            # The connection "comes up" but closes immediately (short session).
+            client._connected_since = time.monotonic()
+            if count >= 3:
+                client._running = False
+
+        async def fake_sleep(d):
+            sleeps.append(d)
+
+        with (
+            patch("aiohttp.TCPConnector", return_value=MagicMock()),
+            patch("aiohttp.ClientSession", return_value=AsyncMock()),
+            patch("asyncio.sleep", fake_sleep),
+        ):
+            client._connect = quick_clean_connect
+            await client.start()
+
+        # Every clean close paced a non-zero sleep (no busy loop) and the backoff
+        # grew because the connection never stayed up long enough to reset it.
+        assert len(sleeps) == 2
+        assert all(d > 0 for d in sleeps)
+        assert sleeps[1] > sleeps[0]
+
+    async def test_stable_connection_resets_backoff(self):
+        """Issue #297: a connection that stayed up long enough resets the
+        backoff to the minimum."""
+        client = HAClient("ws://ha.local", "tok")
+        sleeps: list[float] = []
+        count = 0
+        clock = [0.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        async def long_lived_connect():
+            nonlocal count
+            count += 1
+            client._connected_since = fake_monotonic()
+            clock[0] += 100  # 100 s elapse during the session → well past stable
+            if count >= 3:
+                client._running = False
+
+        async def fake_sleep(d):
+            sleeps.append(d)
+
+        with (
+            patch("aiohttp.TCPConnector", return_value=MagicMock()),
+            patch("aiohttp.ClientSession", return_value=AsyncMock()),
+            patch("asyncio.sleep", fake_sleep),
+            patch("time.monotonic", fake_monotonic),
+        ):
+            client._connect = long_lived_connect
+            await client.start()
+
+        # Each long-lived session reset the backoff, so every paced delay is the
+        # minimum (never grows).
+        assert sleeps
+        assert all(d == sleeps[0] for d in sleeps)
+
     async def test_start_ssl_verify_false_passes_false_to_connector(self):
         client = HAClient("ws://ha.local", "tok", ssl_verify=False)
         client._running = False  # don't loop
@@ -249,6 +357,30 @@ class TestConnect:
         assert connected_during_read == [True]
         # _connected must be cleared after _connect() returns (finally block)
         assert not client._connected.is_set()
+
+    async def test_connect_passes_heartbeat_to_ws_connect(self):
+        """Issue #297: ws_connect must be given a heartbeat so a silently
+        half-open socket is detected."""
+        client = HAClient("ws://ha.local", "tok")
+        client._handshake = AsyncMock()
+        client._subscribe_state_changed = AsyncMock()
+        client.fetch_states = AsyncMock(return_value=[])
+        client.get_temperature_unit = AsyncMock(return_value="F")
+        client._read_loop = AsyncMock()
+
+        mock_ws = AsyncMock()
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.ws_connect = MagicMock(return_value=mock_ctx)
+        client._session = mock_session
+
+        await client._connect()
+
+        _, kwargs = mock_session.ws_connect.call_args
+        assert kwargs.get("heartbeat") is not None
 
     async def test_connect_fetch_states_failure_is_swallowed(self):
         client = HAClient("ws://ha.local", "tok")


### PR DESCRIPTION
## What & why

Fixes #297. Two robustness defects in `backend/ha_client.py`'s connection lifecycle.

### A. No delay / backoff reset on a clean close → busy loop
`_connect()` returns **normally** when `_read_loop` ends on a clean close (the `async for` terminates / a `CLOSED` frame arrives). In that path the old loop did no `sleep` and reset `backoff` to 1. So if HA (or the supervisor proxy) accepts connections but closes them shortly after subscribe — e.g. during an HA restart — the client spun: connect → auth → **full `/api/states` fetch** → subscribe → close → repeat, with zero delay, hammering HA.

### B. Unguarded handshake/subscribe receives → can hang forever
`_handshake()` and `_subscribe_state_changed()` called `await self._ws.receive_json()` with no timeout, and `ws_connect` had no `heartbeat=`. If the peer accepts the upgrade but never sends `auth_required` (hung proxy / half-open socket), `start()` blocked forever inside `_connect()` and the reconnect loop never ran again — permanent loss of HA connectivity until restart.

## Fix

- The reconnect loop now treats a clean close like a failure for pacing: it always sleeps before reconnecting, and resets the backoff **only** if the connection stayed up at least `_STABLE_CONNECTION_S` (30 s), tracked via `_connected_since` (`time.monotonic()`). A short-lived connection keeps the backoff growing (1→2→…→60 s) instead of spinning.
- Both connect-phase receives are wrapped in `asyncio.wait_for(..., timeout=_HANDSHAKE_TIMEOUT_S)` (10 s), and `ws_connect` is passed `heartbeat=_WS_HEARTBEAT_S` (30 s).

## Test plan

TDD — added to `test_ha_client_internals.py` (written failing first):

- `TestHandshake::test_handshake_times_out_on_silent_peer` and `TestSubscribeStateChanged::test_subscribe_times_out_on_silent_peer` — a slow/silent peer raises `TimeoutError` instead of hanging.
- `TestConnect::test_connect_passes_heartbeat_to_ws_connect` — `ws_connect` is called with a `heartbeat`.
- `TestStart::test_clean_close_paces_reconnect_without_busy_loop` — a short-lived clean close still paces a non-zero, growing delay (no busy loop).
- `TestStart::test_stable_connection_resets_backoff` — a long-lived session resets the backoff to the minimum.

Existing `start()`/`_connect()`/handshake tests still pass.

- Full backend suite: 836 passed, coverage 93.32%.
- `ruff check` / `ruff format --check`: clean. `mypy`: clean.
- Branch rebased onto current `main` (post #311–#319 merges); no conflicts.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_