### PR TITLE
Make Dev Mode Clear durable with an id watermark (#303)

### DIFF
--- a/smart_vent/frontend/src/pages/DevMode.test.tsx
+++ b/smart_vent/frontend/src/pages/DevMode.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import DevMode from "./DevMode";
 import * as api from "../api";
 
@@ -108,6 +108,47 @@ describe("DevMode Page", () => {
     const clearBtn = screen.getByText("Clear");
     fireEvent.click(clearBtn);
     expect(screen.queryByText(/Vent opened/i)).not.toBeInTheDocument();
+  });
+
+  it("clear is durable: the 3s poll does not repopulate cleared rows but new ones still appear (Issue #303)", async () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <DevModeContext.Provider value={{ devMode: true, toggleDevMode: async () => {} }}>
+          <DevMode />
+        </DevModeContext.Provider>
+      );
+      // Flush the initial fetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByText(/Vent opened/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Clear"));
+      expect(screen.queryByText(/Vent opened/i)).not.toBeInTheDocument();
+
+      // The next poll returns the same rows plus a genuinely new one.
+      vi.mocked(api.getDevLogs).mockResolvedValue([
+        ...mockDevLogs,
+        {
+          id: 5,
+          timestamp: "2024-01-01T12:04:00",
+          message: "Fresh event",
+          level: "info",
+          category: "dev",
+          details: null,
+        },
+      ]);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      // Cleared rows stay gone; only the new row (higher id) shows.
+      expect(screen.queryByText(/Vent opened/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/Fresh event/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders all action-feed icon variants and the temperature column", async () => {

--- a/smart_vent/frontend/src/pages/DevMode.tsx
+++ b/smart_vent/frontend/src/pages/DevMode.tsx
@@ -173,14 +173,29 @@ export default function DevModePage() {
   const [entries, setEntries] = useState<EventLogEntry[]>([]);
   const [zones, setZones] = useState<ZoneStatus[]>([]);
   const [loading, setLoading] = useState(true);
+  // "Cleared" watermark: rows with id <= this are hidden so the 3s poll can't
+  // repopulate a feed the user cleared. Genuinely new events have higher ids
+  // and still appear. (Issue #303)
+  const clearedBeforeIdRef = useRef(0);
 
   const fetchLogs = async () => {
     try {
       const logs = await getDevLogs(500);
-      setEntries(logs.slice().reverse()); // oldest first for the feed
+      const visible = logs.filter((l) => l.id > clearedBeforeIdRef.current);
+      setEntries(visible.slice().reverse()); // oldest first for the feed
     } catch {
       /* ignore */
     }
+  };
+
+  const clearFeed = () => {
+    // Durable clear: record the newest id currently shown as a watermark, then
+    // empty the feed. Subsequent polls filter everything at or below it.
+    clearedBeforeIdRef.current = entries.reduce(
+      (max, e) => Math.max(max, e.id),
+      clearedBeforeIdRef.current
+    );
+    setEntries([]);
   };
 
   const fetchZones = async () => {
@@ -207,7 +222,6 @@ export default function DevModePage() {
       clearInterval(logsInterval);
       clearInterval(zonesInterval);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [devMode]);
 
   if (!devMode) {
@@ -278,7 +292,7 @@ export default function DevModePage() {
             <span className="text-muted text-sm">
               auto-refreshes every 3s · {entries.length} entries
             </span>
-            <button className="btn btn-secondary btn-sm" onClick={() => setEntries([])}>
+            <button className="btn btn-secondary btn-sm" onClick={clearFeed}>
               Clear
             </button>
           </div>


### PR DESCRIPTION
## What & why

Fixes #303.

The Dev Mode "Clear" button did `onClick={() => setEntries([])}`, clearing only local state. The polling `fetchLogs` re-fetches the same persisted rows every 3 s and replaces the feed wholesale, so the cleared feed fully repopulated — Clear appeared to work, then everything came back.

## Fix

Added a `clearedBeforeIdRef` watermark. Clicking Clear records the newest event id currently shown and empties the feed; `fetchLogs` filters every poll to rows with `id > clearedBeforeIdRef.current`. Event-log ids are monotonic, so already-seen rows stay cleared while genuinely new events (higher ids) still appear. No API change — the clear is durable for the session.

Also removed a now-spurious `// eslint-disable-next-line react-hooks/exhaustive-deps` in the same effect (ESLint reported it as an unused directive); `npm run lint` is now fully clean.

## Test plan

TDD — added `clear is durable: the 3s poll does not repopulate cleared rows but new ones still appear` to `DevMode.test.tsx` (failing first): renders the feed, clicks Clear, then drives the 3 s poll under fake timers with the mock returning the same rows plus a new id. Asserts the cleared rows stay gone and only the new row appears. Failed before (rows repopulated), passes after. Existing `allows clearing logs` test still passes.

- Frontend: all DevMode tests pass; `npm run lint` clean; `npm run format:check` clean; coverage thresholds met.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_