### PR TITLE
Compute vacation modal datetime-local min in local time (#294)

### DIFF
--- a/smart_vent/frontend/src/components/VacationModeModal.test.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import VacationModeModal from "./VacationModeModal";
+import { toDatetimeLocalString } from "./datetimeLocal";
 import * as api from "../api";
 
 vi.mock("../api");
@@ -52,6 +53,39 @@ describe("VacationModeModal — enable flow", () => {
     fireEvent.click(btn);
     expect(await screen.findByText(/in the future/i)).toBeInTheDocument();
     expect(api.enableVacationMode).not.toHaveBeenCalled();
+  });
+});
+
+describe("toDatetimeLocalString (Issue #294)", () => {
+  it("formats using LOCAL components, not UTC", () => {
+    // A stand-in Date that only implements the LOCAL getters. If the helper
+    // reached for the UTC getters (or toISOString) it could not produce this
+    // string from these values.
+    const localOnly = {
+      getFullYear: () => 2026,
+      getMonth: () => 5, // June (0-indexed)
+      getDate: () => 9,
+      getHours: () => 3,
+      getMinutes: () => 7,
+    } as unknown as Date;
+    expect(toDatetimeLocalString(localOnly)).toBe("2026-06-09T03:07");
+  });
+
+  it("zero-pads single-digit month/day/hour/minute", () => {
+    expect(toDatetimeLocalString(new Date(2026, 0, 1, 0, 0))).toBe("2026-01-01T00:00");
+  });
+});
+
+describe("VacationModeModal — datetime-local min (Issue #294)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  it("computes the min from local time so western timezones aren't blocked", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 9, 3, 7, 0));
+    render(<VacationModeModal current={OFF} onClose={vi.fn()} onChanged={vi.fn()} />);
+    const input = screen.getByLabelText(/Return date/i);
+    expect(input.getAttribute("min")).toBe(toDatetimeLocalString(new Date(Date.now() + 60_000)));
   });
 });
 

--- a/smart_vent/frontend/src/components/VacationModeModal.tsx
+++ b/smart_vent/frontend/src/components/VacationModeModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { enableVacationMode, disableVacationMode, type VacationMode } from "../api";
+import { toDatetimeLocalString } from "./datetimeLocal";
 
 interface Props {
   current: VacationMode;
@@ -142,7 +143,7 @@ export default function VacationModeModal({ current, onClose, onChanged }: Props
                 type="datetime-local"
                 value={returnAt}
                 onChange={(e) => setReturnAt(e.target.value)}
-                min={new Date(Date.now() + 60_000).toISOString().slice(0, 16)}
+                min={toDatetimeLocalString(new Date(Date.now() + 60_000))}
               />
               <div className="form-hint">
                 Vacation mode will end automatically at this local date and time and normal

--- a/smart_vent/frontend/src/components/datetimeLocal.ts
+++ b/smart_vent/frontend/src/components/datetimeLocal.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a Date as a `datetime-local` input value (`YYYY-MM-DDTHH:mm`) from its
+ * LOCAL components.
+ *
+ * A `datetime-local` input interprets its `value`/`min`/`max` as local time, so
+ * formatting via `toISOString()` (UTC) shifts the bound by the UTC offset — west
+ * of UTC that rejects perfectly valid near-future times. (Issue #294)
+ */
+export function toDatetimeLocalString(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}


### PR DESCRIPTION
## What & why

Fixes #294.

`VacationModeModal.tsx` set the `datetime-local` `min` with `new Date(Date.now() + 60_000).toISOString().slice(0, 16)`. A `datetime-local` input interprets `min` as **local** time, but `toISOString()` is **UTC**. West of UTC the minimum is hours in the future: at 10:00 local in UTC−5 the picker rejected everything before 15:01 local, blocking valid return times in the next 5 hours (the JS validation at submit would have accepted them). East of UTC the min is harmlessly in the past.

## Fix

Added `toDatetimeLocalString(date)` in a small `src/components/datetimeLocal.ts` module that formats `YYYY-MM-DDTHH:mm` from the date's **local** components (`getFullYear`/`getMonth`/`getDate`/`getHours`/`getMinutes`, zero-padded), and used it for the `min`. (Kept in its own module rather than exporting a non-component function from the modal, which would trip `react-refresh/only-export-components`.)

## Test plan

TDD — added to `VacationModeModal.test.tsx` (failing first):

- `toDatetimeLocalString` formats from local components — verified with a stand-in `Date` that only implements the **local** getters (a UTC/`toISOString` implementation could not produce the expected string), plus a zero-padding case. This is timezone-independent, so it catches the bug even in a UTC CI runner.
- The modal's `min` attribute equals `toDatetimeLocalString(now + 60s)` (wiring), under fake timers.

- Frontend: 14 test files pass; `npm run lint` and `npm run format:check` clean; coverage thresholds met (lines 90.5, statements 88, functions 86.6, branches 73.6).

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_