### PR TITLE
Skill library review pass: fix truncated skill descriptions, wrong facts, and finish the drift scrub

### DIFF
--- a/.claude/skills/plenum-architecture-contract/SKILL.md
+++ b/.claude/skills/plenum-architecture-contract/SKILL.md
@@ -15,8 +15,9 @@ description: >-
 
 The design decisions this system stands on, stated as invariants with their
 rationale. Every claim below was verified against the repo at v0.22.1
-(2026-07-04). Where `CLAUDE.md` or `DESIGN.md` prose has drifted behind the
-code, the drift is called out — **the repo files win**.
+(2026-07-04). Where `DESIGN.md` prose has drifted behind the code (or
+`CLAUDE.md` had, before the 2026-07-05 corrections in PR #388), the drift is
+called out — **the repo files win**.
 
 **When NOT to use this skill:**
 - Domain theory (why short-cycling kills compressors, what a deadband is, HA
@@ -107,12 +108,12 @@ negative °C number (#291 was exactly this in a chart subtitle). `units.py`
 keeps all four converters side by side to make the axis visible.
 
 **The parity system** keeps the contract enforced: every write-boundary
-temperature field is registered in `TEMPERATURE_FIELDS` in `routes.py`
-(field → kind: `absolute` / `absolute_nullable` / `delta` / `delta_nullable`;
-11 fields as of v0.22.1) AND in `e2e/tests/temperature-fields.ts`, with a
-`// @covers:` round-trip test in `e2e/tests/temperature-units.spec.ts`.
+temperature field is registered in `TEMPERATURE_FIELDS` in both `routes.py`
+(12 fields as of v0.22.1) and `e2e/tests/temperature-fields.ts`, with
+`// @covers:` round-trip tests, and
 `backend/tests/test_temperature_field_parity.py` fails CI on any drift. The
-add-a-field procedure and gates are owned by `plenum-change-control`.
+add-a-field procedure and gates are owned by `plenum-change-control`; the
+parity-rule details by `plenum-validation-and-qa`.
 
 **History note:** older CLAUDE.md copies placed `_to_f`/`_delta_to_f`/`_from_f`
 in `backend/api/routes.py`; CLAUDE.md was corrected 2026-07-05 (PR #388). They
@@ -150,7 +151,7 @@ live in `backend/units.py` and are imported into routes.py under those aliases
 | **Heat pumps unsupported** | Deliberate scope cut | Stated in `docs/safety.md`. The cooling lockout has no heating equivalent because a conventional furnace is assumed; reversing-valve/defrost semantics would invalidate several guards. Don't "fix" cold-weather heating behaviour by analogy with the cooling lockout. |
 | **OpenAPI decorators are documentation-only** | Verified current at v0.22.1 | `@docs` / `@request_schema` / `@response_schema` (`api/openapi.py`, #188) install **no validation middleware** — handlers parse `await request.json()` themselves. #295 (closed) did **not** add schema-driven validation; it added targeted per-field validators in routes.py: `_THERMO_NUMERIC_BOUNDS` + `_validate_thermostat_numeric` for the safety-critical numeric fields, `_validate_deadband_override`, `_validate_ambient_suppression`. Any *new* body field is unvalidated unless you validate it by hand — the schema will happily document a constraint nobody enforces. |
 | **`DESIGN.md` is stale** | Historical doc | See §1. `docs/` pages are the docs of record for shipped behaviour. |
-| **CLAUDE.md drift** | Trust the repo files; CLAUDE.md corrected 2026-07-05 (PR #388) | The 2026-07-04 audit found and fixed: (a) unit helpers live in `backend/units.py`, not routes.py (§2); (b) the visual-regression E2E suite lives in `.github/workflows/container-ci.yml` — there is **no** `e2e.yml` anymore; (c) coverage thresholds ratcheted to backend `fail_under = 92.5` (`pyproject.toml`), frontend 90/85/72/87 (`vite.config.ts`). If CLAUDE.md and the repo disagree again, the repo wins — re-run the Provenance checks. |
+| **CLAUDE.md drift** | Trust the repo files; CLAUDE.md corrected 2026-07-05 (PR #388) | The 2026-07-04 audit found and fixed: (a) unit helpers live in `backend/units.py`, not routes.py (§2); (b) the visual-regression E2E suite lives in `.github/workflows/container-ci.yml` — there is **no** `e2e.yml` anymore; (c) coverage thresholds ratcheted (backend `fail_under` 92.5 as of 2026-07; table of record: `plenum-validation-and-qa` §6). If CLAUDE.md and the repo disagree again, the repo wins — re-run the Provenance checks. |
 
 ---
 
@@ -180,7 +181,7 @@ All facts verified 2026-07-04 against v0.22.1 (`smart_vent/config.yaml`).
 Volatile facts and how to re-verify:
 
 - **Helper location / aliases**: `grep -n "from ..units import" smart_vent/backend/api/routes.py` (lines 35–38 as of 2026-07).
-- **TEMPERATURE_FIELDS count (11)**: `grep -c '":' <(sed -n '/^TEMPERATURE_FIELDS/,/^}/p' smart_vent/backend/api/routes.py)` or read routes.py lines ~243–262.
+- **TEMPERATURE_FIELDS count (12, recounted 2026-07-05)**: `grep -c '":' <(sed -n '/^TEMPERATURE_FIELDS/,/^}/p' smart_vent/backend/api/routes.py)` → 12, or read routes.py lines ~243–262.
 - **Ports 8099/9099**: `grep -n "PORT" smart_vent/backend/main.py`; `grep -n "tcp" smart_vent/config.yaml`.
 - **Tick cadence / jobs**: `grep -n "add_job" -A4 smart_vent/backend/scheduler.py`.
 - **Coverage thresholds** (ratchet upward over time): `grep fail_under smart_vent/pyproject.toml`; `grep -A4 "lines:" smart_vent/frontend/vite.config.ts`.

--- a/.claude/skills/plenum-auth-campaign/SKILL.md
+++ b/.claude/skills/plenum-auth-campaign/SKILL.md
@@ -27,6 +27,14 @@ without supervision by (a) running the Phase-0 recon to establish today's
 behavior as ground truth, then (b) walking numbered phases, each with an entry
 gate, exact steps, and EXPECTED observations with branch-outs.
 
+## When NOT to use this skill
+
+- General "how do I gate a change / what CI must pass" → **plenum-change-control**.
+- Shipped MCP transport internals / loopback design rationale → **plenum-architecture-contract** (owns the MCP loopback invariant) and **plenum-failure-archaeology** (the default-port-mapping revert #387).
+- Where a config knob lives / add-a-knob parity → **plenum-config-and-flags**.
+- How to write tests CI accepts / coverage gates → **plenum-validation-and-qa**.
+- Running the stack to execute the curl matrix → **plenum-run-and-operate** / **plenum-build-and-env**.
+
 ## The problem in one paragraph
 
 Both the web UI (`0.0.0.0:8099`) and the MCP server (`0.0.0.0:9099`) are
@@ -314,8 +322,8 @@ wrong layer (must be REST-side, since dispatch is loopback).
 ### Phase 5 — Validation & promotion
 
 Route all of this through **plenum-change-control** (classification, CI gates,
-reviewer evidence) and **plenum-validation-and-qa** (how to add tests CI accepts,
-coverage gates — currently ~92.5 backend / 90-85-72-87 frontend per repo config,
+reviewer evidence) and **plenum-validation-and-qa** (how to add tests CI accepts;
+coverage gates — backend 92.5 as of 2026-07, full table in its §6,
 re-verify). Do not restate those here.
 - Backend: pytest integration tests for every matrix cell in both `require_auth`
   states and both temperature units (Celsius-mode pattern lives in
@@ -354,14 +362,6 @@ A+C with `require_auth` ON.
 
 The last row is the backwards-compat guarantee: with the flag off, the Phase-0
 baseline codes must be reproduced exactly.
-
-## When NOT to use this skill
-
-- General "how do I gate a change / what CI must pass" → **plenum-change-control**.
-- Shipped MCP transport internals / loopback design rationale → **plenum-architecture-contract** (owns the MCP loopback invariant) and **plenum-failure-archaeology** (the default-port-mapping revert #387).
-- Where a config knob lives / add-a-knob parity → **plenum-config-and-flags**.
-- How to write tests CI accepts / coverage gates → **plenum-validation-and-qa**.
-- Running the stack to execute the curl matrix → **plenum-run-and-operate** / **plenum-build-and-env**.
 
 ## Provenance and maintenance
 

--- a/.claude/skills/plenum-build-and-env/SKILL.md
+++ b/.claude/skills/plenum-build-and-env/SKILL.md
@@ -131,10 +131,9 @@ exact names, several are commonly misguessed:
 | `npm run test:coverage` | `vitest run --coverage` |
 
 Smoke test (verified: `npx vitest run src/contexts.test.ts` — 13 tests pass).
-Coverage thresholds live in `vite.config.ts` `test.coverage.thresholds`:
-**lines 90, functions 85, branches 72, statements 87** (as of 2026-07,
-v0.22.1; CLAUDE.md corrected 2026-07-05 — recalibrated for
-Vitest 4's v8 remapping).
+Coverage thresholds live in `vite.config.ts` `test.coverage.thresholds`
+(four ratcheted values, recalibrated for Vitest 4's v8 remapping; threshold
+table of record: `plenum-validation-and-qa` §6).
 
 ### Vite dev server: port and proxies
 

--- a/.claude/skills/plenum-change-control/SKILL.md
+++ b/.claude/skills/plenum-change-control/SKILL.md
@@ -43,11 +43,11 @@ flagged explicitly — **the repo files win**.
 | # | Rule (from CLAUDE.md unless noted) | Rationale | Incident behind it |
 |---|---|---|---|
 | 1 | **Never leak exception detail into API responses.** In route-handler `except` blocks: `log.exception("…context…")` then `return error("generic message", status=5xx)`. Never embed `{exc}` / `str(exc)` in the body. | Raw exception strings disclose internals (paths, SQL, tokens) — CWE-209 information disclosure. | **Security alert #4** (GitHub code-scanning alert; not an issue — detail lives in CLAUDE.md). `routes.py` has 5 `log.exception` call sites following the pattern (as of 2026-07, v0.22.1). |
-| 2 | **The frontend NEVER converts temperatures on outgoing payloads** (no `toStorage`/`toStorageDelta` on POST/PUT bodies). Conversion happens exactly once, at the backend write boundary via `_to_f`/`_delta_to_f`. | Two independent converters on one path means double conversion the moment both run. | **#231**: in °C mode the Thermostats form called `toStorage(16)` → 60.8, then the backend's `_to_f` converted again → **141.44 °F stored**. Both sides' unit tests passed because each asserted a *different* contract. Spawned the 3-file parity system (§2.1) and the dual-unit E2E matrix. Sibling °C bugs: #280, #281, #284, #291, #292. Full invariant owned by `plenum-architecture-contract`. |
-| 3 | **Every backend/API knob must have a UI control** — a new `ThermostatConfig` field, system setting, or write-boundary tunable requires a form control + helper text on the matching React page, in the same change. 100% rule. | A knob reachable only via DB/API is an incomplete feature; the add-on's users operate through the ingress UI only. | Written rule in CLAUDE.md. No single triggering incident found in the mined issue history (checked closed-bugs.md / closed-features.md) — treat as a standing product decision, not folklore. |
+| 2 | **The frontend NEVER converts temperatures on outgoing payloads** (no `toStorage`/`toStorageDelta` on POST/PUT bodies). Conversion happens exactly once, at the backend write boundary via `_to_f`/`_delta_to_f`. | Two independent converters on one path means double conversion the moment both run. | **#231**: both sides converted, so 16 °C reached the DB as 141.44 °F — while each side's unit tests passed. Spawned the 3-file parity system (§2.1) and the dual-unit E2E matrix. Full story: `plenum-failure-archaeology`; invariant: `plenum-architecture-contract`. |
+| 3 | **Every backend/API knob must have a UI control** — a new `ThermostatConfig` field, system setting, or write-boundary tunable requires a form control + helper text on the matching React page, in the same change. 100% rule. | A knob reachable only via DB/API is an incomplete feature; the add-on's users operate through the ingress UI only. | Written rule in CLAUDE.md. No single triggering incident found in the closed-issue corpus on GitHub (48 bug + 58 feature issues, mined 2026-07-04) — treat as a standing product decision, not folklore. |
 | 4 | **Never mention Claude/AI authorship or include Claude session links** in commit messages, PR titles/bodies, or issue comments. | Repo owner's hygiene policy; keeps the public history tool-agnostic. | No incident in mined history; the full git log (450 commits checked) contains no such mention — the rule has held. |
 | 5 | **After every push to a PR, update the PR body** (what changed, why, test plan) without being asked. **Review fixes go to the PR's own branch**, never a separate review branch. | Reviewers and the changelog generator (`release-pr.yml` builds release notes from PR titles) rely on PR metadata being current; fixes on a side branch never appear in the PR diff. | Written rule in CLAUDE.md; no specific incident found in mined history. |
-| 6 | **Validate temperature bounds AFTER unit normalization** — convert to internal °F first, then apply the 40–90 °F range check, before persisting. | Bounds applied to the raw display value are meaningless when the unit varies: 150 raw could be °C or °F. | `.jules/sentinel.md` entry **2026-05-05 [MEDIUM]**: missing normalized-value validation allowed extreme setpoints through. See `_temp_range_error()` and `_validate_deadband_override()` in `routes.py` (converts via `_delta_to_f` *then* checks 0–10 °F) for the canonical pattern. |
+| 6 | **Validate temperature bounds AFTER unit normalization** — convert to internal °F first, then apply the field's range check, before persisting. Bounds are per-field: user targets 40–90 °F, `min_setpoint`/`max_setpoint` 40–100 °F, `deadband_override` 0–10 °F (catalog: `plenum-config-and-flags`). | Bounds applied to the raw display value are meaningless when the unit varies: 150 raw could be °C or °F. | `.jules/sentinel.md` entry **2026-05-05 [MEDIUM]**: missing normalized-value validation allowed extreme setpoints through. See `_temp_range_error()` and `_validate_deadband_override()` in `routes.py` (converts via `_delta_to_f` *then* checks 0–10 °F) for the canonical pattern. |
 | 7 | **Safety guards are one-way ratchets** — never weaken a protective interlock (short-cycle protection, cooling lockout, staleness guard, cycle timeout, min_open_vents, max_setpoint envelope) to fix a comfort complaint or a flaky test. **[INFERRED — not written in CLAUDE.md; derived from history, label it as inferred if you cite it in a PR.]** | These guards protect physical equipment (compressor slugging, dead-heading the air handler, runaway cycles). A regression is silent until hardware is damaged. | The **#208–#213 safety-hardening wave**: #208 no short-cycle protection; #209 no cold-weather compressor lockout (→ `cooling_lockout_below_f`); #210 `min_open_vents` bypass can dead-head the air handler; #211 no sensor-staleness guard; #212 cycle timeout had zero tests ("a protective interlock with no test is one that can silently regress"); #213 safety features shipped off by default. Plus #267 (thermostat unavailability suspended ALL safety monitoring) and #367/#368 (max_setpoint envelope not enforced with zero active rooms). |
 
 ---
@@ -82,8 +82,9 @@ field actually appears in `routes.py` source.
 
 Also required:
 - The handler must call `_to_f`/`_delta_to_f` (imported into `routes.py` from
-  `backend/units.py` — CLAUDE.md says the helpers live in `routes.py`; they
-  have since moved to `units.py` and are re-imported under the old names).
+  `backend/units.py`; pre-2026-07-05 CLAUDE.md copies said the helpers live in
+  `routes.py` — corrected in PR #388; if docs and repo disagree again, the
+  repo wins).
 - Bounds check AFTER conversion (rule 6).
 - A Celsius-mode backend integration test (set
   `client.app["scheduler"]._active_unit = "C"`, POST a °C value, assert stored °F).
@@ -118,16 +119,10 @@ construction. The round-trip matrix (°F and °C stacks in container-ci's
   (dual-unit filenames, e.g. `dashboard-Fahrenheit-chromium.png` /
   `dashboard-Celsius-chromium.png`, plus `-mobile` variants) and fails on any
   pixel deviation. Goldens for **both** unit sets must be regenerated.
-- **History note:** pre-2026-07-05 CLAUDE.md copies described a standalone
-  `.github/workflows/e2e.yml` with `max-parallel: 1` and in-job golden
-  commits (corrected in PR #388). That workflow no longer exists — the visual-regression matrix now
-  lives in `.github/workflows/container-ci.yml` (jobs `e2e` +
-  `commit-goldens`). Both unit legs run **in parallel**; each leg that
-  regenerates goldens verifies them in a second pass, uploads only its own
-  unit's PNGs as artifact `goldens-F`/`goldens-C`, and a fan-in
-  `commit-goldens` job makes one combined commit + rebase + push to the PR
-  branch (`ci: update E2E golden screenshots (F + C)`). The detached-HEAD push
-  bug in the old fan-in was #369.
+- The matrix lives in `.github/workflows/container-ci.yml` (jobs `e2e` +
+  `commit-goldens`); a fan-in bot commits regenerated goldens back to the PR
+  branch. Full leg/fan-in mechanics (and the pre-2026-07-05 `e2e.yml` /
+  `max-parallel: 1` history, corrected in PR #388): `plenum-ci-and-release` §3.
 - Your obligations: review every changed PNG in the diff like code; if the
   change adds time-varying or engine-driven UI (clocks, timers, feeds, live
   counts), wrap it in `<Frozen>` from `frontend/src/ci.tsx` or goldens never
@@ -181,16 +176,18 @@ Files: `smart_vent/backend/engine/cycle_engine.py`, `vent_controller.py`,
 
 ---
 
-## 3. Coverage and lint gates (verified numbers; CLAUDE.md matches since 2026-07-05)
+## 3. Coverage and lint gates (CLAUDE.md matches the repo since 2026-07-05, PR #388)
 
-| Gate | Verified value (2026-07, v0.22.1) | Where | CLAUDE.md says |
-|---|---|---|---|
-| Backend coverage | `fail_under = 92.5` | `smart_vent/pyproject.toml` line 48 | 90 (stale) |
-| Frontend coverage | lines 90, functions 85, branches 72, statements 87 | `smart_vent/frontend/vite.config.ts` lines 29–34 | 80.9 / 71.1 / 77.1 / 80.9 (stale) |
-| Python lint | `ruff check backend/` + `ruff format --check backend/` | `lint.yml` | same |
-| Types | `mypy backend/ --ignore-missing-imports` | `lint.yml` | same |
-| Frontend lint | `npm run lint` + `npm run format:check` | `lint.yml` | same |
-| Security | Trivy fs scan of source (lint.yml); Trivy image scan on release PRs (container-ci) — no CRITICAL allowed | `lint.yml`, `container-ci.yml` | same |
+Coverage threshold table of record: `plenum-validation-and-qa` §6.
+
+| Gate | Value / command | Where |
+|---|---|---|
+| Backend coverage | `fail_under` ratchet (92.5 as of 2026-07) | `smart_vent/pyproject.toml` |
+| Frontend coverage | four vitest thresholds — see `plenum-validation-and-qa` §6 | `smart_vent/frontend/vite.config.ts` |
+| Python lint | `ruff check backend/` + `ruff format --check backend/` | `lint.yml` |
+| Types | `mypy backend/ --ignore-missing-imports` | `lint.yml` |
+| Frontend lint | `npm run lint` + `npm run format:check` | `lint.yml` |
+| Security | Trivy fs scan of source (lint.yml); Trivy image scan on release PRs (container-ci) — no CRITICAL allowed | `lint.yml`, `container-ci.yml` |
 
 Practical implication of rising thresholds: coverage is ratcheted, not fixed.
 Ship tests with every change; a change that lowers coverage below the ratchet
@@ -259,12 +256,12 @@ cd smart_vent/frontend && npx vitest run --coverage
 
 | You are about to… | Gates you must clear | Evidence you must produce |
 |---|---|---|
-| Add/rename a temperature field on any write endpoint | `test_temperature_field_parity.py` (3-file lockstep); round-trip matrix (F+C); backend + frontend coverage ratchets | `_to_f`/`_delta_to_f` call with correct kind; post-conversion 40–90 °F bounds; Celsius integration test (stored °F asserted); frontend test asserting raw display value in POST body; `@covers:` tagged round-trip; UI control |
+| Add/rename a temperature field on any write endpoint | `test_temperature_field_parity.py` (3-file lockstep); round-trip matrix (F+C); backend + frontend coverage ratchets | `_to_f`/`_delta_to_f` call with correct kind; post-conversion per-field bounds (rule 6; catalog in `plenum-config-and-flags`); Celsius integration test (stored °F asserted); frontend test asserting raw display value in POST body; `@covers:` tagged round-trip; UI control |
 | Add a `config.yaml` option | `test_addon_config.py` | `bashio::config`/`get_config` read + export in `run.sh`; UI control if user-tunable; docs of the default |
 | Change anything a page renders | Visual-regression matrix (F+C legs in container-ci) | Regenerated goldens for BOTH units reviewed PNG-by-PNG in the diff; `<Frozen>` wrap for any new volatile UI |
 | Add an API endpoint | `test_api_spec_enforcement.py`; coverage ratchets | `@docs` + `@response_schema` (200/201); handler-side body validation; CWE-209-safe except blocks (`log.exception` + generic `error()`) |
 | Add a Python dependency | CI installs `".[dev]"` — nothing else | Entry in `pyproject.toml` `[project]` or dev extras; justification if runtime; never PyYAML |
-| Touch engine / a safety guard | Full backend suite at 92.5% ratchet; reviewer scrutiny at the repo's highest bar | Consequence-level tests (not reason-strings), boundary tests both sides, pinned defaults, degraded-sensor behavior tests; explicit PR-body justification for ANY weakening (one-way ratchet, inferred rule) |
+| Touch engine / a safety guard | Full backend suite at the coverage ratchet (§3); reviewer scrutiny at the repo's highest bar | Consequence-level tests (not reason-strings), boundary tests both sides, pinned defaults, degraded-sensor behavior tests; explicit PR-body justification for ANY weakening (one-way ratchet, inferred rule) |
 | Change a UI form that submits temperatures | Parity test §2.1 items 2–3 if fields change; vitest coverage; round-trip matrix | No `toStorage`/`toStorageDelta` on outgoing payloads (#231); init via `toDisplay`/`toDisplayDelta`; delta fields use the delta helpers (no −32 corruption) |
 | Push any commit to a PR | — | Updated PR body (what/why/test plan), every time; fixes pushed to the PR's own branch; zero AI-authorship mentions or session links |
 | Cut a release | Green Validate Release dry-run; required check `Build (PR validation)`; Trivy no CRITICAL | Three version files agree; changelog section correct; one-click start of validate-release on the bot PR |

--- a/.claude/skills/plenum-ci-and-release/SKILL.md
+++ b/.claude/skills/plenum-ci-and-release/SKILL.md
@@ -16,7 +16,8 @@ description: >
 
 Everything here was verified against the workflow YAML on the branch as of
 2026-07 (v0.22.1). **The repo YAML is the source of truth** — two docs of
-record lag behind it (see "Known doc drift" at the end):
+record lagged behind it until corrected on 2026-07-05 (see "Doc drift
+history" at the end):
 
 - Pre-2026-07-05 `CLAUDE.md` copies described a standalone
   `.github/workflows/e2e.yml` with `max-parallel: 1` and in-job golden commits
@@ -249,7 +250,7 @@ and is UNVERIFIED from the working tree (needs admin API access).
 | Red check / symptom | Likely cause | Fix |
 |---|---|---|
 | `Python (ruff)` fails only on `ruff format --check` | unformatted code | `cd smart_vent && ruff format backend/`, commit |
-| `Python (pytest)` fails with coverage error | backend coverage below `fail_under = 90` (`pyproject.toml`) | add tests — patterns in `plenum-validation-and-qa` |
+| `Python (pytest)` fails with coverage error | backend coverage below the `fail_under` ratchet in `pyproject.toml` — 92.5 as of 2026-07; see `plenum-validation-and-qa` | add tests — patterns in `plenum-validation-and-qa` |
 | `Python (pytest)` fails in `test_temperature_field_parity.py` | temperature field added to only 1–2 of the 3 registries (`routes.py` `TEMPERATURE_FIELDS`, `e2e/tests/temperature-fields.ts`, `// @covers:` tag in the spec) | complete all three — checklist in `plenum-change-control` §2.1 |
 | `Python (pytest)` fails in `test_addon_config.py` | `config.yaml` option without matching `bashio::config` in `run.sh` | add to both files |
 | `Python (pytest)` fails in `test_api_spec_enforcement.py` | new `/api/` route without `@docs` + `@response_schema` | add the decorators |
@@ -279,16 +280,17 @@ them nightly (04:17 UTC). Deletion rules, exactly as coded:
   boolean that lists deletions without deleting — use it before changing
   retention.
 
-## 7. Known doc drift (as of 2026-07, v0.22.1)
+## 7. Doc drift history (all corrected 2026-07-05, PR #388)
 
-| Doc | Stale claim | Reality |
+| Doc | Pre-2026-07-05 stale claim | Reality (and current text) |
 |---|---|---|
-| `CLAUDE.md` "E2E visual regression" section | standalone `.github/workflows/e2e.yml`; `max-parallel: 1`; each leg commits its own goldens; "verify with updated goldens runs in the same job" via `git checkout -f -B` | no `e2e.yml` exists; legs run in parallel inside `container-ci.yml`; verify happens per-leg, commit happens once in the `Commit updated goldens` fan-in (#366) |
-| `CLAUDE.md` same section | `mode=pull` polling loop in "Decide image source" | replaced by `needs: build` + direct pull since the move into container-ci |
-| `RELEASE.md` "What triggers what" table (pre-2026-07-05) | `docker.yml` → `build-pr` / `build-release`; required check "Build & Push release image" | corrected 2026-07-05 (PR #388): all PR container work is `container-ci.yml`'s `Build (PR validation)`, which is the required check |
+| `CLAUDE.md` "E2E visual regression" section | standalone `.github/workflows/e2e.yml`; `max-parallel: 1`; each leg commits its own goldens; "verify with updated goldens runs in the same job" via `git checkout -f -B` | no `e2e.yml` exists; legs run in parallel inside `container-ci.yml`; verify happens per-leg, commit happens once in the `Commit updated goldens` fan-in (#366). Corrected in PR #388. |
+| `CLAUDE.md` same section | `mode=pull` polling loop in "Decide image source" | replaced by `needs: build` + direct pull since the move into container-ci. Corrected in PR #388. |
+| `RELEASE.md` "What triggers what" table | `docker.yml` → `build-pr` / `build-release`; required check "Build & Push release image" | corrected 2026-07-05 (PR #388): all PR container work is `container-ci.yml`'s `Build (PR validation)`, which is the required check |
 
-When these disagree, the workflow YAML wins. If you touch the workflows,
-update `RELEASE.md`'s table and CLAUDE.md's E2E section in the same PR.
+If docs and repo disagree again, the workflow YAML wins. If you touch the
+workflows, update `RELEASE.md`'s table and CLAUDE.md's E2E section in the
+same PR.
 
 ## Provenance and maintenance
 

--- a/.claude/skills/plenum-config-and-flags/SKILL.md
+++ b/.claude/skills/plenum-config-and-flags/SKILL.md
@@ -206,6 +206,9 @@ in the same change.
 4. Verify: `cd smart_vent && python -m pytest backend/tests/test_addon_config.py -q`.
 
 ### B. New temperature field on a write boundary
+(Gates and reviewer evidence: `plenum-change-control` §2.1; parity-rule
+mechanics and failure texts: `plenum-validation-and-qa` §5. This checklist is
+the catalog-side companion, not the owner.)
 1. Backend: convert with `_to_f` (absolute) or `_delta_to_f` (delta) from `backend/units.py`; validate the **°F value** after conversion (40–90 °F for user targets, per `.jules/sentinel.md`); pick nullable semantics deliberately.
 2. Register in `TEMPERATURE_FIELDS` in `routes.py` with the right kind — a wrong absolute/delta kind silently corrupts data.
 3. Register in `e2e/tests/temperature-fields.ts` (`field`, `kind`, `ui`, `endpoints`).

--- a/.claude/skills/plenum-debugging-playbook/SKILL.md
+++ b/.claude/skills/plenum-debugging-playbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plenum-debugging-playbook
-description: Symptom-to-triage playbook for Plenum (smart-thermostat-with-vents). Load when something is behaving wrong at runtime and you need to find the cause fast — temperatures off by ~×1.8 or ~30°, cycles that never end or end early, vents thrashing or stuck open/closed, a zone the engine silently stopped controlling, timestamps shifted by hours, duplicated/zombie live-feed rows, HA entity or cover-service failures, wrong heat/cool mode or oscillation, or one of the three classic CI failures. Gives ranked causes, the exact discriminating command/query/log line, and the issue precedent for each.
+description: Symptom-to-triage playbook for Plenum (smart-thermostat-with-vents). Load when something is behaving wrong at runtime and you need to find the cause fast — temperatures off by ~×1.8 or ~30°, cycles that never end or end early, vents thrashing or stuck open/closed, a zone the engine silently stopped controlling, timestamps shifted by hours, duplicated/zombie live-feed rows, HA entity or cover-service failures, wrong heat/cool mode or oscillation, or one of the three classic CI failures (golden-screenshot diff, TEMPERATURE_FIELDS parity, coverage gate). Gives ranked causes, the exact discriminating command/query/log line, and the issue precedent for each.
 ---
 
 # Plenum Debugging Playbook
@@ -35,14 +35,14 @@ All paths relative to repo root; runtime paths are inside the container.
 | Surface | What it is | How to read it |
 |---|---|---|
 | Backend log | Python logging → container stdout. Every event-log write is mirrored here as `[CATEGORY] message` (`smart_vent/backend/event_logger.py:71`) | Docker: `docker logs <container>`. HAOS: add-on Log tab (container name carries the repo-ID prefix, e.g. `..._plenum` — see #92) |
-| `event_log` DB table | Persisted structured events: `id, timestamp, level, category, message, details` (`db.py`). Categories in use: `system`, `api`, `engine`, `presence`, `ha`, `reconcile`. Capped ~5000 rows (trim had an off-by-one, #299) | `sqlite3 /data/app.db "SELECT timestamp,level,category,message FROM event_log ORDER BY id DESC LIMIT 50;"` (DB is `$DATA_DIR/app.db`, default `/data/app.db` — `backend/main.py:42-43`) |
+| `event_log` DB table | Persisted structured events: `id, timestamp, level, category, message, details` (`db.py`). Categories in use: `system`, `api`, `engine`, `presence`, `ha`, `reconcile`, `dev` (Logs.tsx filter list). Capped ~5000 rows (trim had an off-by-one, #299) | `sqlite3 "$DATA_DIR/app.db" "SELECT timestamp,level,category,message FROM event_log ORDER BY id DESC LIMIT 50;"` (code default `/data/app.db` — `backend/main.py:42-43`; add-on default `/config/app.db` — see `plenum-run-and-operate`) |
 | Logs page → Live Feed | UI over `GET /api/logs/events` + WS pushes | Filter by category/level; beware #302 dup rows, #283 zombie sockets |
 | Logs page → Cycle History | UI over `GET /api/logs` (cycle_logs rows), per-cycle drill-down `GET /api/logs/{cycle_id}/detail` and `/temp-samples` | A cycle with `ended_at IS NULL` shows "Active/running" |
-| Cycle tables | `cycle_logs`, `room_cycle_states` (per-room `target_temp, reached_at, vent_closed_at, role, joined_at`), `cycle_temp_samples`, `cycle_setpoint_history`, `cycle_vent_events` | `sqlite3 /data/app.db "SELECT id,mode,started_at,ended_at,ended_reason,in_min_runtime_hold FROM cycle_logs ORDER BY started_at DESC LIMIT 10;"` |
+| Cycle tables | `cycle_logs`, `room_cycle_states` (per-room `target_temp, reached_at, vent_closed_at, role, joined_at`), `cycle_temp_samples`, `cycle_setpoint_history`, `cycle_vent_events` | `sqlite3 "$DATA_DIR/app.db" "SELECT id,mode,started_at,ended_at,ended_reason,in_min_runtime_hold FROM cycle_logs ORDER BY started_at DESC LIMIT 10;"` |
 | HA states as Plenum sees them | `POST /api/ha/states` with `{"entity_ids": [...]}` — sensor values already normalized to °F | `curl -s -X POST localhost:8099/api/ha/states -H 'Content-Type: application/json' -d '{"entity_ids":["sensor.x"]}'` |
 | Zone status | `GET /api/status` (per-zone cycle_state/hvac_mode/current_temp/setpoint), `GET /api/system/status`, `GET /api/healthz` | The #367 evidence format |
 | Health endpoints | `GET /api/sensor-health` (per-sensor freshness vs staleness threshold), `GET /api/thermostat-health` | First stop for "engine seems blind" |
-| Settings | `GET /api/settings`; `system_settings` table keys include `temperature_unit`, `unit_change_ack_required`, `unit_change_acked_unit`, `system_enabled`, `developer_mode`, `sensor_stale_after_min`, `vacation_mode_enabled`, `vacation_mode_return_at`, `outside_temperature_entity_id`, `mcp_enabled` | `sqlite3 /data/app.db "SELECT * FROM system_settings;"` |
+| Settings | `GET /api/settings`; `system_settings` table keys include `temperature_unit`, `unit_change_ack_required`, `unit_change_acked_unit`, `system_enabled`, `developer_mode`, `sensor_stale_after_min`, `vacation_mode_enabled`, `vacation_mode_return_at`, `outside_temperature_entity_id`, `mcp_enabled` | `sqlite3 "$DATA_DIR/app.db" "SELECT * FROM system_settings;"` |
 | Live WS | `GET /ws` (`main.py:146`), broadcasts zone status + log events, temperatures raw °F | |
 
 ---
@@ -51,15 +51,15 @@ All paths relative to repo root; runtime paths are inside the container.
 
 | # | Symptom (as an operator states it) | Most likely causes, ranked | Discriminating experiment | Precedent |
 |---|---|---|---|---|
-| 1 | "Shows 158°F / -16°C / values off by ×1.8 or ~30°" | (a) absolute-vs-delta conversion misuse; (b) double conversion (frontend converted before POST); (c) a write path bypassing `to_f` (MCP, new endpoint); (d) HA fixture/instance in the wrong unit | Read the stored value: `sqlite3 /data/app.db "SELECT min_setpoint,deadband FROM thermostat_configs;"` — sane °F (60–85, deadband ~0.5–2) ⇒ display bug; insane (141.44, negative) ⇒ write-boundary bug | #231 #280 #281 #284 #291 #292 |
+| 1 | "Shows 158°F / -16°C / values off by ×1.8 or ~30°" | (a) absolute-vs-delta conversion misuse; (b) double conversion (frontend converted before POST); (c) a write path bypassing `to_f` (MCP, new endpoint); (d) HA fixture/instance in the wrong unit | Read the stored value: `sqlite3 "$DATA_DIR/app.db" "SELECT min_setpoint,deadband FROM thermostat_configs;"` — sane °F (60–85, deadband ~0.5–2) ⇒ display bug; insane (141.44, negative) ⇒ write-boundary bug | #231 #280 #281 #284 #291 #292 |
 | 2 | "Cycle runs for hours / never ends" or "ends the instant it starts" | (a) post-closure drift blocking termination; (b) large `temp_offset` / stale sensor lying about room temp; (c) deadband in the completion check; (d) schedule window restarting cycles | `curl -s localhost:8099/api/logs/<cycle_id>/detail` — compare `vent_closed_at` per room vs cycle `ended_at`; then `GET /api/sensor-health` for staleness | #86 #70 #211 #38 |
-| 3 | "Vents open/close repeatedly" or "stay open/closed when they shouldn't" | (a) min-runtime hold not gated (thrash); (b) close path bypassing `control_method` dispatcher (silently no-op close); (c) idle-room vents left over from previous cycle; (d) airflow floor (`min_open_vents_fraction`) refusing a close | `sqlite3 /data/app.db "SELECT timestamp,entity_id,action,reason FROM cycle_vent_events WHERE cycle_id='<id>' ORDER BY timestamp;"` — alternating open/close on the same entity ⇒ thrash; "Closed" logged but HA shows open ⇒ dispatcher bypass | #237 #57 #82 #67 #244 #210 |
+| 3 | "Vents open/close repeatedly" or "stay open/closed when they shouldn't" | (a) min-runtime hold not gated (thrash); (b) close path bypassing `control_method` dispatcher (silently no-op close); (c) idle-room vents left over from previous cycle; (d) airflow floor (`min_open_vents_fraction`) refusing a close | `sqlite3 "$DATA_DIR/app.db" "SELECT timestamp,entity_id,action,reason FROM cycle_vent_events WHERE cycle_id='<id>' ORDER BY timestamp;"` — alternating open/close on the same entity ⇒ thrash; "Closed" logged but HA shows open ⇒ dispatcher bypass | #237 #57 #82 #67 #244 #210 |
 | 4 | "The engine just stopped doing anything for a zone" | (a) exception before `engine.tick()` swallowed; (b) engine deleted mid-cycle (last room removed); (c) startup task garbage-collected; (d) `active_rooms=0` early-exit (no safety checks run); (e) thermostat unavailable mid-cycle | Backend log: is the 60 s `Reconcile <climate.x>: engine=... active_rooms=N` line still appearing for that zone? Absent ⇒ (a)/(b)/(c). Present with `active_rooms=0` while rooms bake ⇒ (d) | #286 #285 #304 #367 #267 |
 | 5 | "Times are hours off / picker rejects valid times" | (a) `datetime.now()` (naive local) mixed into a UTC pipeline; (b) frontend printing raw naive-UTC string without `+ "Z"` conversion; (c) UTC used to build a `datetime-local` bound; (d) wrong `timezone` add-on option / `TZ` env | Offset direction test: shifted by exactly the browser's UTC offset ⇒ display bug (b); shifted the *other* way ⇒ backend wrote local time (a). Check `echo $TZ` in the container vs the `timezone` option | #65 #26 #294 #301 |
 | 6 | "Live feed shows duplicates / keeps loading after I leave / Clear doesn't work" | (a) WS reconnect after intentional close (zombie sockets, stale handlers); (b) offset pagination sliding under new rows; (c) local-only Clear repopulated by polling | Browser devtools → Network → WS: more than one open `/ws` connection after navigating away and back ⇒ (a). Duplicated rows only after "Load older" ⇒ (b) | #283 #302 #303 #297 (backend twin) |
 | 7 | "Vent didn't move / sensor shows unavailable / HA connection flaky" | (a) vent's `control_method` doesn't match what the integration supports (`cover.open_cover` unsupported); (b) sensor stale-but-numeric; (c) HA WS busy-loop or hung handshake during HA restart | Test the vent directly: `POST /api/vents/test` (the Rooms-page Test Open/Close buttons use it); `GET /api/sensor-health` for (b); backend log connect/close spam for (c) | #57 #82 #211 #297 |
-| 8 | "CI is red" (the 3 classics) | (a) golden screenshot diff; (b) `TEMPERATURE_FIELDS` parity test; (c) coverage gate | (a) look at the changed PNGs in the PR diff — visual-regression legs now live in `container-ci.yml` (not a standalone e2e.yml) and a `commit-goldens` fan-in pushes regenerated goldens; (b) run `python -m pytest backend/tests/test_temperature_field_parity.py -v` from `smart_vent/`; (c) `fail_under = 92.5` in `pyproject.toml`, vitest lines 90 / functions 85 / branches 72 / statements 87 in `frontend/vite.config.ts` | #182 #369 #329; → `plenum-ci-and-release` |
-| 9 | "It's heating when it should cool" / "heat and cool alternate every few minutes" | (a) mode inferred from live `hvac_action` at cycle boundary (heat_cool oscillation); (b) `_read_hvac_mode` fallback defaulting to heat on `idle`; (c) big `temp_offset` or stale sensor flipping the room-temp vote; (d) restored stale cycle mode after restart | `sqlite3 /data/app.db "SELECT started_at,mode,ended_reason FROM cycle_logs ORDER BY started_at DESC LIMIT 10;"` — strict cool/heat alternation with minutes-long gaps ⇒ (a); one wrong-direction cycle after restart ⇒ (d) | #29 #38 #48 #26 |
+| 8 | "CI is red" (the 3 classics) | (a) golden screenshot diff; (b) `TEMPERATURE_FIELDS` parity test; (c) coverage gate | (a) look at the changed PNGs in the PR diff — visual-regression legs now live in `container-ci.yml` (not a standalone e2e.yml) and a `commit-goldens` fan-in pushes regenerated goldens; (b) run `python -m pytest backend/tests/test_temperature_field_parity.py -v` from `smart_vent/`; (c) coverage below the ratchets (backend `fail_under` 92.5 as of 2026-07; thresholds table → `plenum-validation-and-qa` §6) | #182 #369 #329; → `plenum-ci-and-release` |
+| 9 | "It's heating when it should cool" / "heat and cool alternate every few minutes" | (a) mode inferred from live `hvac_action` at cycle boundary (heat_cool oscillation); (b) `_read_hvac_mode` fallback defaulting to heat on `idle`; (c) big `temp_offset` or stale sensor flipping the room-temp vote; (d) restored stale cycle mode after restart | `sqlite3 "$DATA_DIR/app.db" "SELECT started_at,mode,ended_reason FROM cycle_logs ORDER BY started_at DESC LIMIT 10;"` — strict cool/heat alternation with minutes-long gaps ⇒ (a); one wrong-direction cycle after restart ⇒ (d) | #29 #38 #48 #26 |
 
 ---
 
@@ -82,12 +82,11 @@ Discriminate the four signatures:
 | Display shows a **negative °C** for a small positive delta (2 °F deadband → −16.7 °C) | **absolute conversion applied to a delta** — someone used `toDisplay`/`from_f` (subtracts 32) where `toDisplayDelta`/`from_f_delta` (scale only) was required | #291; magnitude-only ×1.8 error with no sign flip = delta never converted at all, #292 |
 | Everything is °F even though the home is metric | auto-detect broken: HA `unit_system` is an *object* (compare `unit_system["temperature"] == "°C"`, not `== "metric"`), and blank `temperature_unit` in `run.sh` used to default-lock to `F` | #281; engine reading raw °C climate attributes as °F = #280 (runaway-HVAC class, not display) |
 
-Story (#231, the costliest): a Celsius user typed 16 °C; it reached the DB as
-141.44 °F. Both sides' unit tests passed, because each side's conversion was
-individually correct — only the *composition* was wrong. That escape created
-the three-file parity system and the dual-unit E2E matrix. If you see family-1
-symptoms, your first question is always "which side converted, and how many
-times?" — answered by reading the stored °F value, never by reading the UI.
+Story in one line (#231, the costliest — full account in
+`plenum-failure-archaeology`): both sides converted, 16 °C stored as
+141.44 °F, and each side's tests passed. If you see family-1 symptoms, your
+first question is always "which side converted, and how many times?" —
+answered by reading the stored °F value, never by reading the UI.
 
 ### 2. Cycle never terminates / terminates early
 
@@ -254,10 +253,11 @@ Ranked causes, with direction as the discriminator (browser at UTC−5):
    `ui: true` field lacks a `// @covers:` tag in
    `e2e/tests/temperature-units.spec.ts`. It is telling you a #231-class bug
    is possible — add the missing entry, don't weaken the test.
-3. **Coverage gate.** Backend `fail_under = 92.5` (`smart_vent/pyproject.toml`);
-   frontend vitest thresholds lines 90 / functions 85 / branches 72 /
-   statements 87 (`smart_vent/frontend/vite.config.ts`). CLAUDE.md's older
-   numbers (90 / 80.9…) are stale — trust the repo files.
+3. **Coverage gate.** Backend `fail_under` ratchet in
+   `smart_vent/pyproject.toml`; frontend vitest thresholds in
+   `smart_vent/frontend/vite.config.ts` (values: `plenum-validation-and-qa`
+   §6). Pre-2026-07-05 CLAUDE.md copies quoted older numbers; corrected in
+   PR #388 — if docs and repo disagree again, the repo wins.
    Also common but flake-class: the E2E global-setup room-creation click race
    (#329) — a red Round-trip leg on an unrelated PR is usually this; re-run
    before digging.

--- a/.claude/skills/plenum-diagnostics-and-tooling/SKILL.md
+++ b/.claude/skills/plenum-diagnostics-and-tooling/SKILL.md
@@ -60,7 +60,7 @@ Jargon used below (one-line definitions; theory in `hvac-zoning-reference`):
 | Timestamps | Naive **UTC** ISO strings (`2026-07-04T11:48:00.123456`) — `db._dts()` strips tzinfo on write. Bucket to local time with SQLite's `date(col,'localtime')` like the metrics code does. Exception: `schedules.expires_at` is naive **local** wall-clock (#359). |
 | Durations | Not stored; derive with `(julianday(ended_at)-julianday(started_at))*86400.0` seconds — the same expression `db.py` uses. |
 | Running cycle | `cycle_logs.ended_at IS NULL`. |
-| JSON columns | `cycle_logs.rooms_json` (`{room_id: {name, source}}`; `source` ∈ schedule/presence/override), `vents_at_start/_end`, `event_log.details`, `room_cycle_states.trigger_detail`. |
+| JSON columns | `cycle_logs.rooms_json` (`{room_id: {name, source}}`; `source` ∈ schedule/presence/override/safety — `safety` rooms are pulled in by the #367 envelope backstop, `cycle_engine.py:3013`), `vents_at_start/_end`, `event_log.details`, `room_cycle_states.trigger_detail`. |
 
 ### Schema map (tables you'll actually query — full DDL in `smart_vent/backend/db.py` `SCHEMA` + `_MIGRATIONS`, lines 38–425)
 

--- a/.claude/skills/plenum-docs-and-writing/SKILL.md
+++ b/.claude/skills/plenum-docs-and-writing/SKILL.md
@@ -212,6 +212,8 @@ that this matters: the stats block stamped "June 2026" was already stale by 2026
 
 Note the pattern: the **thresholds** (CI-enforced ratchets) stayed true; the **counts**
 (unenforced snapshots) rotted. Prefer claims CI enforces; date-stamp the rest.
+(Coverage-threshold table of record: `plenum-validation-and-qa` §6 — quote it,
+don't re-derive.)
 
 **Stats-refresh runbook** (do this whenever touching the Tested block, and at least
 once per minor release):

--- a/.claude/skills/plenum-failure-archaeology/SKILL.md
+++ b/.claude/skills/plenum-failure-archaeology/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: plenum-failure-archaeology
-description: The chronicle of every settled battle in Plenum (smart-thermostat-with-vents) — major investigations, dead ends, rejected approaches, and reverts, each as symptom → root cause → evidence → fix → status. Load when you suspect a bug was seen before, when someone proposes re-fixing or weakening something (deadband in at-target, frontend toStorage on payloads, default-mapped MCP port, per-selector screenshot masks), when you need the incident behind a guard/test name, or before filing an issue that might duplicate #26–#369 history. NOT for live triage of a new symptom (use plenum-debugging-playbook) or for the invariant statements themselves (plenum-architecture-contract).
+description: >-
+  The chronicle of every settled battle in Plenum
+  (smart-thermostat-with-vents) — major investigations, dead ends, rejected
+  approaches, and reverts, each as symptom → root cause → evidence → fix →
+  status. Load when you suspect a bug was seen before, when someone proposes
+  re-fixing or weakening something (deadband in at-target, frontend toStorage
+  on payloads, default-mapped MCP port, per-selector screenshot masks), when
+  you need the incident behind a guard/test name, or before filing an issue
+  that might duplicate #26–#369 history. NOT for live triage of a new symptom
+  (use plenum-debugging-playbook) or for the invariant statements themselves
+  (plenum-architecture-contract).
 ---
 
 # Plenum Failure Archaeology
@@ -279,7 +289,8 @@ from code). Settled.
 
 **#254 — overflow rooms were invisible in cycle history.** Their temps were
 buried in vent-event reason strings. Fix: `room_cycle_states.role`
-discriminator (`'active'`/`'overflow'`/`'safety'`-era values), one collapsed
+discriminator (`'active'` | `'overflow'`; note `'safety'` is a *source* on
+`ActiveRoom`, not a role — `cycle_engine.py:3013`), one collapsed
 row per overflow room, surfaced in the Logs cycle detail. Settled.
 
 **#268 — the anti-thrash gate had zero real coverage (test-quality
@@ -345,8 +356,9 @@ goldens committed to git. It promptly proved **flaky beyond rescue by
 masking** (**#182**): live temps, countdowns, engine feeds, and Recharts
 float jitter differed between the update pass and the verify pass;
 per-selector masks were whack-a-mole. The suite was **disabled** (PR #180)
-for months — the dead end to remember. The rescue (all now hard rules in
-CLAUDE.md's E2E section):
+for months — the dead end to remember. The rescue (these became the project's
+hard E2E rules, since restated in CLAUDE.md and superseded in mechanism by
+#366 below):
 
 - **Determinism by construction**: `isCI` (`VITE_APP_VERSION === "CI"`) +
   `<Frozen>` in `frontend/src/ci.tsx` — freeze anything that changes between
@@ -358,9 +370,10 @@ CLAUDE.md's E2E section):
   `unit_system: us_customary`; the matrix varies only Plenum's display unit.
   Dual-unit goldens (`-Fahrenheit-`/`-Celsius-` filenames) catch conversion
   regressions in both directions.
-- Golden auto-commit needs `max-parallel: 1` (legs push to the same ref) and
-  a forced checkout; high-DPI mobile needs a per-spec `maxDiffPixels` bump
-  (metrics: 800) instead of masks.
+- Golden auto-commit *needed* `max-parallel: 1` (legs pushed to the same ref)
+  and a forced checkout — until #366 replaced that design with parallel legs
+  + a single fan-in commit job; high-DPI mobile needs a per-spec
+  `maxDiffPixels` bump (metrics: 800) instead of masks.
 
 **#329** — a *distinct* flake: `global-setup.ts` room-creation clicks raced
 a list re-render ("element detached from the DOM"), reddening unrelated PRs
@@ -468,7 +481,8 @@ any new absolute frontend path must survive the ingress prefix.
 exist; the real bind mount is
 `/mnt/data/supervisor/addons/data/<repo_id>_<slug>/`, invisible to the
 Samba `addon_configs` share because the manifest only mapped `data`. Fix:
-`config.yaml` adds `addon_config:rw` with `DATA_DIR=/addon_config` + a
+`config.yaml` adds `addon_config:rw` with `DATA_DIR=/config` (config.yaml:43,
+run.sh:82) + a
 one-shot `run.sh` migration; docs corrected with `docker inspect` recipes
 (`docs/backup-restore.md`). Settled.
 

--- a/.claude/skills/plenum-proof-and-analysis-toolkit/SKILL.md
+++ b/.claude/skills/plenum-proof-and-analysis-toolkit/SKILL.md
@@ -350,7 +350,7 @@ import in a diff.
 ```bash
 cd smart_vent/backend
 grep -rn "utcnow()" --include="*.py" . | grep -v tests          # expect: empty
-grep -rn "datetime\.now()" --include="*.py" . | grep -v tests   # expect: only tz.py:38, db.py:276
+grep -rn "datetime\.now()" --include="*.py" . | grep -v tests   # expect: only tz.py:38, db.py:276 as code, plus two docstring/comment mentions (tz.py:7, db.py:273) — ignore those
 grep -rn "datetime.now(UTC)" --include="*.py" . | grep -v tests | wc -l   # ~50 — the storage norm
 grep -rn "astimezone" --include="*.py" . | grep -v tests        # expect: only inside tz.py
 ```
@@ -536,7 +536,7 @@ Volatile facts — re-verify before trusting:
 
 | Fact | Re-verify with |
 |---|---|
-| Converters live in `backend/units.py` (CLAUDE.md drift) | `grep -n "def to_f" smart_vent/backend/units.py` |
+| Converters live in `backend/units.py` (pre-2026-07-05 CLAUDE.md copies said routes.py; corrected in PR #388 — if docs and repo disagree again, the repo wins) | `grep -n "def to_f" smart_vent/backend/units.py` |
 | `CycleState` = IDLE/RUNNING/TERMINATING only | `grep -n -A4 "class CycleState" smart_vent/backend/engine/cycle_engine.py` |
 | Unavailability abort default 5 min, field `unavailable_abort_after_min` | `grep -n unavailable_abort_after_min smart_vent/backend/db.py` |
 | Trim uses `id <`, `_EVENT_LOG_MAX=5000`, every 100th insert | `grep -n -B2 -A8 "_EVENT_LOG_MAX" smart_vent/backend/db.py` |

--- a/.claude/skills/plenum-research-frontier/SKILL.md
+++ b/.claude/skills/plenum-research-frontier/SKILL.md
@@ -32,16 +32,19 @@ measurement substrate (DB queries, ready-made analysis scripts) is owned by
    (`cooling_lockout_below_f`), the airflow floor (`min_open_vents_fraction`),
    the staleness/unavailability guards, or the `min_setpoint`/`max_setpoint`
    envelope — even "temporarily, for data collection".
-2. **The sandbox is Dev Mode, not a simulator** (verified in
-   `docs/system-modes.md`). Dev Mode runs the engine normally — real sensor
-   reads, real room selection, real vent-move computation — but intercepts every
-   outbound HA service call (`climate.set_temperature`, `cover.open_cover`,
-   `cover.close_cover`, `cover.set_cover_position`, `cover.set_cover_tilt_position`,
+2. **The sandbox is Dev Mode, not a simulator.** Dev Mode runs the engine
+   normally — real sensor reads, real room selection, real vent-move
+   computation — but intercepts every outbound HA service call
+   (`climate.set_temperature`, `cover.open_cover`, `cover.close_cover`,
+   `cover.set_cover_position`, `cover.set_cover_tilt_position`,
    `cover.toggle`) and logs it to `event_log` instead of sending it. There are
    **no simulated cycles and no synthetic house model**: what you get is
    *shadow mode* — the engine's would-be commands against the real house's real
    trajectory, which itself is being driven by whatever is actually controlling
-   the HVAC. System **Off** is stronger still: engines do not tick at all.
+   the HVAC. Mode semantics are owned by **plenum-run-and-operate**; the one
+   line that matters here: the engine gate is `system_enabled OR dev_mode`
+   (`scheduler.py:477`), so engines keep ticking under Dev Mode even with
+   System Off — only both-off stops ticking entirely.
    Design experiments accordingly — Dev Mode gives you counterfactual command
    logs, not counterfactual temperatures.
 3. **Offline first.** Every item below starts with read-only analysis of
@@ -49,10 +52,10 @@ measurement substrate (DB queries, ready-made analysis scripts) is owned by
    open it `mode=ro`, as the diagnostics scripts do.
 4. **All stored temperatures are °F; deltas are °F deltas** (no −32). Model in
    °F end-to-end; convert only at the write boundary if a result ever ships
-   (see plenum-architecture-contract for the #231 contract; note the conversion
-   helpers live in `smart_vent/backend/units.py` — CLAUDE.md's
-   "helpers in routes.py" framing has drifted). Timestamps in the DB are naive
-   UTC ISO strings.
+   (see plenum-architecture-contract for the #231 contract; the conversion
+   helpers live in `smart_vent/backend/units.py` — pre-2026-07-05 CLAUDE.md
+   copies said routes.py; corrected in PR #388 — if docs and repo disagree
+   again, the repo wins). Timestamps in the DB are naive UTC ISO strings.
 5. **Anything that ships needs a UI control** (CLAUDE.md 100% rule) and clears
    plenum-change-control. Advice-only outputs (a "suggested value" shown in the
    UI) are a deliberately lower-risk shipping target than closed-loop control.
@@ -85,7 +88,7 @@ auto-generated MCP tools (below).
 
 **Data-hygiene caveat found while verifying (check before trusting):** the only
 production writer of `cycle_temp_samples` (`cycle_engine.py:1098`) always passes
-a non-NULL `room_id`, yet `db._degree_minutes_timeseries` (db.py:1873) filters
+a non-NULL `room_id`, yet `db._degree_minutes_timeseries` (db.py:1897) filters
 `s.room_id IS NULL` (thermostat-level samples), which in the current code only
 tests create. Before building on either representation, run on a real DB:
 `sqlite3 app.db "SELECT COUNT(*), SUM(room_id IS NULL) FROM cycle_temp_samples"`.

--- a/.claude/skills/plenum-research-methodology/SKILL.md
+++ b/.claude/skills/plenum-research-methodology/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: plenum-research-methodology
-description: The discipline that turns a hunch into an accepted result in the Plenum repo — the evidence bar (one mechanism must explain every observation, hypotheses must predict numbers before you measure, adversarial refutation), the hunch→issue→sandbox-experiment→PR→docs lifecycle, how to run a systematic audit like the #280–#305 wave, experiment hygiene (both-directions tests, timezone matrix, restart-mid-state, simulated-vs-real HVAC), and a result-acceptance checklist. Load when you have a theory about a bug or a design idea and need to know what proof this project demands before it ships.
+description: >-
+  The discipline that turns a hunch into an accepted result in the Plenum repo
+  — the evidence bar (one mechanism must explain every observation, hypotheses
+  must predict numbers before you measure, adversarial refutation), the
+  hunch→issue→sandbox-experiment→PR→docs lifecycle, how to run a systematic
+  audit like the #280–#305 wave, experiment hygiene (both-directions tests,
+  timezone matrix, restart-mid-state, simulated-vs-real HVAC), and a
+  result-acceptance checklist. Load when you have a theory about a bug or a
+  design idea and need to know what proof this project demands before it
+  ships.
 ---
 
 # Plenum research methodology: hunch → accepted result
@@ -12,6 +21,15 @@ This skill is the *process* discipline. It does not tell you what to research
 system (load **plenum-diagnostics-and-tooling**). Load it when you are about
 to claim "I know why X happens" or "we should build Y" and want that claim to
 survive review in this repo.
+
+## When NOT to use this skill
+
+- You need a symptom→cause triage table *right now* → **plenum-debugging-playbook**.
+- You want the specific SQL/log/metric to measure something → **plenum-diagnostics-and-tooling**.
+- You want analysis math with worked examples → **plenum-proof-and-analysis-toolkit**.
+- You want what's worth researching next → **plenum-research-frontier**.
+- You're past the result and shipping it → **plenum-change-control**, **plenum-validation-and-qa**.
+- You want the history of a specific settled battle → **plenum-failure-archaeology**.
 
 Jargon used below (see **hvac-zoning-reference** for full definitions):
 *deadband* = tolerance band around a target temperature; *overshoot* =
@@ -146,7 +164,7 @@ not give you:
 
 | Sandbox | What it IS (verified in code/docs) | What it is NOT |
 |---|---|---|
-| **System Off** (`system_enabled` flag) | Engines do not tick at all; any running cycle is aborted immediately (vents restored, setpoint released). Plenum keeps monitoring HA state and serving the UI with **zero** service calls to HA. README: "use this while transitioning from another HVAC control system." | Not an experiment mode — nothing computes, so you observe HA passively but learn nothing about engine decisions. |
+| **System Off** (`system_enabled` flag) | Semantics owned by **plenum-run-and-operate** (engine gate is `system_enabled OR dev_mode`, `scheduler.py:477`): with Dev Mode also off, engines skip their ticks; any running cycle is aborted immediately (vents restored, setpoint released). Plenum keeps monitoring HA state and serving the UI with **zero** service calls to HA once that one-time in-flight abort completes (abort nuance: plenum-run-and-operate). | Not an experiment mode on its own — with Dev Mode off, nothing computes, so you observe HA passively but learn nothing about engine decisions. With Dev Mode ON, engines still tick even while System is Off (writes intercepted) — that combination is Dev Mode's shadow mode, not a quieter System Off. |
 | **Dev Mode** (`developer_mode` flag) | Pure **write interception**: every HA write in `ha_client.py` (`set_thermostat_temperature`, `set_thermostat_hvac_mode`, `set_thermostat_temperature_range`, `open_cover`, `close_cover`, position/tilt/toggle) checks `self.dev_mode` and logs a `[DEV] Would …` line to the event log instead of calling HA. The engine runs fully: real 60s ticks, real sensor reads, real room selection and setpoint math. See `docs/system-modes.md`. | **No fake clock, no simulated physics, no simulated cycles.** Reads are live and time is wall-clock. Because commands never reach HA, rooms never respond to the "conditioning" — so closed-loop behavior (reaching target, post-closure drift, min-runtime holds ending naturally) will NOT play out as it would live. Dev Mode validates *decisions*, not *outcomes*. Cycles started in Dev Mode also historically lingered ACTIVE across toggles (#54) — check cycle state after toggling. |
 | **Compose test stack / fake HA** | The E2E docker-compose stack (see **plenum-build-and-env**) and `backend/tests/integration/fake_ha.py` give scripted HA responses — you control the physics. | Not real thermal mass or compressor behavior (§4d). |
 
@@ -372,15 +390,6 @@ env var, or mock differ from production in the exact dimension under test?
 
 ---
 
-## When NOT to use this skill
-
-- You need a symptom→cause triage table *right now* → **plenum-debugging-playbook**.
-- You want the specific SQL/log/metric to measure something → **plenum-diagnostics-and-tooling**.
-- You want analysis math with worked examples → **plenum-proof-and-analysis-toolkit**.
-- You want what's worth researching next → **plenum-research-frontier**.
-- You're past the result and shipping it → **plenum-change-control**, **plenum-validation-and-qa**.
-- You want the history of a specific settled battle → **plenum-failure-archaeology**.
-
 ## Provenance and maintenance
 
 Facts verified against the repo on 2026-07-05 (v0.22.1):
@@ -388,13 +397,16 @@ Facts verified against the repo on 2026-07-05 (v0.22.1):
 - Dev Mode = write interception only, no fake clock/physics:
   `grep -n "dev_mode" smart_vent/backend/ha_client.py` (interception sites)
   and `docs/system-modes.md`.
-- System Off semantics (no ticks, abort running cycle, zero HA calls):
-  `docs/system-modes.md`; README §System On/Off ("use this while
-  transitioning").
+- System Off semantics (skip ticks unless Dev Mode is on, abort running
+  cycle, zero HA calls after the one-time abort): engine gate
+  `system_enabled OR dev_mode` at `scheduler.py:477`; details owned by
+  **plenum-run-and-operate**. Note `docs/system-modes.md` (~line 26) states
+  the precedence backwards — a known doc bug; the code wins.
 - Conversion helpers live in `smart_vent/backend/units.py` (`to_f`,
-  `delta_to_f`, `from_f`, `from_f_delta`) — consolidated by #251. CLAUDE.md
-  still describes them as `_to_f`/`_delta_to_f` in `routes.py`; this is known
-  drift — trust the repo (see **plenum-architecture-contract**).
+  `delta_to_f`, `from_f`, `from_f_delta`) — consolidated by #251.
+  Pre-2026-07-05 CLAUDE.md copies said `_to_f`/`_delta_to_f` in `routes.py`;
+  corrected in PR #388 — if docs and repo disagree again, the repo wins
+  (see **plenum-architecture-contract**).
   Re-verify: `grep -n "def " smart_vent/backend/units.py`.
 - 141.44 double-conversion arithmetic: `python3 -c "print((16*9/5+32)*9/5+32)"`.
 - `app.db` path: `smart_vent/backend/main.py:42-43` (`DATA_DIR` default

--- a/.claude/skills/plenum-run-and-operate/SKILL.md
+++ b/.claude/skills/plenum-run-and-operate/SKILL.md
@@ -259,12 +259,19 @@ Follow README "First-time setup" in order:
 4. **Add schedules** (days, start/end, target temp).
 5. **Check the System On/Off toggle** (top-right, every page).
 
-### System On/Off semantics (doc: `docs/system-modes.md`)
+### System On/Off semantics (owned by this skill; code wins over `docs/system-modes.md`)
 
 - **On** — engines tick every 60 s and drive vents/thermostats.
-- **Off** — "monitoring only": engine ticks are skipped and Plenum makes
-  **zero HA service calls**; UI, logs, and state monitoring keep working. Use
-  while migrating off another control system.
+- **Off** (with Dev Mode also off) — "monitoring only": engine ticks are
+  skipped and Plenum makes **zero HA service calls**; UI, logs, and state
+  monitoring keep working. Use while migrating off another control system.
+- **The engine gate is `system_enabled OR dev_mode`** (`scheduler.py:477`).
+  So with System Off + Dev Mode On, engines **DO tick** — they run the full
+  decision logic every 60 s while `ha_client.py` intercepts every write and
+  logs `[DEV] Would …` instead of sending it. System Off fully stops ticking
+  only when Dev Mode is also off. **Known doc bug:** `docs/system-modes.md`
+  (~line 26) states the opposite precedence ("System Off takes precedence
+  over Dev Mode") — that is wrong vs the code; needs a follow-up docs issue.
 - **Caveat — a fresh install starts ON**: `system_enabled` defaults to `"1"`
   (`scheduler.py:56,88`). If you're setting up against live equipment, flip
   it Off *before* step 1 and back On at step 5.
@@ -278,8 +285,8 @@ Follow README "First-time setup" in order:
   naturally. So "zero HA calls while Off" holds only *after* this one-time
   cleanup — by design, so equipment is never left mid-cycle with vents shut.
 - **Dev Mode** is different: engines run fully but every HA service call is
-  intercepted and logged instead of sent. System Off takes precedence over
-  Dev Mode. (Details: `docs/system-modes.md`, `plenum-config-and-flags`.)
+  intercepted and logged instead of sent — and per the OR gate above, that
+  holds even while System is Off. (Flag catalog: `plenum-config-and-flags`.)
 
 ---
 
@@ -384,7 +391,9 @@ Known doc drift at that date (repo files win): README Option B `docker run`
 lacks `-e DATA_DIR=/data` and uses `-e TZ` (clobbered by `run.sh:81`);
 README/`docs/backup-restore.md` still describe the pre-`/config` HAOS data
 location; README's `/tmp/flair-dev` local default is stale (`.env.sample`
-says `./data`).
+says `./data`); `docs/system-modes.md` (~line 26) states the System-Off /
+Dev-Mode precedence backwards — the engine gate is `system_enabled OR
+dev_mode` (`scheduler.py:477`; see §System On/Off).
 
 Re-verify volatile facts:
 - Ports/defaults: `grep -n "PORT\|MCP_PORT\|DATA_DIR" smart_vent/backend/main.py` (8099/9099/`/data` code defaults) and `grep -n "8099\|9099" smart_vent/config.yaml` (both `null`).

--- a/.claude/skills/plenum-validation-and-qa/SKILL.md
+++ b/.claude/skills/plenum-validation-and-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plenum-validation-and-qa
-description: What counts as evidence in the Plenum repo (smart-thermostat-with-vents) and how to add tests CI will accept. Load when writing or debugging tests (pytest, vitest, Playwright), when a coverage gate or parity/enforcement test fails (test_temperature_field_parity, test_addon_config, test_api_spec_enforcement), when you need the Celsius-mode test patterns, when adding an E2E round-trip with @covers tags, or when regenerating golden screenshots.
+description: How to run and add tests in Plenum (pytest/vitest/Playwright run commands, the --no-cov trap), what counts as evidence in the repo (smart-thermostat-with-vents), and how to add tests CI will accept. Load when running, writing, or debugging tests, when a coverage gate or parity/enforcement test fails (test_temperature_field_parity, test_addon_config, test_api_spec_enforcement), when you need the Celsius-mode test patterns, when adding an E2E round-trip with @covers tags, or when regenerating golden screenshots.
 ---
 
 # Plenum Validation and QA
@@ -44,10 +44,9 @@ sufficient for conversion correctness.
 Backend — needs Python **3.12+** (`requires-python = ">=3.12"` in `smart_vent/pyproject.toml`; a 3.11 venv fails at pip-install time):
 
 ```bash
-python3.12 -m venv /tmp/venv
-/tmp/venv/bin/pip install -e '/path/to/repo/smart_vent[dev]'
+# venv setup (once) → plenum-build-and-env; then, with the venv active:
 cd smart_vent
-/tmp/venv/bin/python -m pytest backend/tests/ -v            # full suite (what lint.yml runs)
+python -m pytest backend/tests/ -v            # full suite (what lint.yml runs)
 # Executed 2026-07-04: 918 passed in ~83 s, coverage 93.64% (gate 92.5%)
 ```
 
@@ -58,8 +57,8 @@ nonzero *even when every test passes* ("FAIL Required test coverage of 92.5%
 not reached"). Always:
 
 ```bash
-/tmp/venv/bin/python -m pytest backend/tests/test_units.py --no-cov -q
-/tmp/venv/bin/python -m pytest backend/tests/integration/test_rooms_api.py --no-cov -q
+python -m pytest backend/tests/test_units.py --no-cov -q
+python -m pytest backend/tests/integration/test_rooms_api.py --no-cov -q
 ```
 
 Frontend:
@@ -93,8 +92,9 @@ job's two projects + update→verify double pass.
 
 ### Unit tests: `test_units.py` (NOT `test_routes_helpers.py` — renamed)
 
-The conversion helpers live in **`smart_vent/backend/units.py`** (CLAUDE.md
-still says routes.py — the repo wins). Four functions: `to_f`, `delta_to_f`
+The conversion helpers live in **`smart_vent/backend/units.py`**
+(pre-2026-07-05 CLAUDE.md copies said routes.py; corrected in PR #388 — if
+docs and repo disagree again, the repo wins). Four functions: `to_f`, `delta_to_f`
 (display→°F, 2dp), `from_f`, `from_f_delta` (°F→display, 1dp).
 `routes.py` imports them as `_to_f` / `_delta_to_f` / `_from_f` /
 `_from_f_delta` (lines 35–38). `backend/tests/test_units.py` holds 24 tests
@@ -312,7 +312,7 @@ Rules of the house:
 ### A. Add a backend unit test
 1. Put it in `smart_vent/backend/tests/test_<topic>.py`; class-per-helper
    (`TestToF` style) for pure functions.
-2. Run scoped: `cd smart_vent && /tmp/venv/bin/python -m pytest backend/tests/test_<topic>.py --no-cov -q`.
+2. Run scoped: `cd smart_vent && python -m pytest backend/tests/test_<topic>.py --no-cov -q` (venv active; setup → `plenum-build-and-env`).
 3. Before pushing, run the full suite *with* coverage (drop `--no-cov`) —
    the 92.5% gate is on the whole run.
 4. New test-only dependency? Add to `[project.optional-dependencies] dev` in
@@ -365,8 +365,9 @@ Rules of the house:
 3. Review every changed PNG like code; commit.
 4. Or let CI do it: push, the container-ci `e2e` legs upload `goldens-F`/`goldens-C`
    artifacts and the `commit-goldens` fan-in job pushes one combined commit
-   back to your branch (details → `plenum-ci-and-release`; the CLAUDE.md
-   `max-parallel: 1` / same-job-verify prose predates this fan-in design).
+   back to your branch (details → `plenum-ci-and-release`; pre-2026-07-05
+   CLAUDE.md copies described the older `max-parallel: 1` / same-job-verify
+   design — corrected in PR #388).
 5. If a golden won't stabilise between the update and verify passes, you have
    un-frozen volatile UI — wrap it in `<Frozen>` (section 6).
 
@@ -413,12 +414,14 @@ Facts verified by reading repo files and **executing** commands on 2026-07-04
   transcribed from `e2e/README.md` and `container-ci.yml` (lines 491, 650–676),
   not run (no Docker here). Full backend pytest run executed: 918 passed,
   ~83 s, coverage 93.64% against the 92.5% gate.
-- Known CLAUDE.md drift confirmed against the repo (repo wins): helpers live
-  in `backend/units.py` (`test_units.py`, not `test_routes_helpers.py`);
-  parity kinds are `absolute|absolute_nullable|delta|delta_nullable`; the
-  visual suite lives in `container-ci.yml` (`e2e` + `commit-goldens` jobs; no
-  standalone `e2e.yml`, no `max-parallel: 1`); coverage gates are 92.5 backend
-  and 90/85/72/87 frontend.
+- CLAUDE.md drift history: pre-2026-07-05 CLAUDE.md copies said the helpers
+  lived in routes.py (`test_routes_helpers.py`), described a standalone
+  `e2e.yml` with `max-parallel: 1`, and quoted the old coverage numbers —
+  all corrected in PR #388. Current repo truth: helpers in
+  `backend/units.py` (`test_units.py`); parity kinds
+  `absolute|absolute_nullable|delta|delta_nullable`; visual suite in
+  `container-ci.yml` (`e2e` + `commit-goldens` jobs); coverage gates per §6.
+  If docs and repo disagree again, the repo wins.
 
 Re-verify volatile facts:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ task matches a skill, load it instead of re-deriving from source. Quick router:
 | Fresh-clone setup, install/build traps | `plenum-build-and-env` |
 | Running the add-on/Docker/local, data paths, backup/restore, MCP attach | `plenum-run-and-operate` |
 | Measuring behavior: DB queries, metrics semantics, ready-made scripts | `plenum-diagnostics-and-tooling` |
-| Writing tests, parity/enforcement failures, Celsius patterns, goldens | `plenum-validation-and-qa` |
+| Running/writing the test suites, parity/enforcement failures, Celsius patterns, goldens | `plenum-validation-and-qa` |
 | CI red, golden-bot pushes, workflows, releases | `plenum-ci-and-release` |
 | Editing docs/README/CHANGELOG, house style, claims discipline | `plenum-docs-and-writing` |
 | Auth work (#373) | `plenum-auth-campaign` |


### PR DESCRIPTION
## What

Follow-up to #388 (merged): the planned three-reviewer (factual / doctrine / usability) + fixer pass over the 16-skill library, applied as one commit.

**Blocking fix**: two skill frontmatter `description` fields (`plenum-failure-archaeology`, `plenum-research-methodology`) were plain YAML scalars containing ` #NNN` issue references — YAML treats ` #` as a comment, silently truncating the descriptions mid-sentence and destroying their trigger/routing text for any model that loads skills by description. Both are now `>-` block scalars; all 16 frontmatters verified to parse to full text.

**Correctness fixes** (each verified against source before editing):
- Three skills claimed "System Off takes precedence over Dev Mode / engines do not tick". The engine gate is `system_enabled OR dev_mode` (`scheduler.py:477`) — with System Off + Dev Mode On, engines DO tick with writes intercepted. `plenum-run-and-operate` now owns these semantics and flags `docs/system-modes.md` as stating the wrong precedence (doc bug left for a follow-up, not edited here).
- `fail_under = 90` → 92.5 in the CI failure-triage table; `TEMPERATURE_FIELDS` count 11 → 12; `DATA_DIR=/addon_config` → `/config` in the #92 archaeology entry; `role` vs `source` enums corrected (`safety` is a source, `cycle_engine.py:3013`); event-category list gains `dev`; one `db.py` line cite fixed.
- Finished the past-tense sweep: no skill still asserts CLAUDE.md is *currently* stale on the items corrected in #388 (remaining stale-doc claims — README/DESIGN.md — are genuinely still true and kept).

**One-home-per-fact dedup**: coverage thresholds now live in `plenum-validation-and-qa` §6 with pointers elsewhere; the #231 narrative is compressed to pointers outside its owning skills; golden-bot mechanism pointered to `plenum-ci-and-release`; System On/Off + Dev Mode semantics owned by `plenum-run-and-operate`.

**Usability**: sharper trigger descriptions ("how do I run the tests" now routes; the three classic CI failures are named), `$DATA_DIR`-aware DB paths in the playbook, "When NOT to use" moved to the top in two skills, scratchpad-path citations replaced with GitHub-corpus references, and the CLAUDE.md router row updated to match.

## Why

The reviews found that every factual contradiction sat exactly where a fact was duplicated instead of cross-referenced, plus one ship-stopper invisible to human readers (the YAML truncation). The factual reviewer verified ~200 commands/paths/numbers and re-ran all five diagnostic scripts — zero fabrications; these fixes close out everything the reviewers rated blocking or important.

## Test plan

- Docs-only (markdown + one CLAUDE.md table row): no runtime surface.
- All 16 frontmatters verified with `yaml.safe_load` to parse to their full description text.
- Post-fix greps confirm: no `fail_under = 90` outside the intentional historical-example table, no "11 fields", no `/addon_config` DATA_DIR, no present-tense CLAUDE.md stale-claims.

---
_Generated by [Claude Code](https://claude.ai/code/session_016CL9GYrk3Jt9YmfC2irn2N)_