### PR TITLE
Map the MCP port to a default host port so it shows in the add-on Network config

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,15 +13,17 @@ The MCP server is served over **Streamable HTTP** on a **dedicated port (default
 Two things are required before a client can connect:
 
 1. **Turn it on.** In the web UI, open the settings cog (⚙️) → **MCP** and toggle it on (red = off, green = on). It is **off by default** because the endpoint is unauthenticated and exposes the full write surface. The toggle takes effect immediately — no restart needed.
-2. **Expose the port.** The MCP port is not published by default. How you do this depends on your install:
+2. **Expose the port.** The MCP server listens on its own port; how it's published depends on your install:
 
 ### Home Assistant OS / Supervised
 
-HAOS doesn't allow direct Docker port access, so publish the port from the add-on itself:
+HAOS doesn't allow direct Docker port access, so the port is published from the add-on itself. The add-on ships with `9099/tcp` **mapped to host port `9099` by default**, so it appears (pre-filled) in the add-on's **Configuration → Network** section:
 
 1. Open the **Plenum** add-on → **Configuration** tab.
-2. In the **Network** section, set a host port for `9099/tcp` (e.g. `9099`).
-3. **Save**, then **Restart** the add-on.
+2. In the **Network** section you'll see a `9099/tcp` row set to `9099`. Change it to a different host port if you like, or clear it to disable direct access.
+3. If you changed it, **Save** and **Restart** the add-on.
+
+(Publishing the port is safe on its own — the MCP endpoint returns `503` until you also flip the toggle in step 1.)
 
 ### Docker (standalone)
 

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -17,10 +17,10 @@ hassio_api: true
 auth_api: true
 ports:
   8099/tcp: null
-  9099/tcp: null
+  9099/tcp: 9099
 ports_description:
   8099/tcp: "Web UI — leave blank to disable direct access, set a port to expose it on the host"
-  9099/tcp: "MCP server (Model Context Protocol) — set a port to attach an MCP client at http://<host>:<port>/mcp. Also turn the MCP server on in Plenum's settings."
+  9099/tcp: "MCP server (Model Context Protocol) — mapped to host port 9099 by default. Attach an MCP client at http://<host>:9099/mcp; change or clear this to remap/disable. The MCP server also has to be turned on in Plenum's settings (it stays off — returning 503 — until you do)."
 options:
   ha_url: ""
   ha_token: ""

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -285,14 +285,15 @@ function SettingsDropdown() {
                 <p>
                   <strong>
                     The MCP server runs on its own separate port (default 9099) — not this web
-                    UI&apos;s port — so you must expose that port before any client can reach it.
+                    UI&apos;s port — and that port must be published to reach it.
                   </strong>
                 </p>
                 <p>
                   <strong>Home Assistant OS / Supervised:</strong> HAOS doesn&apos;t allow direct
-                  Docker port access, so publish the port from the add-on itself — open the Plenum
-                  add-on → <em>Configuration</em> tab → <em>Network</em> section → set a host port
-                  for <code>9099/tcp</code> → Save, then Restart the add-on.
+                  Docker port access, so the port is published from the add-on. It&apos;s mapped to
+                  host <code>9099</code> by default — check the Plenum add-on →{" "}
+                  <em>Configuration</em> tab → <em>Network</em> section, where you can change the
+                  host port or clear it to disable direct access (Save + Restart if you change it).
                 </p>
                 <p>
                   <strong>Docker (standalone):</strong> publish the container port, e.g.{" "}


### PR DESCRIPTION
## Problem

After updating the add-on, the MCP server port did **not** appear in the add-on's **Configuration → Network** section, so there was no way to expose/set it (only the `8099` web-UI row showed).

## Fix

`config.yaml`: map `9099/tcp` to host port **`9099`** (an explicit default) instead of `null`, and refresh its `ports_description`. This matches the documented `ports` form (`"container-port/type": host-port`, e.g. the docs' `"123/tcp": 123`) and the working `8099` row, so the Network card renders a pre-filled `9099/tcp` row.

The user stays in control of exposure: in the Network card they can change the host port, or **clear the field to not publish the port at all**. Publishing it is safe on its own — the MCP endpoint returns **503 until the in-app toggle is enabled**, so nothing is reachable by default.

Also updated `docs/mcp.md` and the in-app confirmation modal to reflect the default mapping.

## Not included / delivery

- **No version bump.** Version numbers are only touched by tag-based releases, never directly in a PR. Delivery of this schema change to installed add-ons happens through the normal release, which reloads the add-on's port schema.
- No backend logic changed — the MCP server, toggle, and tools are unchanged from #375; this only adjusts how the port is published.

## Test plan
- `config.yaml` parses with `ports: {8099/tcp: null, 9099/tcp: 9099}`; `test_addon_config.py` (config/run.sh parity) passes.
- Frontend eslint + prettier + `App.test.tsx` (MCP toggle/modal) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)