### PR TITLE
CI: build the release image once, fork-PR artifact handoff, nightly ci-tag cleanup

### DIFF
--- a/.github/workflows/ci-image-cleanup.yml
+++ b/.github/workflows/ci-image-cleanup.yml
@@ -1,0 +1,92 @@
+name: Cleanup CI Images
+
+# Nightly housekeeping for the per-PR container pipeline.
+#
+# container-ci.yml pushes a throwaway ghcr.io/<repo>:ci-<sha> image on every
+# same-repo PR. Those tags pile up in GHCR forever. This workflow deletes
+# container versions whose tags are ALL ci-* and that are older than
+# RETENTION_DAYS. It never touches :latest or release (semver) tags — a version
+# carrying any non-ci-* tag is skipped, and untagged versions are left alone.
+#
+# Token: GITHUB_TOKEN works only if this repo has Admin access to the package
+# (package page → Settings → "Manage Actions access"). Deleting versions of a
+# USER-owned GHCR package via GITHUB_TOKEN can 403; if a scheduled run fails on
+# the DELETE call, create a classic PAT with `delete:packages` (+ `read:packages`)
+# and add it as the repo secret GHCR_CLEANUP_TOKEN — it is preferred when present.
+#
+# Use the workflow_dispatch "dry_run" input to preview deletions safely.
+
+on:
+  schedule:
+    - cron: "17 4 * * *" # 04:17 UTC nightly
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: "Delete ci-* image versions older than this many days"
+        required: false
+        default: "14"
+      dry_run:
+        description: "List what would be deleted without deleting"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete stale ci-* images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale ci-<sha> image versions
+        env:
+          GH_TOKEN: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+          RETENTION_DAYS: ${{ github.event.inputs.retention_days || '14' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          PACKAGE="${REPO#*/}" # strip "owner/" → bare package name
+          CUTOFF=$(date -u -d "${RETENTION_DAYS} days ago" +%s)
+          echo "Package: ${PACKAGE} (owner ${OWNER})"
+          echo "Deleting ci-* versions updated before $(date -u -d "@${CUTOFF}")"
+          echo "Dry run: ${DRY_RUN}"
+
+          PAGE=1
+          while :; do
+            RESP=$(gh api \
+              "/users/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100&page=${PAGE}" \
+              2>/dev/null || echo "[]")
+            COUNT=$(echo "$RESP" | jq 'length')
+            if [ "$COUNT" = "0" ]; then
+              break
+            fi
+
+            # Select versions whose tags are non-empty and ALL begin with "ci-",
+            # and whose updated_at is older than the cutoff. `all(empty)` is true,
+            # so the length guard prevents deleting untagged versions.
+            echo "$RESP" | jq -r --argjson cutoff "$CUTOFF" '
+              .[]
+              | select(
+                  (.metadata.container.tags | length) > 0
+                  and (all(.metadata.container.tags[]; startswith("ci-")))
+                  and ((.updated_at | fromdateiso8601) < $cutoff)
+                )
+              | "\(.id) \(.metadata.container.tags | join(","))"
+            ' | while read -r ID TAGS; do
+              echo "→ version ${ID} [${TAGS}]"
+              if [ "${DRY_RUN}" = "true" ]; then
+                echo "   (dry-run — not deleted)"
+              else
+                gh api -X DELETE \
+                  "/users/${OWNER}/packages/container/${PACKAGE}/versions/${ID}"
+                echo "   deleted"
+              fi
+            done
+
+            PAGE=$((PAGE + 1))
+          done
+          echo "Cleanup complete."

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -36,9 +36,21 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run when a newer commit lands on the same PR. Besides
+# saving CI minutes, this stops two concurrent runs of this workflow from racing
+# to reserve the same buildx/qemu (binfmt) GHA cache key — the "another job may
+# be creating this cache" warning seen when commits are pushed back-to-back.
+concurrency:
+  group: container-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # docker/build-push-action@v6 (and the other docker/* actions) still ship a
+  # Node.js 20 runtime, which GitHub has deprecated. Opt every JS action in this
+  # workflow into the Node.js 24 runtime to clear the deprecation warning.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # -----------------------------------------------------------------------

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -78,10 +78,16 @@ jobs:
 
           # Release PR? The release workflow opens it from a release/vX.Y.Z branch
           # and has already bumped smart_vent/config.yaml to the numeric version.
+          # Fork takes precedence: a fork can't push to GHCR, so even a fork PR
+          # named release/v* uses the artifact-handoff path, never the publish
+          # path (otherwise both build steps would fire and the push would fail).
           case "${HEAD_REF}" in
             release/v*) IS_RELEASE=true ;;
             *) IS_RELEASE=false ;;
           esac
+          if [ "${HEAD_REPO}" != "${IMAGE_NAME}" ]; then
+            IS_RELEASE=false
+          fi
           echo "is_release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
 
           REPO_LC=$(echo "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/container-ci.yml
+++ b/.github/workflows/container-ci.yml
@@ -1,14 +1,31 @@
 name: Container CI
 
 # Single source of truth for the per-PR container pipeline. Builds the addon
-# image ONCE (multi-arch) and pushes it to ghcr.io/<repo>:ci-<pr-sha>, then the
-# smoke test and the temperature-conversion E2E legs (F / C) PULL that one image
-# instead of each rebuilding it. Previously the same image was built ~4× per PR
-# (build-pr + smoke + E2E F + E2E C). Issues #330, #331, #332, #333.
+# image ONCE and reuses it for the smoke test and the temperature-conversion
+# E2E legs (F / C) instead of each rebuilding it. Previously the same image was
+# built ~4× per PR (build-pr + smoke + E2E F + E2E C).
+#
+# The `build` job has three modes, decided at runtime:
+#
+#   • Normal same-repo PR
+#       → multi-arch build, push ghcr.io/<repo>:ci-<sha> (throwaway).
+#         Downstream jobs PULL it.
+#
+#   • Release PR (head branch like release/v0.17.0)
+#       → multi-arch build, push the REAL ghcr.io/<repo>:<version> + :latest,
+#         then Trivy-scan it. Downstream jobs PULL the explicit :<version> tag
+#         (never :latest, so tests run against exactly the artifact being
+#         published). This replaces docker.yml's old build-release job — a
+#         release PR now builds the image ONCE instead of twice. See #337.
+#
+#   • Fork PR
+#       → fork tokens are read-only and cannot push to GHCR, so build
+#         single-arch, `docker save` to an artifact; downstream jobs
+#         download + `docker load` it (tagged plenum-e2e). See #337.
 #
 # Cross-job reuse needs `needs:` (same workflow), which is why the smoke test
-# (was lint.yml) and the conversion matrix (was e2e-conversion.yml) now live
-# here alongside the build.
+# (was lint.yml) and the conversion matrix (was e2e-conversion.yml) live here
+# alongside the build. Issues #330, #331, #332, #333 and #334 follow-ups (#337).
 
 on:
   pull_request:
@@ -25,10 +42,10 @@ env:
 
 jobs:
   # -----------------------------------------------------------------------
-  # Build the image once (multi-arch) and push it to a throwaway PR-SHA tag.
-  # Multi-arch so the same tag is pullable locally on amd64 or arm64 for
-  # manual testing (issue #332). This is also the required "Build (PR
-  # validation)" check — pushing the image IS the Dockerfile validation.
+  # Build the image once. Mode (ci-<sha> / release :<version> / fork artifact)
+  # is decided by the `meta` step. This is the required "Build (PR validation)"
+  # check — for a release PR it is also the publish + vulnerability scan that
+  # used to live in docker.yml's build-release job.
   # -----------------------------------------------------------------------
   build:
     name: Build (PR validation)
@@ -36,20 +53,54 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write # Trivy SARIF upload (release PRs only)
     outputs:
       image: ${{ steps.meta.outputs.image }}
+      is_fork: ${{ steps.meta.outputs.is_fork }}
+      is_release: ${{ steps.meta.outputs.is_release }}
     steps:
       - uses: actions/checkout@v6
 
+      - name: Compute build mode and image ref
+        id: meta
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Fork? A fork's head repo differs from this repo, and its GITHUB_TOKEN
+          # is read-only — it cannot push to GHCR.
+          if [ "${HEAD_REPO}" != "${IMAGE_NAME}" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Release PR? The release workflow opens it from a release/vX.Y.Z branch
+          # and has already bumped smart_vent/config.yaml to the numeric version.
+          case "${HEAD_REF}" in
+            release/v*) IS_RELEASE=true ;;
+            *) IS_RELEASE=false ;;
+          esac
+          echo "is_release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
+
+          REPO_LC=$(echo "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
+          echo "latest_image=${REPO_LC}:latest" >> "$GITHUB_OUTPUT"
+          if [ "${IS_RELEASE}" = "true" ]; then
+            VERSION=$(grep '^version:' smart_vent/config.yaml \
+              | sed 's/version:[[:space:]]*//' | tr -d '"')
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "image=${REPO_LC}:${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image=${REPO_LC}:ci-${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pin addon version for deterministic UI
+        # Non-release PRs pin to "CI" so screenshots/UI are deterministic. Release
+        # PRs MUST keep the real version so the published image shows v<version>.
+        if: steps.meta.outputs.is_release != 'true'
         run: |
           sed -i 's/^version:.*/version: CI/' smart_vent/config.yaml
-
-      - name: Compute image ref
-        id: meta
-        run: |
-          echo "image=${REGISTRY}/${IMAGE_NAME}:ci-${{ github.event.pull_request.head.sha }}" \
-            | tr '[:upper:]' '[:lower:]' >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -58,13 +109,30 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
+        if: steps.meta.outputs.is_fork != 'true'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # ── Release PR (same-repo): publish the real version tags ───────────────
+      - name: Build and push release image (multi-arch)
+        if: steps.meta.outputs.is_release == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./smart_vent
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}
+            ${{ steps.meta.outputs.latest_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Normal same-repo PR: throwaway ci-<sha> tag ─────────────────────────
       - name: Build and push CI image (multi-arch)
+        if: steps.meta.outputs.is_release != 'true' && steps.meta.outputs.is_fork != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./smart_vent
@@ -74,8 +142,84 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # ── Fork PR: can't push; build single-arch and hand off via artifact ────
+      # `load: true` only supports a single platform, which is fine: CI runners
+      # are amd64 and forks never need the arm64 variant (that exists only so the
+      # pushed tag is locally pullable on Apple Silicon — see #332).
+      - name: Build fork image (single-arch, load)
+        if: steps.meta.outputs.is_fork == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./smart_vent
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: plenum-e2e:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Save fork image to artifact
+        if: steps.meta.outputs.is_fork == 'true'
+        run: docker save plenum-e2e:latest -o /tmp/plenum-image.tar
+
+      - name: Upload fork image artifact
+        if: steps.meta.outputs.is_fork == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: plenum-image
+          path: /tmp/plenum-image.tar
+          retention-days: 1
+
+      # ── Release PR: vulnerability scan of the published image ───────────────
+      # (Moved from docker.yml's build-release job so a release PR builds once.)
+      - name: Run Trivy vulnerability scan on release image
+        if: steps.meta.outputs.is_release == 'true'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.meta.outputs.image }}
+          format: "table"
+          output: "trivy-report.txt"
+          trivyignores: ".trivyignore"
+
+      - name: Parse Trivy results for critical vulnerabilities
+        if: steps.meta.outputs.is_release == 'true'
+        run: |
+          # Match "CRITICAL: N" where N >= 1 — avoids false positives from
+          # summary lines like "CRITICAL: 0" that appear even when clean.
+          if grep -qE 'CRITICAL: [1-9]' trivy-report.txt; then
+            echo "❌ CRITICAL vulnerabilities found!" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else
+            echo "✅ No critical vulnerabilities found" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Display full Trivy report in summary
+        if: always() && steps.meta.outputs.is_release == 'true'
+        run: |
+          echo "## Container Image Vulnerability Scan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat trivy-report.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload Trivy SARIF for GitHub Security tab
+        if: steps.meta.outputs.is_release == 'true'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.meta.outputs.image }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          trivyignores: ".trivyignore"
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && steps.meta.outputs.is_release == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+
   # -----------------------------------------------------------------------
-  # Smoke test: pull the prebuilt image and confirm /api/healthz serves.
+  # Smoke test: obtain the prebuilt image and confirm /api/healthz serves.
+  # Same-repo PRs pull the pushed tag; fork PRs load the saved artifact.
   # (Was lint.yml → docker-smoke-test; same check name.)
   # -----------------------------------------------------------------------
   smoke:
@@ -86,7 +230,19 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Download fork image artifact
+        if: needs.build.outputs.is_fork == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: plenum-image
+          path: /tmp
+
+      - name: Load fork image
+        if: needs.build.outputs.is_fork == 'true'
+        run: docker load -i /tmp/plenum-image.tar
+
       - name: Log in to GitHub Container Registry
+        if: needs.build.outputs.is_fork != 'true'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -94,7 +250,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull prebuilt image
+        if: needs.build.outputs.is_fork != 'true'
         run: docker pull ${{ needs.build.outputs.image }}
+
+      - name: Resolve image ref
+        id: img
+        run: |
+          if [ "${{ needs.build.outputs.is_fork }}" = "true" ]; then
+            echo "ref=plenum-e2e:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ needs.build.outputs.image }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run Container Smoke Test
         run: |
@@ -106,7 +272,7 @@ jobs:
             -e HA_TOKEN=dummy \
             -e TIMEZONE=America/New_York \
             -e TEMPERATURE_UNIT=F \
-            ${{ needs.build.outputs.image }}
+            ${{ steps.img.outputs.ref }}
 
           echo "Waiting for /api/healthz to respond..."
           for i in $(seq 1 30); do
@@ -129,9 +295,9 @@ jobs:
           echo "Smoke test passed!"
 
   # -----------------------------------------------------------------------
-  # Temperature-conversion round-trip under both °F and °C. Each leg pulls
-  # the single prebuilt image (via PLENUM_IMAGE) instead of rebuilding.
-  # (Was e2e-conversion.yml; same "Round-trip (F|C)" check names.)
+  # Temperature-conversion round-trip under both °F and °C. Each leg reuses
+  # the single prebuilt image (pull for same-repo PRs, load-from-artifact for
+  # forks) instead of rebuilding. (Was e2e-conversion.yml; same check names.)
   # -----------------------------------------------------------------------
   conversion:
     name: Round-trip (${{ matrix.unit }})
@@ -145,14 +311,22 @@ jobs:
       fail-fast: false
       matrix:
         unit: [F, C]
-    env:
-      # docker-compose.test.yml uses this for the plenum service's image, so
-      # `compose up` reuses the pulled image and never rebuilds.
-      PLENUM_IMAGE: ${{ needs.build.outputs.image }}
     steps:
       - uses: actions/checkout@v6
 
+      - name: Download fork image artifact
+        if: needs.build.outputs.is_fork == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: plenum-image
+          path: /tmp
+
+      - name: Load fork image
+        if: needs.build.outputs.is_fork == 'true'
+        run: docker load -i /tmp/plenum-image.tar
+
       - name: Log in to GitHub Container Registry
+        if: needs.build.outputs.is_fork != 'true'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -160,7 +334,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull prebuilt image
-        run: docker pull "${PLENUM_IMAGE}"
+        if: needs.build.outputs.is_fork != 'true'
+        run: docker pull "${{ needs.build.outputs.image }}"
+
+      - name: Resolve PLENUM_IMAGE for compose
+        run: |
+          # docker-compose.test.yml's plenum service uses ${PLENUM_IMAGE:-plenum-e2e}.
+          # Same-repo: point it at the pulled tag. Fork: the loaded image is
+          # already tagged plenum-e2e (the compose default), so use that.
+          if [ "${{ needs.build.outputs.is_fork }}" = "true" ]; then
+            echo "PLENUM_IMAGE=plenum-e2e" >> "$GITHUB_ENV"
+          else
+            echo "PLENUM_IMAGE=${{ needs.build.outputs.image }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Compose file list
         id: compose

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # Clear the Node.js 20 deprecation warning from docker/build-push-action@v6
+  # and the other docker/* actions by opting into the Node.js 24 runtime.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # -----------------------------------------------------------------------

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,26 +3,28 @@ name: Build & Push Docker Image
 # Behaviour by trigger:
 #
 #   release/v* PR open/update → main
-#     ├─ build-release  : BUILD + PUSH :<version> and :latest  ← required check, blocks merge
-#     └─ (other jobs skipped)
+#     └─ Handled in container-ci.yml's "build" job, which builds the image ONCE
+#        and pushes :<version> + :latest (and Trivy-scans it). That single image
+#        is then reused by the smoke test and the °F/°C E2E legs. The old
+#        build-release job lived here and built the image a SECOND time; it was
+#        removed so a release PR builds once. See #337.
 #
 #   release/v* merged → main
-#     └─ All jobs skipped (image was already published during the PR)
+#     └─ build-and-push is skipped (image was already published during the PR).
 #
 #   Any other PR open/update → main
-#     └─ Dockerfile validation now lives in container-ci.yml's "build" job
+#     └─ Dockerfile validation lives in container-ci.yml's "build" job
 #        (build + push to a ci-<sha> tag, reused by smoke + E2E). See #333.
 #
 #   Any other branch merged → main
 #     └─ build-and-push : BUILD + PUSH — only when smart_vent/config.yaml changed
+#        (covers a version bump that lands outside the release/v* flow).
+#
+# This workflow therefore only does work on push-to-main now; all pull_request
+# container work moved to container-ci.yml.
 
 on:
   push:
-    branches:
-      - main
-    paths-ignore:
-      - 'e2e/screenshots/**'
-  pull_request:
     branches:
       - main
     paths-ignore:
@@ -33,102 +35,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # -----------------------------------------------------------------------
-  # Release PR: build AND push the versioned image while the PR is open.
-  # This job is the required status check that gates merging the release PR.
-  # Only runs for PRs from a release/v* branch.
-  # -----------------------------------------------------------------------
-  build-release:
-    name: Build & Push release image
-    if: |
-      github.event_name == 'pull_request' &&
-      startsWith(github.head_ref, 'release/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      security-events: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Read version from config.yaml
-        id: version
-        run: |
-          VERSION=$(grep '^version:' smart_vent/config.yaml \
-            | sed 's/version:[[:space:]]*//' \
-            | tr -d '"')
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Building release image version: ${VERSION}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push release image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./smart_vent
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Run Trivy vulnerability scan on image
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          format: "table"
-          output: "trivy-report.txt"
-          trivyignores: ".trivyignore"
-
-      - name: Parse Trivy results for critical vulnerabilities
-        run: |
-          # Match "CRITICAL: N" where N >= 1 — avoids false positives from
-          # summary lines like "CRITICAL: 0" that appear even when clean.
-          if grep -qE 'CRITICAL: [1-9]' trivy-report.txt; then
-            echo "❌ CRITICAL vulnerabilities found!" >> $GITHUB_STEP_SUMMARY
-            exit 1
-          else
-            echo "✅ No critical vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Display full Trivy report in summary
-        if: always()
-        run: |
-          echo "## Container Image Vulnerability Scan" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat trivy-report.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload Trivy SARIF for GitHub Security tab
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          trivyignores: ".trivyignore"
-
-      - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: "trivy-results.sarif"
-
   # -----------------------------------------------------------------------
   # Main push: only runs for non-release merges AND only if config.yaml
   # changed (i.e. a version bump landed outside the release PR flow).

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -4,6 +4,15 @@ name: Validate Release
 # suite, smoke-tests the container against /api/healthz, and runs E2E visual
 # regression tests against a live HA + Plenum stack.
 # Nothing is pushed. Run this before tagging to confirm a commit is releasable.
+#
+# Triggers:
+#   • workflow_dispatch — manual run against any ref (the original entry point).
+#   • pull_request to main — but the job only runs for release/v* PRs (gated by
+#     the job-level `if` below). The release PR is opened by the bot with
+#     GITHUB_TOKEN, so GitHub's loop guard means it won't auto-start; start it
+#     with one click from the PR's checks ("Run"/"Approve and run"). This is the
+#     extra pre-release test pass the release reviewer wants without having to
+#     hunt for the workflow in the Actions tab. See #337.
 
 on:
   workflow_dispatch:
@@ -12,10 +21,16 @@ on:
         description: "Branch or commit SHA to validate (defaults to current branch)"
         required: false
         default: ""
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'e2e/screenshots/**'
 
 jobs:
   validate:
     name: Release Validation
+    # Manual dispatch always runs; on a PR, only for release/v* branches.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release/v')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,6 +26,11 @@ on:
     paths-ignore:
       - 'e2e/screenshots/**'
 
+env:
+  # Clear the Node.js 20 deprecation warning from docker/setup-buildx-action by
+  # opting this workflow's JS actions into the Node.js 24 runtime.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   validate:
     name: Release Validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,14 @@ has a `bashio::config '<key>'` call in `run.sh`. Add new options to **both** fil
 | Frontend (ESLint + Prettier) | `npm ci` then `npm run lint` + `npm run format:check` + `npm run test:coverage` |
 | Security (Trivy source scan) | `trivy fs` vulnerability scan of the source tree |
 
-**Container CI (`.github/workflows/container-ci.yml`)** builds the addon image **once** (multi-arch), pushes it to `ghcr.io/<repo>:ci-<pr-sha>`, then reuses that single image for the **Build (PR validation)**, **Docker Smoke Test**, and **Round-trip (F)/(C)** temperature-conversion E2E checks — instead of rebuilding the container ~4× per PR. See #333. `docker-compose.test.yml`'s `plenum` service reads `${PLENUM_IMAGE}` so each E2E leg pulls the prebuilt image rather than rebuilding.
+**Container CI (`.github/workflows/container-ci.yml`)** builds the addon image **once** and reuses it for the **Build (PR validation)**, **Docker Smoke Test**, and **Round-trip (F)/(C)** temperature-conversion E2E checks — instead of rebuilding the container ~4× per PR. See #333. `docker-compose.test.yml`'s `plenum` service reads `${PLENUM_IMAGE}` so each E2E leg reuses the prebuilt image rather than rebuilding. The `build` job picks a mode at runtime (#337):
+- **Normal same-repo PR** → multi-arch build, push `ghcr.io/<repo>:ci-<pr-sha>` (throwaway); downstream jobs **pull** it.
+- **Release PR** (`release/vX.Y.Z` head) → multi-arch build, push the **real** `:<version>` + `:latest`, then Trivy-scan. Downstream jobs pull the explicit `:<version>` tag (never `:latest`). This is the publish + scan that used to be `docker.yml`'s `build-release` job — moving it here means a release PR builds **once** instead of twice. `docker.yml` now only builds on push-to-main (a config bump outside the release flow).
+- **Fork PR** → fork tokens are read-only, so build single-arch, `docker save` to an artifact; downstream jobs `docker load` it (tagged `plenum-e2e`, the compose default).
+
+The throwaway `ci-*` tags are pruned nightly by **`.github/workflows/ci-image-cleanup.yml`** (deletes `ci-*` versions older than `RETENTION_DAYS`; never `:latest` or semver tags). **`validate-release.yml`** also runs on `release/v*` PRs (one extra dry-run pass; click to start, since the bot PR won't auto-trigger it).
+
+**Branch protection:** since the release build moved out of `docker.yml`, the required check for release PRs is now **Build (PR validation)** (container-ci), not the old **Build & Push release image**.
 
 **Note:** All Python CI jobs install dependencies with `pip install ".[dev]"`, so
 runtime deps (aiohttp, apscheduler, aiosqlite, aiohttp-apispec, …) and test deps


### PR DESCRIPTION
Closes #337.

Follow-ups from the build-once container pipeline (#334). Three related changes plus a doc update and some CI hardening.

## What changed

### 1. Fork-PR image handoff (`container-ci.yml`)
The `build` job now selects a mode at runtime:
- **Normal same-repo PR** → multi-arch build, push `ghcr.io/<repo>:ci-<sha>` (throwaway); downstream jobs **pull** it. (unchanged)
- **Fork PR** → fork tokens are read-only and can't push to GHCR, so build single-arch, `docker save` to an artifact; `smoke` + `conversion` `docker load` it (tagged `plenum-e2e`, the compose default, so `PLENUM_IMAGE` stays unset).

**Fork takes precedence over release**: a fork PR whose head branch happens to be named `release/v*` uses the artifact path, not the publish path — otherwise both build steps would fire and the push would fail on the fork's read-only token. (Fixed in `5c93df6`.)

### 2. Release PR builds once (`container-ci.yml` + `docker.yml`)
On a same-repo `release/v*` PR the `build` job now builds + pushes the **real `:<version>` + `:latest`** and Trivy-scans it — the work that used to live in `docker.yml`'s `build-release` job, which built the image a **second** time. So a release PR now builds **once**.
- Smoke + the °F/°C round-trip pull the **explicit `:<version>` tag, never `:latest`**, so the tests exercise exactly the artifact being published.
- `build-release` is removed from `docker.yml`, and `docker.yml` no longer runs on `pull_request` (it only builds on push-to-main now, for a config bump outside the release flow). The release-merge skip on `main` is unchanged.

### 3. Nightly `ci-*` tag cleanup (`ci-image-cleanup.yml`, new)
Scheduled nightly (+ `workflow_dispatch` with a `dry_run` input). Deletes container versions whose tags are **all** `ci-*` and older than `RETENTION_DAYS` (default 14). Never touches `:latest` or semver tags; leaves untagged versions alone. Prefers a `GHCR_CLEANUP_TOKEN` PAT when present, else `GITHUB_TOKEN`.

### Extra: Validate Release on release PRs (`validate-release.yml`)
Added a `pull_request` trigger gated (job-level `if`) to `release/v*` branches, keeping `workflow_dispatch`. The release PR is bot-opened with `GITHUB_TOKEN`, so it won't auto-start — start it with one click from the PR checks.

### CI hardening (`effe5af`)
- **Node.js 20 deprecation:** set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on `container-ci.yml`, `docker.yml`, and `validate-release.yml` so `docker/build-push-action@v6` and the other `docker/*` actions stop emitting the Node 20 deprecation warning (GitHub forces Node 24 by default as of 2026-06-16 regardless).
- **Cache-reservation warning:** added a `concurrency` group to `container-ci.yml` so a newer commit cancels the in-progress run for the same PR. This was the cause of the benign "another job may be creating this cache" binfmt warning — two back-to-back pushes overlapped and raced on the shared buildx/qemu GHA cache key. Also saves CI minutes.

## ⚠️ Maintainer action required (one-time, in the GitHub UI)
1. **Branch protection:** the release build moved out of `docker.yml`, so the required check for release PRs changes from **"Build & Push release image"** → **"Build (PR validation)"** (container-ci). Settings → Branches → `main` → swap it, or release PRs will block on a check that no longer runs.
2. **Cleanup token:** run `Cleanup CI Images` once with **`dry_run: true`** to confirm it can enumerate versions. If a real run later 403s on delete (common for user-owned GHCR packages via `GITHUB_TOKEN`), add a PAT with `delete:packages` + `read:packages` as repo secret `GHCR_CLEANUP_TOKEN`. (Note: `workflow_dispatch` is only available once this is merged to `main`.)

## Test plan
- [x] All workflows parse (`yaml.safe_load`).
- [x] No test references the changed workflows (grep over `backend/tests`).
- [x] No dangling references to the removed `build-release` job (only comments remain).
- [x] Fork/release mode precedence: a `release/v*` fork PR resolves to the fork (artifact) path, exactly one build step fires.
- [x] Cleanup selection filter validated locally against a representative sample (only old `ci-*` selected; `latest`/semver/untagged/`ci-*+latest` all skipped).
- [ ] **Normal PR path** exercised by this PR's own `Build (PR validation)` + `Docker Smoke Test` + `Round-trip (F)/(C)` checks (same-repo, `ci-<sha>`).
- [ ] **Release path** verified on the next `release/v*` PR: one build, `:<version>` published, smoke + round-trip pull `:<version>`, Trivy runs.
- [ ] **Fork path** verified on a fork PR: artifact save/load, single-arch.
- [ ] **Cleanup** verified via `workflow_dispatch` `dry_run: true` after merge.

Note: GitHub Actions / Docker can't run in the dev sandbox, so the fork and release legs are validated by review + YAML parse here and fully exercised by the checks above.