### PR TITLE
De-duplicate paginated log rows by id and ignore superseded fetches (#302)

### DIFF
--- a/smart_vent/frontend/src/pages/Logs.test.tsx
+++ b/smart_vent/frontend/src/pages/Logs.test.tsx
@@ -159,6 +159,67 @@ describe("Logs Page", () => {
     expect(api.clearEventLogs).not.toHaveBeenCalled();
   });
 
+  it("does not duplicate rows when loading older entries overlaps the window (Issue #302)", async () => {
+    // newest-first rows from `hi` down to `lo`, each with a unique message.
+    const makeRows = (hi: number, lo: number): api.EventLogEntry[] =>
+      Array.from({ length: hi - lo + 1 }, (_, i) => {
+        const id = hi - i;
+        return {
+          id,
+          timestamp: "2024-01-01T12:00:00",
+          message: `evt-${id}`,
+          level: "info" as const,
+          category: "system",
+          details: null,
+        };
+      });
+
+    // Initial load returns a full page (ids 100..51). The "Load older" fetch
+    // returns ids 51..2 — overlapping id 51 (as happens once a new head row
+    // has slid the offset window).
+    vi.mocked(api.getEventLogs)
+      .mockResolvedValueOnce(makeRows(100, 51))
+      .mockResolvedValueOnce(makeRows(51, 2));
+
+    render(<Logs />);
+    expect(await screen.findByText("evt-51")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Load older entries/i }));
+    // The genuinely-older rows arrive.
+    expect(await screen.findByText("evt-2")).toBeInTheDocument();
+
+    // The overlapping row must appear exactly once, not duplicated.
+    expect(screen.getAllByText("evt-51")).toHaveLength(1);
+  });
+
+  it("does not duplicate cycles when Load more overlaps the window (Issue #302)", async () => {
+    const makeCycles = (hi: number, lo: number): api.CycleLog[] =>
+      Array.from({ length: hi - lo + 1 }, (_, i) => {
+        const n = hi - i;
+        return {
+          id: `c${String(n).padStart(7, "0")}`, // 8 chars → unique slice(0,8)
+          thermostat_entity_id: "climate.test",
+          started_at: "2024-01-01T12:00:00",
+          ended_at: "2024-01-01T13:00:00",
+          mode: "cool",
+          rooms: {},
+        };
+      });
+    vi.mocked(api.getLogs).mockReset();
+    vi.mocked(api.getLogs)
+      .mockResolvedValueOnce(makeCycles(100, 51))
+      .mockResolvedValue(makeCycles(51, 2)); // overlap at c0000051
+
+    render(<Logs />);
+    fireEvent.click(screen.getByText("Cycle History"));
+    expect(await screen.findByText("c0000100…")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Load more/i }));
+    expect(await screen.findByText("c0000002…")).toBeInTheDocument();
+
+    expect(screen.getAllByText("c0000051…")).toHaveLength(1);
+  });
+
   it("filters the live feed by category and toggles levels", async () => {
     render(<Logs />);
     expect(await screen.findByText(/System started/i)).toBeInTheDocument();

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -673,6 +673,20 @@ function CycleExpanded({
 
 const PAGE_SIZE = 50;
 
+// Offset pagination can re-fetch rows that are already displayed once new rows
+// are inserted at the head (a new event/cycle, locally via WS or in the DB),
+// because the offset window slides. Merge by `id` so an overlapping page never
+// produces visible duplicates (or React duplicate-key warnings). (Issue #302)
+function mergeUniqueById<T extends { id?: string | number }>(
+  incoming: readonly T[],
+  existing: readonly T[],
+  where: "front" | "back"
+): T[] {
+  const seen = new Set(existing.map((x) => x.id).filter((id) => id != null));
+  const fresh = incoming.filter((x) => x.id == null || !seen.has(x.id));
+  return where === "front" ? [...fresh, ...existing] : [...existing, ...fresh];
+}
+
 function CycleHistory() {
   const [logs, setLogs] = useState<CycleLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -697,15 +711,23 @@ function CycleHistory() {
     return { limit: PAGE_SIZE, offset: currentOffset, since, until };
   };
 
+  const loadSeqRef = useRef(0);
+
   const load = async (reset = false) => {
+    const seq = ++loadSeqRef.current;
     setLoading(true);
     const nextOffset = reset ? 0 : offset;
     const rows = await getLogs(buildParams(nextOffset));
+    // Ignore a response that a newer load (e.g. a rapid filter switch) has
+    // superseded, so a slow stale fetch can't overwrite fresher data. (Issue #302)
+    if (seq !== loadSeqRef.current) return;
     if (reset) {
       setLogs(rows);
       setOffset(rows.length);
     } else {
-      setLogs((prev) => [...prev, ...rows]);
+      // Append older cycles at the bottom, dropping any the sliding offset
+      // window re-fetched (a new cycle started mid-browse).
+      setLogs((prev) => mergeUniqueById(rows, prev, "back"));
       setOffset((prev) => prev + rows.length);
     }
     setHasMore(rows.length === PAGE_SIZE);
@@ -878,18 +900,25 @@ function LiveFeed() {
     };
   };
 
+  const loadSeqRef = useRef(0);
+
   const load = async (reset = false) => {
+    const seq = ++loadSeqRef.current;
     setLoading(true);
     const nextOffset = reset ? 0 : offset;
     const rows = await getEventLogs(buildParams(nextOffset));
+    // Ignore a response that a newer load (rapid filter switch) superseded, so
+    // a slow stale fetch can't overwrite fresher data. (Issue #302)
+    if (seq !== loadSeqRef.current) return;
     // API returns newest-first; reverse so feed shows oldest-at-top
     const ordered = [...rows].reverse();
     if (reset) {
       setEntries(ordered);
       setOffset(rows.length);
     } else {
-      // Load more appends older entries at the top
-      setEntries((prev) => [...ordered, ...prev]);
+      // Load more prepends older entries at the top, dropping any the sliding
+      // offset window re-fetched (new events arrived at the head meanwhile).
+      setEntries((prev) => mergeUniqueById(ordered, prev, "front"));
       setOffset((prev) => prev + rows.length);
     }
     setHasMore(rows.length === PAGE_SIZE);
@@ -910,7 +939,10 @@ function LiveFeed() {
         const catOk = category === "all" || entry.category === category;
         const lvlOk = levels.includes(entry.level);
         if (catOk && lvlOk) {
-          setEntries((prev) => [...prev.slice(-499), entry]);
+          // Skip if this id is already shown (a load races a WS push). (Issue #302)
+          setEntries((prev) =>
+            prev.some((e) => e.id === entry.id) ? prev : [...prev.slice(-499), entry]
+          );
         }
       }
     });


### PR DESCRIPTION
## What & why

Fixes #302.

The Live Feed and Cycle History page newest-first with a numeric `offset`, while new rows are simultaneously inserted at the head (in the DB and locally via WS). After any new event the offset window has slid, so "Load older entries" / "Load more" re-fetched rows already displayed and merged them in again — visible twice, and with `key={e.id ?? i}` React logged duplicate-key warnings. Neither tab cancelled in-flight loads on rapid filter switches, so a slow stale response could overwrite a newer one.

## Fix

A small `mergeUniqueById(incoming, existing, where)` helper drops any incoming row whose `id` is already shown, then prepends ("front", Live Feed) or appends ("back", Cycle History). Applied to both load-more merges and the Live Feed WS append (which now also skips an id that's already present). Each `load` takes a `loadSeqRef` token and ignores its response if a newer load has superseded it, so a stale fetch can't clobber fresher data. (Offset still advances by the fetched count; the de-dup absorbs the head-insertion overlap with no gaps.)

## Test plan

TDD — added to `Logs.test.tsx` (both failing first):

- *does not duplicate rows when loading older entries overlaps the window* (Live Feed): initial page ids 100–51, then a "Load older" fetch returning 51–2 (overlapping id 51). The overlapping row renders exactly once (was twice).
- *does not duplicate cycles when Load more overlaps the window* (Cycle History): same scenario for cycles.

All 21 Logs tests pass. `npm run lint` (only a pre-existing unrelated DevMode warning), `npm run format:check`, and coverage thresholds all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_