### PR TITLE
Memoize unit context and refresh thermostat baseline on save (#293)

### DIFF
--- a/smart_vent/frontend/src/App.test.tsx
+++ b/smart_vent/frontend/src/App.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "./App";
 import * as api from "./api";
+import * as contexts from "./contexts";
 import { MemoryRouter } from "react-router-dom";
 
 vi.mock("./api");
@@ -38,6 +39,34 @@ describe("App Root", () => {
     const roomsLink = screen.getAllByText(/Rooms/i)[0]; // Link in nav
     fireEvent.click(roomsLink);
     expect(await screen.findByText(/Rooms/i, { selector: ".page-title" })).toBeInTheDocument();
+  });
+
+  it("memoizes the unit context so a system toggle does not rebuild it (Issue #293)", async () => {
+    vi.mocked(api.setSystemEnabled).mockResolvedValue({ enabled: false });
+    const buildSpy = vi.spyOn(contexts, "buildUnitContext");
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <App />
+      </MemoryRouter>
+    );
+    await screen.findByLabelText(/Settings/i);
+    // Sanity: the spy actually captures AppRoot's calls.
+    await waitFor(() => expect(buildSpy).toHaveBeenCalled());
+    const before = buildSpy.mock.calls.length;
+
+    // Toggle System Off — re-renders AppRoot (toggling, then enabled) but leaves
+    // the unit unchanged. The memoized context must NOT be rebuilt.
+    fireEvent.click(screen.getByLabelText(/Settings/i));
+    fireEvent.click(await screen.findByText(/System On/i));
+    fireEvent.click(screen.getByRole("button", { name: /Confirm/i }));
+    await waitFor(() => expect(api.setSystemEnabled).toHaveBeenCalled());
+    // Re-open the menu to confirm the toggle settled (forces the post-toggle
+    // re-renders to have flushed).
+    fireEvent.click(screen.getByLabelText(/Settings/i));
+    expect(await screen.findByText(/System Off/i)).toBeInTheDocument();
+
+    expect(buildSpy.mock.calls.length).toBe(before);
+    buildSpy.mockRestore();
   });
 
   it("toggles system status via dropdown and confirmation", async () => {

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useRef, useState } from "react";
+import React, { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { Route, Routes, NavLink } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Rooms from "./pages/Rooms";
@@ -80,7 +80,11 @@ function AppRoot({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const unitContextValue = buildUnitContext(unit);
+  // Memoize so the context object (and its toDisplay/toDisplayDelta function
+  // identities) stays stable across AppRoot re-renders — toggling System
+  // On/Off or Dev Mode re-renders AppRoot, and a fresh context every time would
+  // reset every Thermostat card's in-progress form edits. (Issue #293)
+  const unitContextValue = useMemo(() => buildUnitContext(unit), [unit]);
 
   return (
     <SystemContext.Provider value={{ enabled, toggle }}>

--- a/smart_vent/frontend/src/pages/Thermostats.test.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.test.tsx
@@ -148,6 +148,46 @@ describe("Thermostats Page", () => {
     });
   });
 
+  it("keeps saved edits after a unit-context identity change instead of regressing to pre-save values (Issue #293)", async () => {
+    vi.mocked(api.updateThermostat).mockResolvedValue({
+      ...mockThermostats[0],
+      name: "Renamed HVAC",
+    });
+
+    const { rerender } = render(
+      <UnitContext.Provider value={buildUnitContext("F")}>
+        <Thermostats />
+      </UnitContext.Provider>
+    );
+
+    const nameInput = (await screen.findByDisplayValue("Main HVAC")) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Renamed HVAC" } });
+
+    const card = nameInput.closest(".card") as HTMLElement;
+    fireEvent.click(within(card).getByText("Save changes"));
+
+    await waitFor(() =>
+      expect(api.updateThermostat).toHaveBeenCalledWith(
+        "climate.test",
+        expect.objectContaining({ name: "Renamed HVAC" })
+      )
+    );
+    // Wait until the save fully settles (onSaved → parent baseline updated).
+    await screen.findByText("Saved!");
+
+    // Simulate App re-rendering with fresh unit-context identities (the bug's
+    // trigger — e.g. toggling System/Dev). The card's reset effect fires; it
+    // must restore the just-SAVED name, not the pre-save page-load value.
+    rerender(
+      <UnitContext.Provider value={buildUnitContext("F")}>
+        <Thermostats />
+      </UnitContext.Provider>
+    );
+
+    expect(screen.getByDisplayValue("Renamed HVAC")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Main HVAC")).not.toBeInTheDocument();
+  });
+
   it("blocks registration when total vent count is missing (Issue #213)", async () => {
     render(<Thermostats />);
     fireEvent.click(await screen.findByText("+ Register thermostat"));

--- a/smart_vent/frontend/src/pages/Thermostats.tsx
+++ b/smart_vent/frontend/src/pages/Thermostats.tsx
@@ -254,9 +254,11 @@ function AddThermostatModal({
 function ThermostatCard({
   config,
   onDeleted,
+  onSaved,
 }: {
   config: ThermostatConfig;
   onDeleted: () => void;
+  onSaved?: (updated: ThermostatConfig) => void;
 }) {
   const { unitLabel, toDisplay, toDisplayDelta } = useUnit();
   // Form state holds temperatures in DISPLAY units (°C or °F as the user
@@ -317,7 +319,12 @@ function ThermostatCard({
     setSaving(true);
     setError("");
     try {
-      await updateThermostat(config.thermostat_entity_id, form);
+      const updated = await updateThermostat(config.thermostat_entity_id, form);
+      // Refresh the parent's baseline (°F storage units, as returned by the API)
+      // so a later form reset re-derives from the just-saved values — never the
+      // stale page-load config that would silently regress the DB on re-save.
+      // (Issue #293)
+      onSaved?.(updated);
       setSaved(true);
       if (savedTimerRef.current !== null) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
@@ -1027,7 +1034,18 @@ export default function Thermostats() {
         </div>
       ) : (
         configs.map((c) => (
-          <ThermostatCard key={c.thermostat_entity_id} config={c} onDeleted={load} />
+          <ThermostatCard
+            key={c.thermostat_entity_id}
+            config={c}
+            onDeleted={load}
+            onSaved={(updated) =>
+              setConfigs((cs) =>
+                cs.map((x) =>
+                  x.thermostat_entity_id === updated.thermostat_entity_id ? updated : x
+                )
+              )
+            }
+          />
         ))
       )}
 


### PR DESCRIPTION
## What & why

Fixes #293.

`AppRoot` built the unit context unmemoized: `const unitContextValue = buildUnitContext(unit)` — recreated with fresh `toDisplay`/`toDisplayDelta` function identities on **every** `AppRoot` render. `AppRoot` re-renders whenever `enabled`/`toggling`/`devMode`/`togglingDev` change (toggling System On/Off or Dev Mode, or a `system_enabled_changed` / `dev_mode_changed` WS event). Each render's new identities changed the deps of `Thermostats.tsx`'s reset effect (`[config, toDisplay, toDisplayDelta]`), so **every ThermostatCard form reset to `toDisplayForm(config)`**, discarding unsaved edits.

Worse, `save()` never refreshed the `config` prop (the page only reloaded on add/delete), so after a successful save a later context-identity flip reset the form to the **pre-save** values fetched at page load — clicking Save again wrote those stale values back to the DB. An actual data regression, not just a visual glitch.

## Fix

1. **Memoize the context** — `const unitContextValue = useMemo(() => buildUnitContext(unit), [unit])`, so the reset effect only fires on a genuine unit change, not on every AppRoot re-render.
2. **Refresh the parent baseline on save** — `ThermostatCard.save()` now propagates the `updateThermostat` PUT response via a new `onSaved` prop; the `Thermostats` page updates its `configs` entry. A later reset re-derives from the just-saved values, so it can never restore stale pre-save data.

## Test plan

TDD — both written failing first and verified red without the fix:

- `App.test.tsx`: *memoizes the unit context so a system toggle does not rebuild it* — spies on `buildUnitContext`; toggling System Off (which re-renders AppRoot) adds **zero** new calls with the memo (was 4 vs 1 without).
- `Thermostats.test.tsx`: *keeps saved edits after a unit-context identity change instead of regressing to pre-save values* — edits the name, saves, then re-renders with fresh unit-context identities; the field keeps the **saved** name, and the pre-save value is gone (without the `onSaved` baseline refresh it reverted).

- Frontend: `npm run lint` (only a pre-existing unrelated DevMode warning), `npm run format:check`, and coverage thresholds all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_