### PR TITLE
MCP port: revert to null (opt-in) and document that an add-on Update detects it

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,11 +17,13 @@ Two things are required before a client can connect:
 
 ### Home Assistant OS / Supervised
 
-HAOS doesn't allow direct Docker port access, so the port is published from the add-on itself. The add-on ships with `9099/tcp` **mapped to host port `9099` by default**, so it appears (pre-filled) in the add-on's **Configuration → Network** section:
+HAOS doesn't allow direct Docker port access, so the port is published from the add-on itself:
 
 1. Open the **Plenum** add-on → **Configuration** tab.
-2. In the **Network** section you'll see a `9099/tcp` row set to `9099`. Change it to a different host port if you like, or clear it to disable direct access.
-3. If you changed it, **Save** and **Restart** the add-on.
+2. In the **Network** section, find the `9099/tcp` row and set a host port (e.g. `9099`). Leave it blank to keep the port unpublished.
+3. **Save**, then **Restart** the add-on.
+
+> **Don't see a `9099/tcp` row?** Home Assistant re-reads an add-on's `config.yaml` (including its ports) whenever the add-on's **version changes and you press Update** — no uninstall/reinstall needed. `9099/tcp` was added in **v0.22.1**, so if Plenum shows an available update, apply it and the row appears automatically. The one thing that does *not* trigger a reload is re-pulling the image at the *same* version — the version has to change. (This is a Supervisor behavior, not a per-port setting: the row shows for any declared port, and a blank/`null` mapping still shows an empty row you can fill in.)
 
 (Publishing the port is safe on its own — the MCP endpoint returns `503` until you also flip the toggle in step 1.)
 

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -17,10 +17,10 @@ hassio_api: true
 auth_api: true
 ports:
   8099/tcp: null
-  9099/tcp: 9099
+  9099/tcp: null
 ports_description:
   8099/tcp: "Web UI — leave blank to disable direct access, set a port to expose it on the host"
-  9099/tcp: "MCP server (Model Context Protocol) — mapped to host port 9099 by default. Attach an MCP client at http://<host>:9099/mcp; change or clear this to remap/disable. The MCP server also has to be turned on in Plenum's settings (it stays off — returning 503 — until you do)."
+  9099/tcp: "MCP server (Model Context Protocol) — leave blank to disable, set a port to expose it on the host, then attach an MCP client at http://<host>:<port>/mcp. Also turn the MCP server on in Plenum's settings (it returns 503 until enabled)."
 options:
   ha_url: ""
   ha_token: ""

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -290,10 +290,11 @@ function SettingsDropdown() {
                 </p>
                 <p>
                   <strong>Home Assistant OS / Supervised:</strong> HAOS doesn&apos;t allow direct
-                  Docker port access, so the port is published from the add-on. It&apos;s mapped to
-                  host <code>9099</code> by default — check the Plenum add-on →{" "}
-                  <em>Configuration</em> tab → <em>Network</em> section, where you can change the
-                  host port or clear it to disable direct access (Save + Restart if you change it).
+                  Docker port access, so publish the port from the add-on — open the Plenum add-on →{" "}
+                  <em>Configuration</em> tab → <em>Network</em> section, set a host port for{" "}
+                  <code>9099/tcp</code>, then Save and Restart. (No <code>9099/tcp</code> row?
+                  Update the add-on to the latest version — HA re-reads the ports when the add-on
+                  version changes, so a normal Update surfaces it; no reinstall needed.)
                 </p>
                 <p>
                   <strong>Docker (standalone):</strong> publish the container port, e.g.{" "}


### PR DESCRIPTION
## Context / research

A user reported the MCP `9099/tcp` port not appearing in the add-on's **Configuration → Network** section, while the first-party **OpenThread Border Router** add-on shows both of its ports.

Key finding: **a `null` host mapping does render.** OTBR declares `8080/tcp: null` and `8081/tcp: null` and both rows appear. So the earlier switch to an explicit `9099` (#385) was based on a wrong assumption and isn't needed.

The real reason a newly-added port doesn't show on an already-installed add-on: **Home Assistant only re-reads an add-on's `config.yaml` (ports/options schema) when the add-on's version changes and you press Update.** Re-pulling the image at the *same* version does not reload the schema. **No uninstall/reinstall is required** — a normal Update does it. (Sources below.)

The original trap: #375 added `9099/tcp` at version `0.21.0` *without a version bump*, so users on `0.21.0` who "updated the container" got the same `0.21.0` config with no new port. The port now ships in the tagged release **v0.22.1**, so updating the add-on to v0.22.1+ surfaces the row automatically.

## Changes

- **`config.yaml`:** revert `9099/tcp` from an explicit `9099` back to `null` — matching the `8099` web-UI port and OTBR: opt-in, not published until the user sets a host port (the row still shows so they can fill it in).
- **`docs/mcp.md` + in-app modal:** correct the guidance — if the `9099/tcp` row is missing, **Update the add-on** (version change re-reads the ports); reinstall is *not* required.
- **No version bump** — that's done by the tagged release process.

## Sources
- HA Developer Docs — App/Add-on configuration (`ports`, `ports_description`): https://developers.home-assistant.io/docs/apps/configuration/
- OpenThread Border Router `config.yaml` (both ports `null`, both render): https://github.com/home-assistant/addons/blob/master/openthread_border_router/config.yaml

## Test plan
- `config.yaml` parses with `ports: {8099/tcp: null, 9099/tcp: null}`; `test_addon_config.py` parity passes.
- Frontend eslint + prettier + `App.test.tsx` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKixH75kexPiVeR5eoATMJ)_