### PR TITLE
Use delta conversion for overshoot + degree-minutes chart magnitudes in Celsius (#291, #292)

### DIFF
--- a/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
@@ -18,6 +18,7 @@ import {
   VentTimelineChart,
   ChartGrid,
 } from "./MetricsCharts";
+import { fmtOvershootDelta, localizeBinLabel, degreeMinutesSeries } from "./format";
 import { UnitContext, buildUnitContext } from "../../contexts";
 
 vi.mock("../../api");
@@ -311,5 +312,77 @@ describe("MetricsCharts", () => {
       // Only the empty grid wrapper, no chart cards
       expect(container.querySelectorAll(".chart-card").length).toBe(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Celsius delta conversion for chart magnitudes (Issues #291, #292)
+// ---------------------------------------------------------------------------
+
+const C = buildUnitContext("C");
+const F = buildUnitContext("F");
+
+describe("fmtOvershootDelta (Issue #291)", () => {
+  it("converts a 2°F overshoot DELTA to +1.1°C, not the absolute −16.7°C", () => {
+    expect(fmtOvershootDelta(2, C.toDisplayDelta, C.unitLabel)).toBe("1.1°C");
+  });
+  it("is identity (°F label) in Fahrenheit mode", () => {
+    expect(fmtOvershootDelta(2, F.toDisplayDelta, F.unitLabel)).toBe("2.0°F");
+  });
+  it("renders an em-dash for null", () => {
+    expect(fmtOvershootDelta(null, C.toDisplayDelta, C.unitLabel)).toBe("—");
+  });
+});
+
+describe("localizeBinLabel (Issue #291)", () => {
+  it("converts °F bin boundaries to °C deltas in Celsius mode", () => {
+    expect(localizeBinLabel("0–1°F", C.toDisplayDelta, C.unitLabel, true)).toBe("0.0–0.6°C");
+    expect(localizeBinLabel("≥5°F", C.toDisplayDelta, C.unitLabel, true)).toBe("≥2.8°C");
+  });
+  it("leaves backend °F labels unchanged in Fahrenheit mode", () => {
+    expect(localizeBinLabel("0–1°F", F.toDisplayDelta, F.unitLabel, false)).toBe("0–1°F");
+  });
+});
+
+describe("degreeMinutesSeries (Issue #292)", () => {
+  it("scales °F·min magnitudes by the DELTA conversion in Celsius mode", () => {
+    const out = degreeMinutesSeries([{ period: "2024-01-02", value: 90 }], C.toDisplayDelta);
+    expect(out[0].value).toBeCloseTo(50, 5); // 90 × 5/9
+  });
+  it("is identity in Fahrenheit mode", () => {
+    const out = degreeMinutesSeries([{ period: "2024-01-02", value: 90 }], F.toDisplayDelta);
+    expect(out[0].value).toBeCloseTo(90, 5);
+  });
+});
+
+describe("OvershootHistogramChart subtitle in Celsius (Issue #291)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getMetricsOvershootHistogram).mockResolvedValue({
+      thermostat_entity_id: entityId,
+      start_date: range.start,
+      end_date: range.end,
+      bin_size: 1,
+      labels: ["0–1°F", "1–2°F", "≥2°F"],
+      counts: [3, 1, 0],
+      total_room_cycles: 4,
+      overshot_count: 1,
+      overshot_pct: 25,
+      max_overshoot_f: 2,
+      avg_overshoot_f: 1,
+    });
+  });
+
+  it("shows a positive °C overshoot, never the negative absolute conversion", async () => {
+    render(
+      <UnitContext.Provider value={C}>
+        <OvershootHistogramChart entityId={entityId} range={range} />
+      </UnitContext.Provider>
+    );
+    await screen.findByText(/room-cycles overshot/i);
+    const subtitle = screen.getByText(/room-cycles overshot/i).textContent ?? "";
+    expect(subtitle).toContain("max 1.1°C"); // 2 × 5/9
+    expect(subtitle).toContain("avg 0.6°C"); // 1 × 5/9
+    expect(subtitle).not.toContain("-16"); // the buggy absolute conversion
   });
 });

--- a/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
@@ -45,7 +45,15 @@ import {
 } from "../../api";
 import ChartContainer from "../ChartContainer";
 import { COLORS, TOOLTIP_STYLE } from "./colors";
-import { fmtMinutes, fmtPercent, fmtSecondsAsHm, fmtTemperature, shortDayLabel } from "./format";
+import {
+  fmtMinutes,
+  fmtPercent,
+  fmtSecondsAsHm,
+  shortDayLabel,
+  fmtOvershootDelta,
+  localizeBinLabel,
+  degreeMinutesSeries,
+} from "./format";
 import { useUnit } from "../../contexts";
 
 interface Props {
@@ -496,15 +504,12 @@ export function RoomParticipationChart({ entityId, range }: Props) {
 // ---------------------------------------------------------------------------
 
 export function DegreeMinutesChart({ entityId, range }: Props) {
-  const { unitLabel } = useUnit();
+  const { unitLabel, toDisplayDelta } = useUnit();
   const { data, loading } = useFetch<MetricsTimeseries>(
     () => getMetricsTimeseries(entityId, "degree_minutes", "day", range),
     [entityId, range.start, range.end]
   );
-  const series = (data?.series ?? []).map((p) => ({
-    period: shortDayLabel(p.period),
-    value: p.value ?? 0,
-  }));
+  const series = degreeMinutesSeries(data?.series, toDisplayDelta);
   return (
     <ChartContainer
       title="Degree-minutes"
@@ -538,17 +543,17 @@ export function DegreeMinutesChart({ entityId, range }: Props) {
 // ---------------------------------------------------------------------------
 
 export function OvershootHistogramChart({ entityId, range }: Props) {
-  const { unit } = useUnit();
+  const { isCelsius, toDisplayDelta, unitLabel } = useUnit();
   const { data, loading } = useFetch<OvershootHistogram>(
     () => getMetricsOvershootHistogram(entityId, range),
     [entityId, range.start, range.end]
   );
   const series = (data?.labels ?? []).map((label, i) => ({
-    label,
+    label: localizeBinLabel(label, toDisplayDelta, unitLabel, isCelsius),
     count: data?.counts?.[i] ?? 0,
   }));
   const subtitle = data
-    ? `${data.overshot_count}/${data.total_room_cycles} room-cycles overshot — max ${fmtTemperature(data.max_overshoot_f, unit)}, avg ${fmtTemperature(data.avg_overshoot_f, unit)}`
+    ? `${data.overshot_count}/${data.total_room_cycles} room-cycles overshot — max ${fmtOvershootDelta(data.max_overshoot_f, toDisplayDelta, unitLabel)}, avg ${fmtOvershootDelta(data.avg_overshoot_f, toDisplayDelta, unitLabel)}`
     : undefined;
   return (
     <ChartContainer

--- a/smart_vent/frontend/src/components/charts/format.ts
+++ b/smart_vent/frontend/src/components/charts/format.ts
@@ -30,3 +30,60 @@ export function shortDayLabel(period: string): string {
   // period is "YYYY-MM-DD" from the timeseries endpoint.
   return period.length === 10 ? period.slice(5) : period;
 }
+
+// ---------------------------------------------------------------------------
+// Unit-aware DELTA formatters (Issues #291, #292)
+//
+// Overshoot magnitudes and degree-minutes are temperature *deltas*, so they
+// must use the delta conversion (×5/9, no −32). Using the absolute conversion
+// (`fmtTemperature`) on a delta yields nonsense — e.g. a 2 °F overshoot shows
+// as −16.7 °C.
+// ---------------------------------------------------------------------------
+
+/** Format an overshoot delta in the active unit, e.g. "1.1°C" / "2.0°F". */
+export function fmtOvershootDelta(
+  value: number | null | undefined,
+  toDisplayDelta: (fahrenheitDelta: number) => number,
+  unitLabel: string
+): string {
+  if (value == null) return "—";
+  return `${toDisplayDelta(value).toFixed(1)}${unitLabel}`;
+}
+
+/**
+ * Convert a backend overshoot-histogram bin label (°F boundaries, e.g. "0–1°F"
+ * or "≥5°F") into the active display unit. The backend hard-codes °F, so in
+ * Celsius mode both the boundaries and the suffix would otherwise be wrong.
+ * Left untouched in Fahrenheit mode so the °F formatting is preserved exactly.
+ */
+export function localizeBinLabel(
+  label: string,
+  toDisplayDelta: (fahrenheitDelta: number) => number,
+  unitLabel: string,
+  isCelsius: boolean
+): string {
+  if (!isCelsius) return label;
+  const open = label.match(/^≥\s*([\d.]+)/);
+  if (open) return `≥${toDisplayDelta(parseFloat(open[1])).toFixed(1)}${unitLabel}`;
+  const range = label.match(/^([\d.]+)\s*[–-]\s*([\d.]+)/);
+  if (range) {
+    const lo = toDisplayDelta(parseFloat(range[1])).toFixed(1);
+    const hi = toDisplayDelta(parseFloat(range[2])).toFixed(1);
+    return `${lo}–${hi}${unitLabel}`;
+  }
+  return label;
+}
+
+/**
+ * Build the degree-minutes area series, scaling each °F·min point by the delta
+ * conversion so the magnitude matches the unit label on the axis/tooltip.
+ */
+export function degreeMinutesSeries(
+  series: { period: string; value: number | null }[] | undefined,
+  toDisplayDelta: (fahrenheitDelta: number) => number
+): { period: string; value: number }[] {
+  return (series ?? []).map((p) => ({
+    period: shortDayLabel(p.period),
+    value: toDisplayDelta(p.value ?? 0),
+  }));
+}

--- a/smart_vent/frontend/src/components/charts/format.ts
+++ b/smart_vent/frontend/src/components/charts/format.ts
@@ -79,7 +79,7 @@ export function localizeBinLabel(
  * conversion so the magnitude matches the unit label on the axis/tooltip.
  */
 export function degreeMinutesSeries(
-  series: { period: string; value: number | null }[] | undefined,
+  series: { period: string; value?: number | null }[] | undefined,
   toDisplayDelta: (fahrenheitDelta: number) => number
 ): { period: string; value: number }[] {
   return (series ?? []).map((p) => ({


### PR DESCRIPTION
## What & why

Fixes #291 and #292 — two Celsius-mode chart display bugs in `MetricsCharts.tsx` caused by applying the **absolute** °F→°C conversion to **delta** quantities.

### #291 — Overshoot histogram subtitle showed negative °C
`max_overshoot_f` / `avg_overshoot_f` are deltas (degrees past target). The subtitle ran them through `fmtTemperature(…, "C")`, which does the absolute `(v−32)×5/9` — so a 2 °F max overshoot rendered as **−16.7 °C** instead of 1.1 °C (CLAUDE.md pitfall #4). The bin axis labels are also backend-generated with a hard-coded `°F` suffix and boundaries.

### #292 — Degree-minutes chart magnitudes were °F·min labeled with the active unit
The backend integrates `|setpoint − thermostat_temp|` over time in **°F**, so `p.value` is °F·min, but the tooltip/Y-axis stamped it with `unitLabel` (`°C·min` in Celsius) **without converting** — off by 1.8× (90 °F·min shown as "90.0 °C·min" when it's 50 °C·min).

## Fix

Added three pure, unit-aware helpers to `components/charts/format.ts` (kept out of `MetricsCharts.tsx` to avoid a `react-refresh/only-export-components` warning):

- `fmtOvershootDelta(value, toDisplayDelta, unitLabel)` — delta conversion for the subtitle.
- `localizeBinLabel(label, toDisplayDelta, unitLabel, isCelsius)` — converts the backend °F bin boundaries + suffix to the display unit in Celsius mode; leaves °F labels untouched in Fahrenheit mode.
- `degreeMinutesSeries(series, toDisplayDelta)` — scales each °F·min point by the delta conversion so axis/tooltip magnitude and label agree.

`OvershootHistogramChart` and `DegreeMinutesChart` now use these (via `useUnit().toDisplayDelta` / `isCelsius`). In Fahrenheit mode every helper is identity, so imperial behaviour is unchanged.

## Test plan

TDD — added to `MetricsCharts.test.tsx` (all failing first):

- `fmtOvershootDelta`: 2 °F → "1.1°C" (not "−16.7°C"); "2.0°F" in F mode; "—" for null.
- `localizeBinLabel`: "0–1°F" → "0.0–0.6°C", "≥5°F" → "≥2.8°C" in Celsius; unchanged in Fahrenheit.
- `degreeMinutesSeries`: 90 → 50 in Celsius; 90 → 90 in Fahrenheit.
- Render: `OvershootHistogramChart` in a Celsius context shows "max 1.1°C, avg 0.6°C" and never a negative absolute value.

All 28 MetricsCharts tests pass; `npm run lint` (only a pre-existing unrelated DevMode warning), `format:check`, and coverage thresholds pass. Branch rebased on current `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_