### PR TITLE
Localize vent timeline timestamps instead of rendering raw naive-UTC (#301)

### DIFF
--- a/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
@@ -264,6 +264,17 @@ describe("MetricsCharts", () => {
     expect(screen.getByText(/most recent 200 events/i)).toBeInTheDocument();
   });
 
+  it("renders vent timeline timestamps as localized time, not the raw naive-UTC string (Issue #301)", async () => {
+    // Backend vent-event timestamps are naive-UTC ISO strings. They must be
+    // parsed as UTC (append "Z") and localized, matching the Logs/DevMode views.
+    renderWithUnit(<VentTimelineChart entityId={entityId} range={range} />);
+    await screen.findByText(/Vent timeline/i);
+    const localized = new Date("2024-01-01T12:00:00Z").toLocaleString();
+    expect(screen.getByText(localized)).toBeInTheDocument();
+    // The raw, un-localized ISO string must NOT be shown.
+    expect(screen.queryByText("2024-01-01T12:00:00")).not.toBeInTheDocument();
+  });
+
   it("shows the vent-timeline empty state with no events", async () => {
     vi.mocked(api.getMetricsVentTimeline).mockResolvedValue({
       thermostat_entity_id: entityId,

--- a/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
@@ -714,7 +714,12 @@ export function VentTimelineChart({ entityId, range }: Props) {
             <tbody>
               {events.map((e, i) => (
                 <tr key={i}>
-                  <td style={{ padding: "4px 8px", whiteSpace: "nowrap" }}>{e.timestamp}</td>
+                  <td style={{ padding: "4px 8px", whiteSpace: "nowrap" }}>
+                    {/* Backend timestamps are naive-UTC; append "Z" so they're
+                        parsed as UTC and shown in local time (matches Logs/
+                        DevMode), not the raw timezone-shifted ISO string. (#301) */}
+                    {new Date(e.timestamp + "Z").toLocaleString()}
+                  </td>
                   <td style={{ padding: "4px 8px" }}>
                     <span
                       className="badge"


### PR DESCRIPTION
## What & why

Fixes #301.

The vent timeline rendered `{e.timestamp}` verbatim (`MetricsCharts.tsx`). Backend vent-event timestamps are **naive-UTC** ISO strings (`db.py` stores `replace(tzinfo=None).isoformat()`). Every other view appends `"Z"` and localizes (`new Date(ts + "Z").toLocaleString()` in `Logs.tsx` / `DevMode.tsx`), but the vent timeline printed the raw string with no timezone handling — so events appeared shifted by the user's UTC offset relative to the cycle times on the Logs page, and the raw `T`-separated ISO string is user-unfriendly.

## Fix

Render `new Date(e.timestamp + "Z").toLocaleString()`, matching the Logs/DevMode pattern (kept inline rather than adding a shared helper, to avoid colliding with the pending `format.ts` changes in the #291/#292 PR).

## Test plan

TDD — added `renders vent timeline timestamps as localized time, not the raw naive-UTC string` to `MetricsCharts.test.tsx` (failing first): asserts the cell shows `new Date("2024-01-01T12:00:00Z").toLocaleString()` and that the raw `"2024-01-01T12:00:00"` string is **not** present. Failed before (raw string), passes after.

All 21 MetricsCharts tests pass; `npm run lint` (only a pre-existing unrelated DevMode warning), `format:check`, and coverage thresholds pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZL9bB6Ly8iB5Tmj7xakKQ)_