### PR TITLE
Enforce comfort envelope when not in vacation mode (#367)

### DIFF
--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -91,7 +91,7 @@ class RoomOverrideRequestSchema(Schema):
 
 class RoomActiveStatusSchema(Schema):
     room_id = fields.Str()
-    source = fields.Str()  # 'schedule' | 'presence' | 'override' | 'idle'
+    source = fields.Str()  # 'schedule' | 'presence' | 'override' | 'safety' | 'idle'
     target_temp = fields.Float(allow_none=True)
     ends_in_seconds = fields.Int(allow_none=True)
     next_schedule_in_seconds = fields.Int(allow_none=True)

--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -127,6 +127,12 @@ class CycleEngine:
         # (Issue #211). Tracked per-engine so we warn once per stale episode
         # rather than every 60-second tick.
         self._stale_warned: set[str] = set()
+        # Rooms currently held active by per-room safety protection (Issue #367),
+        # so the activation warning is emitted once per breach episode rather
+        # than every tick the room stays over/under the envelope. Rooms that
+        # recover (or gain real demand) are dropped so a future breach warns
+        # again. See ``_add_safety_rooms``.
+        self._safety_warned_room_ids: set[str] = set()
         # Active staleness threshold (minutes). Refreshed at the start of each
         # tick from the ``sensor_stale_after_min`` system setting so changes
         # from the Settings page take effect on the next tick.
@@ -349,6 +355,15 @@ class CycleEngine:
         new_active = await get_active_rooms(conn, self.thermostat_entity_id)
         new_active_map = {ar.room.id: ar for ar in new_active}
 
+        # Per-room safety protection (Issue #367): pull in any zone room whose
+        # own temperature has breached the configured envelope — even with no
+        # presence, schedule, or override — so it is conditioned by a cycle
+        # instead of left to bake while other rooms run. Runs before the
+        # no-active-rooms gate so a breaching room with no other demand still
+        # triggers a protection cycle. The thermostat/system/vacation guards
+        # above have already returned, so reaching here means normal operation.
+        await self._add_safety_rooms(conn, new_active_map)
+
         # Surface room-sensor staleness before any decisions are made off the
         # (now stale-filtered) data. Once-per-episode rate-limited internally.
         await self._emit_sensor_freshness_warnings(new_active_map)
@@ -359,6 +374,11 @@ class CycleEngine:
             # IDLE reconciliation: ensure all zone vents are open even when no
             # rooms are scheduled. Only runs when system is enabled.
             if self._get_enabled is None or self._get_enabled():
+                # Safety backstop (Issue #367): with no room demand, none of the
+                # active-room logic below — where the max/min hard cap lives —
+                # runs, so enforce the envelope directly against thermostat
+                # ambient before the idle reconcile re-opens the zone vents.
+                await self._enforce_safety_setpoint(conn, thermo_state)
                 await self._maybe_reconcile(conn)
             return
 
@@ -475,6 +495,11 @@ class CycleEngine:
         if not new_active_map:
             if self._state != CycleState.IDLE:
                 await self._abort_cycle(conn, reason="no compatible rooms after filtering")
+            # Safety backstop (Issue #367): every room was filtered out, so no
+            # cycle will drive the thermostat this tick. The system-disabled and
+            # vacation guards above have already returned, so reaching here means
+            # the system is enabled — enforce the envelope directly.
+            await self._enforce_safety_setpoint(conn, thermo_state)
             await self._maybe_reconcile(conn)
             await self._maybe_broadcast()
             return
@@ -2931,6 +2956,228 @@ class CycleEngine:
                         self.thermostat_entity_id,
                         exc,
                     )
+
+    # ------------------------------------------------------------------
+    # Safety protection (Issue #367)
+    # ------------------------------------------------------------------
+
+    async def _add_safety_rooms(
+        self, conn: aiosqlite.Connection, new_active_map: dict[str, ActiveRoom]
+    ) -> None:
+        """Activate any zone room that has breached the comfort envelope.
+
+        The per-room ``max_setpoint`` / ``min_setpoint`` hard cap only protects
+        rooms that already have demand (presence/schedule/override). A room with
+        no demand source is never evaluated, so it can bake past the ceiling
+        while a cycle runs for other rooms — e.g. a presence cycle holds the
+        Bedroom at 70°F while the unoccupied Gym climbs to 78°F over a 77°F
+        ceiling.
+
+        This pulls such a room into the active set with ``source="safety"`` so
+        the normal cycle machinery conditions it: it joins the running cycle
+        when the direction matches, or starts a fresh one when the zone is idle.
+        The target is one deadband inside the breached bound (clamped to the
+        envelope) — cool to ``max_setpoint - deadband`` / heat to
+        ``min_setpoint + deadband`` — so the room is brought safely back inside
+        the envelope with a built-in hysteresis margin that prevents edge
+        short-cycling, rather than fully conditioned like an occupied room.
+
+        Mutates ``new_active_map`` in place. Rooms already active (real demand)
+        are left untouched; rooms with no usable sensor reading are skipped (a
+        sensorless zone is covered by the thermostat-ambient backstop instead).
+        """
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+        zone_rooms = await db.get_rooms_for_thermostat(conn, self.thermostat_entity_id)
+        breaching_now: set[str] = set()
+        for room in zone_rooms:
+            if room.id in new_active_map:
+                continue  # already conditioned via override/schedule/presence
+            avg = self._get_avg_temp(room)
+            if avg is None:
+                continue  # no fresh sensor reading — nothing to act on per-room
+            effective = avg + room.temp_offset
+            deadband = _effective_deadband(room, tc.deadband)
+
+            if effective > tc.max_setpoint:
+                target = max(tc.min_setpoint, tc.max_setpoint - deadband)
+                mode_word, bound_word, bound_val = "cooling", "maximum", tc.max_setpoint
+                bound_field = "max_setpoint"
+            elif effective < tc.min_setpoint:
+                target = min(tc.max_setpoint, tc.min_setpoint + deadband)
+                mode_word, bound_word, bound_val = "heating", "minimum", tc.min_setpoint
+                bound_field = "min_setpoint"
+            else:
+                continue  # inside the envelope — no protection needed
+
+            breaching_now.add(room.id)
+            new_active_map[room.id] = ActiveRoom(room=room, target_temp=target, source="safety")
+
+            # Announce once per breach episode, not every tick the room stays
+            # over/under the envelope (it may take many minutes to recover).
+            if room.id not in self._safety_warned_room_ids:
+                self._safety_warned_room_ids.add(room.id)
+                log.warning(
+                    "Safety protection: room %s at %.1f°F breached the %s setpoint "
+                    "%.1f°F with no active demand — adding it to a %s cycle (target %.1f°F)",
+                    room.name,
+                    effective,
+                    bound_word,
+                    bound_val,
+                    mode_word,
+                    target,
+                )
+                if self._logger:
+                    await self._logger.log(
+                        "warning",
+                        "engine",
+                        f"Safety protection engaged for room '{room.name}': it reached "
+                        f"{effective:.1f}°F, past the {bound_word} setpoint {bound_val:.1f}°F, "
+                        f"with no schedule, presence, or override. Adding it to a {mode_word} "
+                        f"cycle (target {target:.1f}°F) to bring it back inside the comfort "
+                        f"envelope.",
+                        {
+                            "thermostat": self.thermostat_entity_id,
+                            "room_id": room.id,
+                            "room_name": room.name,
+                            "room_temp": effective,
+                            "bound": bound_field,
+                            "bound_value": bound_val,
+                            "target_temp": target,
+                            "source": "safety",
+                        },
+                    )
+
+        # Drop rooms that recovered (or gained real demand) so a future breach
+        # warns again rather than staying silently suppressed.
+        self._safety_warned_room_ids &= breaching_now
+
+    async def _enforce_safety_setpoint(
+        self, conn: aiosqlite.Connection, thermo_state: dict | None
+    ) -> bool:
+        """Hard safety backstop for the idle, no-demand gap (Issue #367).
+
+        The per-room ``max_setpoint`` / ``min_setpoint`` hard cap lives in
+        ``_suppression_vote``, which only runs on the active-room code path.
+        When ``get_active_rooms`` returns nothing — an empty house with no
+        schedule, presence, or override demand — ``_do_tick`` takes a
+        ``not new_active_map`` branch and returns before any cap is evaluated,
+        leaving the thermostat ``off`` while the space drifts past the
+        configured envelope. This was observed after a vacation hold ended: the
+        upstairs zone climbed to 81°F against a 77°F ceiling with no cycle ever
+        starting (the thermostat had been reverted ``heat_cool`` → ``off`` and
+        nothing re-engaged it).
+
+        This is the dedicated guard for that gap. It is intentionally
+        self-contained — it starts no engine cycle and mutates no cycle state —
+        and drives the thermostat straight to the breached bound, the same
+        approach as the proven single-setpoint vacation hold. Because it is
+        reached only on the no-active-rooms branches it can never preempt a
+        normal per-room cycle (those run for any room with real demand), and
+        inside the configured envelope it is a complete no-op.
+
+        Returns True when a bound was breached (the thermostat was driven to it,
+        or is already being held there), False otherwise.
+        """
+        if thermo_state is None or thermo_state.get("state") == "unavailable":
+            return False
+
+        tc = await db.get_thermostat_config(conn, self.thermostat_entity_id)
+        current_temp_f = _climate_temp_to_f(
+            thermo_state.get("attributes", {}).get("current_temperature"),
+            self._ha.ha_temp_unit,
+        )
+        if current_temp_f is None:
+            # No usable ambient reading — fail safe by doing nothing rather than
+            # commanding the HVAC off a value we cannot trust.
+            return False
+
+        if current_temp_f > tc.max_setpoint:
+            await self._command_safety_bound(thermo_state, "cool", tc.max_setpoint, current_temp_f)
+            return True
+        if current_temp_f < tc.min_setpoint:
+            await self._command_safety_bound(thermo_state, "heat", tc.min_setpoint, current_temp_f)
+            return True
+        return False
+
+    async def _command_safety_bound(
+        self,
+        thermo_state: dict,
+        ha_mode: str,
+        setpoint: float,
+        current_temp_f: float,
+    ) -> None:
+        """Drive the thermostat to a safety bound, idempotently (Issue #367).
+
+        Re-asserting the identical setpoint every 60 s tick while the HVAC works
+        the space back inside the envelope is needless write traffic that can
+        hit cloud-thermostat rate limits (Issue #296), so the write is skipped
+        when the thermostat is already in the target mode at the target
+        setpoint. ``ha_mode`` is ``"cool"`` (holding ``max_setpoint``) or
+        ``"heat"`` (holding ``min_setpoint``). The bound itself is the target —
+        the thermostat is asked to bring the space exactly to the cap, not past
+        it, so the backstop holds the envelope edge rather than overshooting.
+        """
+        attrs = thermo_state.get("attributes", {})
+        current_mode = thermo_state.get("state")
+        current_sp_f = _climate_temp_to_f(attrs.get("temperature"), self._ha.ha_temp_unit)
+        bound_label = "maximum" if ha_mode == "cool" else "minimum"
+        already_held = (
+            current_mode == ha_mode
+            and current_sp_f is not None
+            and abs(current_sp_f - setpoint) <= _SETPOINT_DRIFT_TOLERANCE_F
+        )
+        if already_held:
+            log.debug(
+                "Safety backstop: %s already holding %s bound %.1f°F (ambient %.1f°F) — "
+                "skipping re-command",
+                self.thermostat_entity_id,
+                bound_label,
+                setpoint,
+                current_temp_f,
+            )
+            return
+
+        try:
+            await self._ha.set_thermostat_temperature(
+                self.thermostat_entity_id, setpoint, hvac_mode=ha_mode
+            )
+        except Exception as exc:
+            log.error(
+                "Safety backstop: failed to command %s for %s: %s",
+                ha_mode,
+                self.thermostat_entity_id,
+                exc,
+            )
+            return
+
+        log.warning(
+            "Safety backstop engaged for %s — ambient %.1f°F breached the %s setpoint "
+            "%.1f°F with no active rooms; commanding %s to %.1f°F",
+            self.thermostat_entity_id,
+            current_temp_f,
+            bound_label,
+            setpoint,
+            ha_mode,
+            setpoint,
+        )
+        if self._logger:
+            await self._logger.log(
+                "warning",
+                "engine",
+                f"Safety backstop engaged for {self.thermostat_entity_id}: ambient "
+                f"{current_temp_f:.1f}°F breached the {bound_label} setpoint "
+                f"{setpoint:.1f}°F while no rooms had active demand. Commanded the "
+                f"thermostat to {ha_mode} to {setpoint:.1f}°F to hold the configured "
+                f"comfort envelope. Add a schedule, presence sensor, or override for this "
+                f"zone if you expect it to be conditioned before a bound is breached.",
+                {
+                    "thermostat": self.thermostat_entity_id,
+                    "current_temp": current_temp_f,
+                    "bound": "max_setpoint" if ha_mode == "cool" else "min_setpoint",
+                    "setpoint": setpoint,
+                    "ha_mode": ha_mode,
+                },
+            )
 
     async def _maybe_broadcast(self) -> None:
         if self._broadcast:

--- a/smart_vent/backend/tests/integration/test_safety_room_protection.py
+++ b/smart_vent/backend/tests/integration/test_safety_room_protection.py
@@ -1,0 +1,247 @@
+"""Per-room safety protection integration tests (Issue #367).
+
+The per-room ``max_setpoint`` / ``min_setpoint`` hard cap only protects rooms
+that already have demand (presence/schedule/override). A room with no demand
+source is never evaluated, so it can bake past the ceiling while a cycle runs
+for other rooms — e.g. a presence cycle holds the Bedroom at 70°F while the
+unoccupied Gym climbs to 78°F over a 77°F ceiling.
+
+``_add_safety_rooms`` closes that gap: any zone room whose own sensor reading
+has breached the envelope is pulled into the active set with ``source="safety"``
+so the normal cycle machinery conditions it — joining the running cycle when
+the direction matches, or starting a fresh one when the zone is idle. The
+target is one deadband inside the breached bound, so the room is brought safely
+back inside the envelope (with a hysteresis margin) rather than fully
+conditioned like an occupied room.
+
+These tests drive the full engine against a fake Home Assistant.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+
+
+async def _configure(
+    client, *, min_setpoint: float = 62.0, max_setpoint: float = 77.0, deadband: float = 1.5
+) -> None:
+    await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": THERMO,
+            "total_vents_count": 6,
+            "min_setpoint": min_setpoint,
+            "max_setpoint": max_setpoint,
+            "deadband": deadband,
+            "overshoot_delta": 2.0,
+            "reconciliation_interval_min": 5,
+        },
+    )
+
+
+async def _make_room(
+    client,
+    name: str,
+    sensor: str | None,
+    vent: str,
+    *,
+    schedule_target: float | None = None,
+) -> str:
+    resp = await client.post("/api/rooms", json={"name": name, "thermostat_entity_id": THERMO})
+    room_id: str = (await resp.json())["id"]
+    if sensor is not None:
+        await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": vent, "control_method": "open_close"},
+    )
+    if schedule_target is not None:
+        now = datetime.now(UTC)
+        start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+        end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+        await client.post(
+            f"/api/rooms/{room_id}/schedules",
+            json={
+                "days_of_week": list(range(7)),
+                "start_time": start.isoformat(timespec="minutes"),
+                "end_time": end.isoformat(timespec="minutes"),
+                "target_temp": schedule_target,
+            },
+        )
+    return room_id
+
+
+async def _warnings(client) -> list[str]:
+    events = await (await client.get("/api/logs/events?level=warning")).json()
+    return [e["message"] for e in events]
+
+
+@pytest.mark.asyncio
+async def test_breaching_room_starts_protection_cycle_when_idle(client, fake_ha, tick) -> None:
+    """Unoccupied room over the ceiling, zone idle → a protection cooling cycle.
+
+    Nobody home, no schedule — but the Gym sensor reads 78°F, 1°F over the
+    77°F ceiling. The room is pulled into a fresh cooling cycle for protection.
+    """
+    await _configure(client)
+    gym = await _make_room(client, "Gym", "sensor.gym_temp", "cover.gym_vent")
+
+    fake_ha.seed_state(
+        THERMO, "off", {"current_temperature": 78.0, "temperature": None, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("sensor.gym_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, f"a protection cooling cycle should start; got {logs}"
+    assert logs[0]["mode"] == "cooling"
+    gym_meta = logs[0]["rooms"][gym]
+    assert gym_meta["source"] == "safety"
+    # Target = one deadband inside the ceiling: 77 − 1.5 = 75.5°F.
+    assert gym_meta["target"] == pytest.approx(75.5)
+
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls and sp_calls[-1].data.get("hvac_mode") == "cool", fake_ha.calls
+
+    warnings = await _warnings(client)
+    assert any("Safety protection engaged for room 'Gym'" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_breaching_room_joins_running_presence_cycle(client, fake_ha, tick) -> None:
+    """The reported scenario: Bedroom cooling for an occupant, Gym then bakes.
+
+    A cooling cycle is already running to hold the occupied Bedroom at 70°F.
+    The unoccupied Gym drifts to 78°F (over the 77°F ceiling) and must be pulled
+    into that SAME cycle for protection — not left to bake, and not spun up as a
+    competing second cycle.
+    """
+    await _configure(client)
+    bedroom = await _make_room(
+        client, "Bedroom", "sensor.bedroom_temp", "cover.bedroom_vent", schedule_target=70.0
+    )
+    gym = await _make_room(client, "Gym", "sensor.gym_temp", "cover.gym_vent")
+
+    # Warm upstairs. Bedroom (occupied, target 70) drives cooling; Gym in-band.
+    fake_ha.seed_state(
+        THERMO, "cool", {"current_temperature": 78.0, "temperature": 78.0, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("sensor.bedroom_temp", "80.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("sensor.gym_temp", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.bedroom_vent", "open", {})
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1 and logs[0]["mode"] == "cooling"
+    cycle_id = logs[0]["id"]
+    assert gym not in logs[0]["rooms"], "in-band Gym should not be in the cycle yet"
+
+    # Gym now bakes to 78°F — over the 77°F ceiling — with nobody in it.
+    fake_ha.seed_state("sensor.gym_temp", "78.0", {"unit_of_measurement": "°F"})
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, "Gym should JOIN the running cycle, not start a second"
+    assert logs[0]["id"] == cycle_id
+    assert logs[0]["rooms"][gym]["source"] == "safety"
+    assert logs[0]["rooms"][gym]["target"] == pytest.approx(75.5)
+    assert logs[0]["rooms"][bedroom]["source"] == "schedule"
+
+    warnings = await _warnings(client)
+    assert any("Safety protection engaged for room 'Gym'" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_room_below_floor_starts_heating_protection(client, fake_ha, tick) -> None:
+    """Unoccupied room under the floor → a heating protection cycle (freeze guard)."""
+    await _configure(client)
+    gym = await _make_room(client, "Gym", "sensor.gym_temp", "cover.gym_vent")
+
+    fake_ha.seed_state(
+        THERMO, "off", {"current_temperature": 55.0, "temperature": None, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("sensor.gym_temp", "55.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1 and logs[0]["mode"] == "heating", logs
+    assert logs[0]["rooms"][gym]["source"] == "safety"
+    # Target = one deadband inside the floor: 62 + 1.5 = 63.5°F.
+    assert logs[0]["rooms"][gym]["target"] == pytest.approx(63.5)
+
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls and sp_calls[-1].data.get("hvac_mode") == "heat", fake_ha.calls
+
+
+@pytest.mark.asyncio
+async def test_in_envelope_room_not_activated(client, fake_ha, tick) -> None:
+    """A room comfortably inside the envelope is never safety-activated."""
+    await _configure(client)
+    await _make_room(client, "Gym", "sensor.gym_temp", "cover.gym_vent")
+
+    fake_ha.seed_state(
+        THERMO, "off", {"current_temperature": 72.0, "temperature": None, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("sensor.gym_temp", "72.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+
+    assert (await (await client.get("/api/logs")).json()) == [], "in-band room must not activate"
+    warnings = await _warnings(client)
+    assert not any("Safety protection" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_protection_warns_once_per_episode(client, fake_ha, tick) -> None:
+    """The activation warning fires once per breach, not every tick it persists."""
+    await _configure(client)
+    await _make_room(client, "Gym", "sensor.gym_temp", "cover.gym_vent")
+
+    fake_ha.seed_state(
+        THERMO, "off", {"current_temperature": 78.0, "temperature": None, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("sensor.gym_temp", "78.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+    await tick()  # still breaching — must NOT re-announce
+
+    warnings = await _warnings(client)
+    engaged = [m for m in warnings if "Safety protection engaged for room 'Gym'" in m]
+    assert len(engaged) == 1, f"expected exactly one activation warning; got {engaged}"
+
+
+@pytest.mark.asyncio
+async def test_room_without_sensor_not_activated(client, fake_ha, tick) -> None:
+    """A room with no readable sensor can't be safety-activated (no false cycle).
+
+    Per-room protection needs a room temperature; a sensorless zone is the
+    thermostat-ambient backstop's job, not this path. With the thermostat in
+    band too, nothing should happen.
+    """
+    await _configure(client)
+    resp = await client.post("/api/rooms", json={"name": "Gym", "thermostat_entity_id": THERMO})
+    gym = (await resp.json())["id"]
+    await client.post(
+        f"/api/rooms/{gym}/vents",
+        json={"entity_id": "cover.gym_vent", "control_method": "open_close"},
+    )
+
+    fake_ha.seed_state(
+        THERMO, "off", {"current_temperature": 70.0, "temperature": None, "hvac_action": "idle"}
+    )
+    fake_ha.seed_state("cover.gym_vent", "open", {})
+
+    await tick()
+
+    assert (await (await client.get("/api/logs")).json()) == [], "sensorless room can't activate"

--- a/smart_vent/backend/tests/integration/test_safety_setpoint_backstop.py
+++ b/smart_vent/backend/tests/integration/test_safety_setpoint_backstop.py
@@ -1,0 +1,275 @@
+"""Idle safety-setpoint backstop integration tests (Issue #367).
+
+The per-room ``max_setpoint`` / ``min_setpoint`` hard cap only runs on the
+active-room code path. When no room has demand (empty house — no schedule,
+presence, or override), ``_do_tick`` returns on a ``not new_active_map``
+branch before any cap is evaluated, so the thermostat is left ``off`` while
+the space drifts past the configured envelope. This was the production bug:
+after a vacation hold ended, the upstairs zone climbed to 81°F against a 77°F
+ceiling with no cycle ever starting.
+
+The thermostat-ambient backstop is the **last-resort fallback for a zone whose
+rooms have no usable sensor reading** — when a room sensor is readable and
+breaches, per-room safety protection (``_add_safety_rooms``, see
+``test_safety_room_protection.py``) activates that room into a real cycle
+*before* the no-active-rooms branch is reached, so the backstop never runs.
+These tests therefore drive the breach through the **thermostat probe** with
+the room sensor unavailable, which is the exact situation the backstop guards.
+
+These tests drive the full engine against a fake Home Assistant and verify the
+backstop:
+
+  - engages a cooling command at ``max_setpoint`` when idle and ambient is
+    above the ceiling;
+  - engages a heating command at ``min_setpoint`` when idle and ambient is
+    below the floor;
+  - stays inert inside the envelope;
+  - does not re-assert the setpoint when the thermostat is already holding the
+    bound (no needless write traffic — Issue #296);
+  - never preempts a normal per-room cycle when a room actually has demand;
+  - is suppressed while the whole system is disabled (respects the off switch).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+SENSOR = "sensor.test_room_temp"
+VENT = "cover.test_room_vent"
+
+
+async def _configure_thermostat(client, *, min_setpoint: float, max_setpoint: float) -> None:
+    resp = await client.post(
+        "/api/thermostats",
+        json={
+            "thermostat_entity_id": THERMO,
+            "total_vents_count": 6,
+            "min_setpoint": min_setpoint,
+            "max_setpoint": max_setpoint,
+            "overshoot_delta": 2.0,
+            # Reconcile every tick so the idle path is fully exercised alongside
+            # the backstop, matching how the real instance interleaves them.
+            "reconciliation_interval_min": 1,
+        },
+    )
+    assert resp.status in (200, 201)
+
+
+async def _make_idle_room(client) -> str:
+    """Create a room with a sensor + vent but NO schedule/presence.
+
+    With no demand source the room never becomes active, so the engine takes
+    the ``not new_active_map`` branch every tick — the exact gap the backstop
+    guards. A room must exist for the scheduler to spin up a CycleEngine for
+    this thermostat at all.
+    """
+    resp = await client.post("/api/rooms", json={"name": "Bedroom", "thermostat_entity_id": THERMO})
+    room_id: str = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": SENSOR})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": VENT, "control_method": "open_close"},
+    )
+    return room_id
+
+
+async def _make_room_with_schedule(client, *, target_temp: float) -> str:
+    room_id = await _make_idle_room(client)
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+    return room_id
+
+
+async def _warnings(client) -> list[str]:
+    events = await (await client.get("/api/logs/events?level=warning")).json()
+    return [e["message"] for e in events]
+
+
+@pytest.mark.asyncio
+async def test_backstop_cools_to_max_when_idle_and_above_ceiling(client, fake_ha, tick) -> None:
+    """Empty house, ambient above max_setpoint → command cool to max_setpoint.
+
+    This is the exact production scenario: thermostat ``off`` (left behind by
+    the post-vacation revert), no active rooms, ambient drifting past the cap.
+    """
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_idle_room(client)
+
+    # Thermostat is OFF and the space has drifted to 81°F — 4°F over the cap.
+    # The room sensor is unavailable, so per-room safety can't act and the
+    # thermostat-ambient backstop is the mechanism under test.
+    fake_ha.seed_state(
+        THERMO,
+        "off",
+        {"current_temperature": 81.0, "temperature": None, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(SENSOR, "unavailable", {})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    # No cycle was started — the backstop drives the thermostat directly.
+    assert (await (await client.get("/api/logs")).json()) == []
+    assert client.app["scheduler"]._engines[THERMO].cycle_state.value == "idle"
+
+    # The thermostat was commanded to cool to exactly the ceiling.
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls, f"backstop did not command a setpoint; got {fake_ha.calls}"
+    last = sp_calls[-1]
+    assert last.data["temperature"] == pytest.approx(77.0)
+    assert last.data["hvac_mode"] == "cool"
+
+    warnings = await _warnings(client)
+    assert any("Safety backstop engaged" in m and "77.0" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_backstop_heats_to_min_when_idle_and_below_floor(client, fake_ha, tick) -> None:
+    """Empty house, ambient below min_setpoint → command heat to min_setpoint."""
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_idle_room(client)
+
+    # Thermostat OFF, space has dropped to 55°F — 7°F under the floor. Room
+    # sensor unavailable, so the thermostat-ambient backstop is what acts.
+    fake_ha.seed_state(
+        THERMO,
+        "off",
+        {"current_temperature": 55.0, "temperature": None, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(SENSOR, "unavailable", {})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    assert client.app["scheduler"]._engines[THERMO].cycle_state.value == "idle"
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls, f"backstop did not command a setpoint; got {fake_ha.calls}"
+    last = sp_calls[-1]
+    assert last.data["temperature"] == pytest.approx(62.0)
+    assert last.data["hvac_mode"] == "heat"
+
+    warnings = await _warnings(client)
+    assert any("Safety backstop engaged" in m and "62.0" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_backstop_inert_within_envelope(client, fake_ha, tick) -> None:
+    """Idle and comfortably within bounds → the backstop does nothing."""
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_idle_room(client)
+
+    fake_ha.seed_state(
+        THERMO,
+        "off",
+        {"current_temperature": 70.0, "temperature": None, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(SENSOR, "70.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    assert fake_ha.calls_for("set_temperature") == [], "no setpoint should be commanded in-band"
+    warnings = await _warnings(client)
+    assert not any("Safety backstop engaged" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_backstop_does_not_reassert_when_already_holding(client, fake_ha, tick) -> None:
+    """Already cooling at the ceiling → no redundant re-command (Issue #296).
+
+    Once the backstop has driven the thermostat to ``cool`` at ``max_setpoint``,
+    re-sending the identical setpoint every 60 s tick is needless write traffic
+    that can hit cloud-thermostat rate limits.
+    """
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_idle_room(client)
+
+    # Thermostat is ALREADY cooling at the ceiling; the space is still working
+    # its way back down (81°F > 77°F) but no fresh command is needed. Room
+    # sensor unavailable so the backstop (not per-room safety) is exercised.
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 81.0, "temperature": 77.0, "hvac_action": "cooling"},
+    )
+    fake_ha.seed_state(SENSOR, "unavailable", {})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    assert fake_ha.calls_for("set_temperature") == [], (
+        f"backstop re-asserted an already-held setpoint; got {fake_ha.calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backstop_does_not_preempt_normal_cycle(client, fake_ha, tick) -> None:
+    """A room with real demand → a normal per-room cycle runs, not the backstop.
+
+    With an active room the engine never reaches the no-active-rooms branch, so
+    the cycle targets the room (cool to 70 − overshoot), well below the 77°F
+    safety ceiling, and no backstop warning is emitted.
+    """
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_room_with_schedule(client, target_temp=70.0)
+
+    # Ambient is above the ceiling, but the scheduled room is what should drive
+    # the cycle — proving the backstop defers to genuine demand.
+    fake_ha.seed_state(
+        THERMO,
+        "cool",
+        {"current_temperature": 81.0, "temperature": 81.0, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(SENSOR, "80.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    logs = await (await client.get("/api/logs")).json()
+    assert len(logs) == 1, f"a normal cooling cycle should start; got {logs}"
+    assert logs[0]["mode"] == "cooling"
+
+    # The commanded setpoint tracks the room target (68), not the safety cap (77).
+    sp_calls = fake_ha.calls_for("set_temperature")
+    assert sp_calls, "a normal cycle should command a setpoint"
+    assert sp_calls[-1].data["temperature"] == pytest.approx(68.0, abs=0.5)
+
+    warnings = await _warnings(client)
+    assert not any("Safety backstop engaged" in m for m in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_backstop_suppressed_when_system_disabled(client, fake_ha, tick) -> None:
+    """System disabled → the backstop is silent (respects the off switch)."""
+    await _configure_thermostat(client, min_setpoint=62.0, max_setpoint=77.0)
+    await _make_idle_room(client)
+    assert (await client.post("/api/system/enabled", json={"enabled": False})).status == 200
+
+    fake_ha.seed_state(
+        THERMO,
+        "off",
+        {"current_temperature": 81.0, "temperature": None, "hvac_action": "idle"},
+    )
+    fake_ha.seed_state(SENSOR, "81.0", {"unit_of_measurement": "°F"})
+    fake_ha.seed_state(VENT, "open", {})
+
+    await tick()
+
+    assert fake_ha.calls_for("set_temperature") == [], (
+        "a disabled system must not command the thermostat"
+    )
+    warnings = await _warnings(client)
+    assert not any("Safety backstop engaged" in m for m in warnings), warnings

--- a/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.test.tsx
@@ -218,6 +218,17 @@ describe("MetricsCharts", () => {
     expect(screen.getByText(/Source breakdown/i)).toBeInTheDocument();
   });
 
+  it("includes the safety source in the breakdown (Issue #367)", () => {
+    const withSafety: api.MetricsSummary = {
+      ...summary,
+      source_breakdown: { schedule: 4, presence: 2, override: 1, safety: 3 },
+    };
+    renderWithUnit(<SourceBreakdownChart summary={withSafety} loading={false} />);
+    // The chart maps every source — including the new "safety" key — to a
+    // colour; this exercises that branch so safety renders distinctly.
+    expect(screen.getByText(/Source breakdown/i)).toBeInTheDocument();
+  });
+
   it("renders the per-room heating/cooling chart", async () => {
     renderWithUnit(<PerRoomHeatingCoolingChart entityId={entityId} range={range} />);
     expect(await screen.findByText(/Per-room heating vs cooling/i)).toBeInTheDocument();

--- a/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
+++ b/smart_vent/frontend/src/components/charts/MetricsCharts.tsx
@@ -394,7 +394,9 @@ export function SourceBreakdownChart({
           ? COLORS.schedule
           : name === "presence"
             ? COLORS.presence
-            : COLORS.override,
+            : name === "safety"
+              ? COLORS.safety
+              : COLORS.override,
     }))
     .filter((d) => d.value > 0);
   return (

--- a/smart_vent/frontend/src/components/charts/colors.ts
+++ b/smart_vent/frontend/src/components/charts/colors.ts
@@ -13,6 +13,7 @@ export const COLORS = {
   schedule: "#3b82f6",
   presence: "#10b981",
   override: "#f59e0b",
+  safety: "#e11d48",
   degree: "#7c3aed",
   overshoot: "#ef4444",
   participation: "#0ea5e9",

--- a/smart_vent/frontend/src/pages/Logs.test.tsx
+++ b/smart_vent/frontend/src/pages/Logs.test.tsx
@@ -315,6 +315,25 @@ describe("Logs Page", () => {
     expect(screen.getByText("cover.living")).toBeInTheDocument();
   });
 
+  it("labels a safety-protection room in the cycle detail (Issue #367)", async () => {
+    vi.mocked(api.getCycleDetail).mockResolvedValue({
+      ...mockCycleDetail,
+      rooms: [
+        {
+          ...mockCycleDetail.rooms[0],
+          source: "safety",
+          trigger_detail: { source: "safety", target: 75.5 },
+        },
+      ],
+    });
+    render(<Logs />);
+
+    fireEvent.click(screen.getByText("Cycle History"));
+    fireEvent.click(await screen.findByText(/climate\.test/i));
+
+    expect(await screen.findByText(/safety protection/i)).toBeInTheDocument();
+  });
+
   it("opens the temperature chart modal for a room", async () => {
     vi.mocked(api.getCycleDetail).mockResolvedValue(mockCycleDetail);
     vi.mocked(api.getCycleTempSamples).mockResolvedValue(mockTempSamples);

--- a/smart_vent/frontend/src/pages/Logs.tsx
+++ b/smart_vent/frontend/src/pages/Logs.tsx
@@ -190,6 +190,9 @@ function triggerSummary(detail: Record<string, unknown> | null): string {
     const exp = detail.holdover_expires_at as string | undefined;
     return exp ? `presence, holdover ends ${new Date(exp + "Z").toLocaleString()}` : "presence";
   }
+  if (source === "safety") {
+    return "safety protection";
+  }
   return source ?? "";
 }
 


### PR DESCRIPTION
Closes #367.

## Problem

The per-room `max_setpoint` / `min_setpoint` hard cap only runs on the **active-room** code path (inside `_suppression_vote`). Two gaps fell out of that:

1. **A room with no demand is never checked.** A room with no presence, schedule, or override is never evaluated against the envelope — so it can bake past the ceiling while a cycle runs for *other* rooms.
2. **An empty zone is never checked.** When `get_active_rooms()` returns nothing, `_do_tick()` returns before any cap runs, leaving the thermostat `off` while the space drifts.

Gap #2 is the original production incident: after a vacation hold ended (thermostat reverted `heat_cool` → `off`), the upstairs zone climbed to **81 °F against a 77 °F ceiling** with no cycle ever starting. Gap #1 is the follow-up reported in review: *"a presence cycle holds the Bedroom at 70 °F while the unoccupied Gym hits 78 °F over the 77 °F ceiling — the Gym should be added to a cycle for protection."*

## Fix — two layered, self-contained mechanisms

Both are scoped to **normal operation only** (system enabled, not vacation, thermostat available); those guards already `return` earlier in `_do_tick`. Both **defer to genuine demand** — a room with real presence/schedule/override is handled before either runs, so neither preempts a normal cycle.

### 1. Per-room protection — `_add_safety_rooms` (primary)

Any zone room whose **own sensor reading** has breached the envelope is pulled into the active set with `source="safety"`, so the normal cycle machinery conditions it:
- **joins** the running cycle when the direction matches (the reported Bedroom-running / Gym-breaching case), or
- **starts a fresh** cycle when the zone is idle.

This runs every tick *before* the no-active-rooms gate, so a breaching room with no other demand still triggers a protection cycle. Activation is announced once per breach episode (rate-limited via `_safety_warned_room_ids`) so a slow recovery doesn't spam the feed. Rooms with no usable sensor reading are skipped (covered by mechanism 2 instead).

### 2. Thermostat-ambient backstop — `_enforce_safety_setpoint` (fallback)

Last-resort guard for a zone whose rooms have **no usable sensor reading**. In the no-active-rooms gap it drives the thermostat straight to the breached bound, mirroring the proven single-setpoint vacation hold. **Idempotent** — skips the write when already holding the bound, so it doesn't re-assert the same setpoint every 60 s and churn cloud-thermostat rate limits (per #296).

## Design decisions (confirmed before implementing)

- **Target = one deadband inside the breached bound** (`max_setpoint − deadband` cooling / `min_setpoint + deadband` heating, clamped to the envelope). This brings the room *safely back inside* the envelope with a built-in hysteresis margin that prevents edge short-cycling, rather than fully conditioning an empty room to comfort. The activation threshold is the bound itself, but the cool/heat target sits a deadband inside it so the demand actually engages (a target *at* the bound would sit inside the deadband and never trigger).
- **Always-on**, using each thermostat's existing `min_setpoint` / `max_setpoint` envelope. No new config field, no `run.sh`/`config.yaml` change, no new control needed — safety can't be accidentally left off, and the envelope already has UI on the Thermostats page.
- **Direct thermostat command (not a synthesized cycle) for the backstop**, keeping it isolated from the cycle/vent/overflow/short-cycle/restore machinery so it runs deterministically every tick.

## Behavior matrix

| Situation | Before | After |
|---|---|---|
| Empty house, thermostat ambient over ceiling | thermostat left `off`, bakes | backstop cools to the ceiling |
| Empty house, a room's sensor over ceiling | nothing | per-room cooling cycle for that room |
| Bedroom presence-cooling, unoccupied Gym over ceiling | Gym bakes | Gym joins the running cycle (`source=safety`) |
| Room below floor, no demand | nothing | heating protection cycle (freeze guard) |
| Room/zone within envelope | n/a | no-op |
| Room with real presence/schedule | normal cycle | unchanged (deferred to) |
| Vacation mode / system disabled | vacation hold / off | unchanged (guards return first) |

## What this does **not** change

- No new tunables, DB columns, `config.yaml` options, or migrations.
- The engine still stores/passes all temperatures in °F; `_climate_temp_to_f` normalisation is unchanged.
- `/api/rooms/active-status` is computed from `room_manager` (override/schedule/presence/idle) and is unchanged, so it will not show `"safety"` — that source appears in the **cycle log** rooms snapshot and the engine event feed, which is where protection is surfaced.

## UI — the new `"safety"` source (commit 2)

The `"safety"` source is now first-class in the UI:
- **Logs** — a safety-sourced room shows **"safety protection"** as its cycle-detail trigger summary (`triggerSummary` in `Logs.tsx`).
- **Metrics** — the source-breakdown donut maps `"safety"` to a distinct rose colour (`colors.ts` + `MetricsCharts.tsx`) instead of falling through to the override amber.
- The `RoomActiveStatusSchema` doc comment now lists `'safety'`.

These render identically to before for any data **without** a safety cycle (the new branches only fire when a safety source is present), so committed visual-regression goldens are unaffected.

## Test plan

**Backend** — new integration tests drive the full engine against the fake HA:

`test_safety_room_protection.py`
- breaching room starts a protection cooling cycle when idle (asserts `source=safety`, target = `max−deadband` = 75.5 °F)
- **breaching room joins a running presence cycle** (the reported scenario — same `cycle_id`, Gym added as `safety`, Bedroom stays `schedule`)
- room below floor starts a heating protection cycle (target = `min+deadband` = 63.5 °F)
- in-envelope room is never activated
- activation warns once per breach episode
- sensorless room is never activated (no false cycle)

`test_safety_setpoint_backstop.py` (re-scoped to the sensorless-zone fallback — the breach is driven through the thermostat probe with the room sensor unavailable, since a readable breaching sensor now triggers per-room protection first)
- cools to ceiling / heats to floor; inert in-band; idempotent (no re-assert); does not preempt a real cycle; silent when system disabled

**Frontend** — new cases cover the safety branch in the source-breakdown chart and the Logs trigger summary.

**Suites:** backend 898 passing, 93.4% coverage (gate 92.5%); frontend 283 passing, coverage above thresholds; `ruff` / `mypy` / `eslint` / `prettier` clean.

## How to verify against the live incident

Walking into a room fires presence and starts a normal cycle as before. The new behavior: an unoccupied room that crosses the envelope (or an empty zone via the thermostat probe) now self-heals into a protection cycle within a tick instead of drifting — which is exactly what failed to happen upstairs.