### PR TITLE
Fix README stats/docs drift and system-modes precedence doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Because Plenum only speaks to `cover.*` and `climate.*` entities, **it's not Fla
 
 ### Tested
 
-> Stats last updated: June 2026 — coverage thresholds are enforced by CI and only ever increase.
+> Stats last updated: July 2026 — coverage thresholds are enforced by CI and only ever increase.
 
-- **Backend:** **733 unit + integration tests** across **38 test modules** (16 unit + 22 integration, ~15.4k lines of test code) covering the cycle engine state machine, scheduler, room manager, vent controller, presence/holdover logic, setpoint bounds, cycle restore after reboot, idle-vent close dispatch, and end-to-end cycle flow through the aiohttp API. Coverage gate: **92.5%** enforced by CI.
+- **Backend:** **918 unit + integration tests** across **56 test modules** (24 unit + 32 integration, ~19.1k lines of test code) covering the cycle engine state machine, scheduler, room manager, vent controller, presence/holdover logic, setpoint bounds, cycle restore after reboot, idle-vent close dispatch, and end-to-end cycle flow through the aiohttp API. Coverage gate: **92.5%** enforced by CI.
   - `pytest backend/tests` from `smart_vent/` runs the full suite.
-- **Frontend:** **243 tests** across **16 test files** (~4.2k lines of test code) with **Vitest + React Testing Library**, covering all major pages, form validations, tab navigation, unit-conversion correctness, and WebSocket integration. Coverage gates enforced by CI: **90% lines · 85% functions · 72% branches · 87% statements**.
+- **Frontend:** **285 tests** across **17 test files** (~4.9k lines of test code) with **Vitest + React Testing Library**, covering all major pages, form validations, tab navigation, unit-conversion correctness, and WebSocket integration. Coverage gates enforced by CI: **90% lines · 85% functions · 72% branches · 87% statements**.
   - `npm test` from `smart_vent/frontend` runs the frontend suite.
-- **E2E (Playwright):** **15 end-to-end tests** across **10 spec files** covering every major page (Dashboard, Rooms, Schedules, Thermostats, Metrics, Logs, Settings, Dev Mode) plus a full temperature round-trip suite that matrix-runs against both a °F stack and a °C stack — the only layer that exercises the full frontend → API → DB → UI conversion contract end-to-end.
+- **E2E (Playwright):** **17 end-to-end tests** across **13 spec files** covering every major page (Dashboard, Rooms, Schedules, Thermostats, Metrics, Logs, Settings, Dev Mode) plus a full temperature round-trip suite that matrix-runs against both a °F stack and a °C stack — the only layer that exercises the full frontend → API → DB → UI conversion contract end-to-end.
   - Specs live in `e2e/tests/`; CI runs them via the `conversion` job in `.github/workflows/container-ci.yml`.
 
 ---
@@ -72,6 +72,7 @@ Feature-by-feature guides live in [`docs/`](./docs/README.md):
 - [Schedules](./docs/schedules.md) — time blocks and overnight ranges
 - [Presence & motion](./docs/presence.md) — motion activation and holdover
 - [Pre-cool / pre-heat](./docs/precool-presence.md) — skip presence HVAC when the outside air will reach the target on its own
+- [Overflow conditioning](./docs/overflow-conditioning.md) — the min-runtime-hold surplus-air tiering
 - [System modes](./docs/system-modes.md) — System On/Off and Dev Mode
 - [Observability](./docs/observability.md) — dashboard, logs, WebSocket
 - [Metrics & analytics](./docs/metrics.md) — heating/cooling charts, outside-temp correlation, CSV export
@@ -136,11 +137,14 @@ docker run -d \
   --name smart-vent \
   -p 8099:8099 \
   -v /path/to/data:/data \
+  -e DATA_DIR=/data \
   -e HA_URL=https://your-ha-instance.com \
   -e HA_TOKEN=your_long_lived_token \
-  -e TZ=America/New_York \
+  -e TIMEZONE=America/New_York \
   ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
 ```
+
+> **Important:** `run.sh` defaults `DATA_DIR` to `/config`, not `/data` — without `-e DATA_DIR=/data` above, the app writes `app.db` inside the container instead of your mounted volume, and every restart wipes your configuration. Likewise, the timezone variable is `TIMEZONE`, not `TZ` — `run.sh` overwrites `TZ` from `TIMEZONE` unconditionally, so setting `-e TZ=...` alone has no effect and schedules will evaluate in UTC.
 
 > **Important:** the `-v /path/to/data:/data` volume mount is required. Without it, `app.db` is written inside the ephemeral container layer and **all configuration is lost when the container restarts**.
 
@@ -295,7 +299,7 @@ The **System On/Off** toggle in the top-right of every page controls whether the
 All configuration lives in a single SQLite file (`app.db` in the `DATA_DIR`). To carry your setup over:
 
 1. Stop the add-on
-2. Copy your local `app.db` (default: `/tmp/flair-dev/app.db`) to the add-on data directory:
+2. Copy your local `app.db` (default: `./data/app.db`, per `DATA_DIR` in `.env.sample`) to the add-on data directory:
    - **HA OS / Supervised**: the real host path is `/mnt/data/supervisor/addons/data/<repo_id>_plenum/app.db`. Find your exact path via SSH with `docker inspect $(docker ps -q --filter name=plenum) --format '{{ json .Mounts }}'` and look for the mount whose `Destination` is `/data`. Note: `/root/addon_configs` (the Samba share) is for add-on *configuration* files, not this data directory.
    - **Docker**: wherever you mounted `/data` with `-v`
 3. Start the add-on — it will apply any pending migrations automatically

--- a/docs/system-modes.md
+++ b/docs/system-modes.md
@@ -7,7 +7,7 @@ Two global toggles control how Plenum behaves at runtime. Both are in the top-ri
 The **System On/Off** switch decides whether Plenum's cycle engine is allowed to make changes in Home Assistant.
 
 - **On** — cycle engines tick every 60s and drive vents and thermostats normally.
-- **Off** — engines do not tick, and any cycle that's running is aborted immediately (vents restored, setpoint released). Plenum still monitors state and serves the UI, but makes zero service calls to HA.
+- **Off** — engines do not tick *unless Dev Mode is also on* (see below), and any cycle that's running is aborted immediately (vents restored, setpoint released). Plenum still monitors state and serves the UI, but makes zero service calls to HA.
 
 Use **Off** while you're transitioning from another HVAC control system, or any time you want Plenum to sit quietly without touching your equipment.
 
@@ -23,4 +23,4 @@ Dev Mode is useful for:
 - Validating a fresh setup against what the engine is doing.
 - Reproducing a bug without affecting the house.
 
-**System On/Off takes precedence.** If the system is Off, Dev Mode is moot — nothing ticks at all.
+**The engine tick gate is System On OR Dev Mode.** With System Off and Dev Mode also off, nothing ticks. But System Off with Dev Mode On still ticks the engine — cycles run and get logged, just with every HA write intercepted (see above), so the real HVAC stays untouched. This is what makes Dev Mode useful as a sandbox even while System is Off (`scheduler.py`'s `get_enabled=lambda: self._system_enabled or self._dev_mode`).


### PR DESCRIPTION
## Summary

Fixes all three open `documentation`-tagged issues:

- **#393** — README "Tested" stats block had rotted, and the Documentation list omitted `docs/overflow-conditioning.md`.
  - Recounted against the repo: backend 918 tests / 56 modules / ~19.1k test LOC (was 733/38/~15.4k); frontend 285 tests / 17 files / ~4.9k LOC (was 243/16/~4.2k); E2E 17 tests / 13 spec files (was 15/10). Coverage gates (92.5% backend; 90/85/72/87 frontend) were already correct and left unchanged.
  - Bumped the "Stats last updated" date to July 2026.
  - Added the missing `docs/overflow-conditioning.md` line to the Documentation list.
- **#392** — README's "Option B — Docker (standalone)" run command silently lost all data and ignored the timezone.
  - `run.sh` defaults `DATA_DIR` to `/config`, not `/data`, so the documented command (which mounts `/data` but never sets `DATA_DIR`) wrote `app.db` to the unmounted `/config` path inside the container — every restart wiped configuration.
  - `run.sh` also unconditionally sets `TZ` from `TIMEZONE`, so the documented `-e TZ=...` had no effect; schedules ran in UTC.
  - Updated the command to pass `-e DATA_DIR=/data` and `-e TIMEZONE=...`, and added an explanatory callout.
  - Corrected the "Migrating from a dev/local instance" section's stale `/tmp/flair-dev/app.db` default to match `.env.sample`'s `DATA_DIR=./data`.
- **#391** — `docs/system-modes.md` had the System On/Off vs. Dev Mode precedence backwards.
  - The doc claimed System Off means "nothing ticks at all." The actual engine gate (`scheduler.py`) is `system_enabled OR dev_mode` — with System Off and Dev Mode On, engines still tick (with all HA writes intercepted), so cycles run and get logged even though the real HVAC is untouched.
  - Corrected both the System On/Off section and the closing precedence note to describe the OR gate.

## Test plan

- [x] `ruff check backend/` and `ruff format --check backend/` — pass
- [x] `npm run lint` (frontend) — pass
- [x] `npm run test:coverage` (frontend) — pass, all thresholds met
- [x] Manually re-ran every recount command from the issues (test/module/file counts, `grep` for `DATA_DIR`/`TZ` in `run.sh`, `grep` for `get_enabled` in `scheduler.py`) and confirmed each fix matches the code
- Docs-only change; no application code touched, so no functional/UI testing needed


---
_Generated by [Claude Code](https://claude.ai/code/session_019TZ5mrC16uuQW7vYnkevGf)_