### PR TITLE
Fix degree-minutes chart reading samples the engine never writes (#394)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -51,7 +51,7 @@ curl http://localhost:8099/api/metrics/thermostats/climate.upstairs/live
 
 ## Background rollups
 
-A daily APScheduler job rolls completed cycles into `daily_thermostat_metrics` at 00:05 local; a monthly job rolls them into `monthly_thermostat_metrics` at 00:10 on the 1st. The page itself queries `cycle_logs` directly so "today" is always live; the rollup tables back longer-horizon trends.
+A daily APScheduler job rolls completed cycles into `daily_thermostat_metrics` at 00:05 local; a monthly job rolls them into `monthly_thermostat_metrics` at 00:10 on the 1st. The Metrics page's charts always query `cycle_logs` directly, even for older ranges — no chart currently reads from the rollup tables, so once a cycle ages past `cycle_log_retention_days` (default 30, cascade-deletes its samples) charts for that range go empty rather than falling back to the surviving rollup row. The rollup tables and their `db.py` readers (`get_daily_thermostat_metrics` / `get_monthly_thermostat_metrics`) exist and are exercised by tests, but nothing in `routes.py` calls them yet — treat "backs longer-horizon trends" as the intent, not the current behavior.
 
 Manual triggers (useful during testing or after a restore):
 
@@ -60,4 +60,4 @@ Manual triggers (useful during testing or after a restore):
 
 ## Vent timeline disclosure
 
-The vent-timeline chart shows **cycle-boundary** events only — `opened_at_start`, `closed_reached_target`, `force_reopened_max_closed`, `closed_at_end`. Mid-cycle vent movements are not currently tracked.
+The vent-timeline chart shows **cycle-boundary** events only — `opened_at_start`, `closed_reached_target`, `force_reopened_max_closed`, `reopened_min_runtime_hold`, `closed_overflow_hold`, `opened_overflow_hold`. Mid-cycle vent movements are not currently tracked.

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -2204,8 +2204,9 @@ async def metrics_thermostat_vent_timeline(request: web.Request) -> web.Response
             "end": end,
             "note": (
                 "Cycle-boundary events only (opened_at_start, closed_reached_target, "
-                "force_reopened_max_closed, closed_at_end). Mid-cycle vent movements "
-                "are not currently tracked."
+                "force_reopened_max_closed, reopened_min_runtime_hold, "
+                "closed_overflow_hold, opened_overflow_hold). Mid-cycle vent "
+                "movements are not currently tracked."
             ),
             "events": events,
         }

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime, time, timedelta
+from itertools import groupby
 
 import aiosqlite
 
@@ -1889,6 +1890,11 @@ async def _degree_minutes_timeseries(
     (cycle_id, timestamp) with MAX() (identical across a tick's rooms) so
     a multi-room tick isn't double-counted, and legacy room_id=NULL rows
     still work unchanged.
+
+    Each cycle's final interval — its last sample up to `ended_at` — is
+    flushed after walking that cycle's rows, so a cycle with only one
+    sample (typical of a short cycle) still contributes rather than being
+    silently dropped.
     """
     sql = """
         SELECT cl.id AS cycle_id,
@@ -1910,29 +1916,31 @@ async def _degree_minutes_timeseries(
     async with conn.execute(sql, (thermostat_id, start_date, end_date)) as cur:
         rows = await cur.fetchall()
 
-    # Walk samples per cycle, accumulating into a (period -> minutes) dict.
+    # Walk each cycle's samples in order, accumulating into a (period -> minutes)
+    # dict. Every cycle's tail — its last sample up to the cycle's own ended_at —
+    # is flushed after the inner loop, so a cycle with only one sample (or any
+    # cycle's final inter-sample gap) still contributes instead of silently
+    # dropping out.
     by_period: dict[str, float] = {}
-    cur_cycle: str | None = None
-    cur_end: datetime | None = None
-    last_ts: datetime | None = None
-    last_delta: float | None = None
-    for r in rows:
-        ts = datetime.fromisoformat(r["timestamp"]).replace(tzinfo=UTC)
-        if r["cycle_id"] != cur_cycle:
-            cur_cycle = r["cycle_id"]
-            cur_end = datetime.fromisoformat(r["ended_at"]).replace(tzinfo=UTC)
+    for _cycle_id, group in groupby(rows, key=lambda r: r["cycle_id"]):
+        cycle_rows = list(group)
+        cur_end = datetime.fromisoformat(cycle_rows[0]["ended_at"]).replace(tzinfo=UTC)
+        last_ts: datetime | None = None
+        last_delta: float | None = None
+        for r in cycle_rows:
+            ts = datetime.fromisoformat(r["timestamp"]).replace(tzinfo=UTC)
+            delta = abs(float(r["setpoint"]) - float(r["thermostat_temp"]))
+            if last_ts is not None and last_delta is not None:
+                interval_end = min(ts, cur_end)
+                dt_min = max(0.0, (interval_end - last_ts).total_seconds() / 60.0)
+                period_key = _period_key(tz.to_local(last_ts), granularity)
+                by_period[period_key] = by_period.get(period_key, 0.0) + last_delta * dt_min
             last_ts = ts
-            last_delta = abs(float(r["setpoint"]) - float(r["thermostat_temp"]))
-            continue
-        if last_ts is not None and last_delta is not None:
-            interval_end = ts
-            if cur_end is not None and interval_end > cur_end:
-                interval_end = cur_end
-            dt_min = max(0.0, (interval_end - last_ts).total_seconds() / 60.0)
+            last_delta = delta
+        if last_ts is not None and last_delta is not None and cur_end > last_ts:
+            dt_min = (cur_end - last_ts).total_seconds() / 60.0
             period_key = _period_key(tz.to_local(last_ts), granularity)
             by_period[period_key] = by_period.get(period_key, 0.0) + last_delta * dt_min
-        last_ts = ts
-        last_delta = abs(float(r["setpoint"]) - float(r["thermostat_temp"]))
 
     return [
         {"period": p, "value": round(v, 2)}

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -1879,25 +1879,32 @@ async def _degree_minutes_timeseries(
 ) -> list[dict]:
     """∫ |setpoint − thermostat_temp| dt computed from cycle_temp_samples,
     bucketed by local date or month. Walks each cycle's thermostat-level
-    samples (room_id IS NULL) in time order and integrates the absolute
-    delta over each inter-sample interval, capped at the cycle's actual
-    end. Returns degree-minutes per bucket. (Phase 4k)
+    trajectory in time order and integrates the absolute delta over each
+    inter-sample interval, capped at the cycle's actual end. Returns
+    degree-minutes per bucket. (Phase 4k)
+
+    The engine's per-tick sampler writes one row per active room, each
+    carrying the same thermostat_temp/setpoint reading (Issue #394) — there
+    is no dedicated room_id=NULL writer. Collapse to one row per
+    (cycle_id, timestamp) with MAX() (identical across a tick's rooms) so
+    a multi-room tick isn't double-counted, and legacy room_id=NULL rows
+    still work unchanged.
     """
     sql = """
         SELECT cl.id AS cycle_id,
                cl.started_at,
                cl.ended_at,
                s.timestamp,
-               s.thermostat_temp,
-               s.setpoint
+               MAX(s.thermostat_temp) AS thermostat_temp,
+               MAX(s.setpoint) AS setpoint
         FROM cycle_logs cl
         JOIN cycle_temp_samples s ON s.cycle_id = cl.id
         WHERE cl.ended_at IS NOT NULL
           AND cl.thermostat_entity_id = ?
-          AND s.room_id IS NULL
           AND s.thermostat_temp IS NOT NULL
           AND s.setpoint IS NOT NULL
           AND date(cl.started_at, 'localtime') BETWEEN ? AND ?
+        GROUP BY cl.id, cl.started_at, cl.ended_at, s.timestamp
         ORDER BY cl.id, s.timestamp ASC
     """
     async with conn.execute(sql, (thermostat_id, start_date, end_date)) as cur:

--- a/smart_vent/backend/models.py
+++ b/smart_vent/backend/models.py
@@ -332,7 +332,8 @@ class CycleVentEvent:
     entity_id: str
     room_id: str | None
     action: (
-        str  # opened_at_start | closed_reached_target | force_reopened_max_closed | closed_at_end
+        str  # opened_at_start | closed_reached_target | force_reopened_max_closed |
+        # reopened_min_runtime_hold | closed_overflow_hold | opened_overflow_hold
     )
     reason: str | None = None
 

--- a/smart_vent/backend/tests/integration/test_metrics_phase2.py
+++ b/smart_vent/backend/tests/integration/test_metrics_phase2.py
@@ -267,7 +267,9 @@ class TestPhase4BackendAdditions:
             duration=timedelta(minutes=30),
         )
         # Two thermostat-level samples 10 minutes apart with |sp-temp|=2°F →
-        # 2°F × 10 min = 20 degree-minutes for that interval.
+        # 2°F × 10 min = 20 degree-minutes for that interval, plus the tail
+        # from the last sample to the cycle's ended_at (20 min later) at the
+        # last sample's delta of 1.5°F → 1.5°F × 20 min = 30. Total 50.
         await db.insert_cycle_temp_sample(conn, "dm1", None, today_dt, None, 76.0, 74.0)
         await db.insert_cycle_temp_sample(
             conn, "dm1", None, today_dt + timedelta(minutes=10), None, 75.5, 74.0
@@ -279,7 +281,7 @@ class TestPhase4BackendAdditions:
         body = await resp.json()
         assert body["metric"] == "degree_minutes"
         assert len(body["series"]) == 1
-        assert body["series"][0]["value"] == pytest.approx(20.0)
+        assert body["series"][0]["value"] == pytest.approx(50.0)
 
     @pytest.mark.asyncio
     async def test_degree_minutes_timeseries_engine_shaped_samples(
@@ -316,9 +318,39 @@ class TestPhase4BackendAdditions:
         body = await resp.json()
         assert body["metric"] == "degree_minutes"
         assert len(body["series"]) == 1
-        # Same math as the room_id=NULL case: 2°F x 10 min = 20 degree-minutes,
-        # NOT double-counted to 40 despite two rooms sampled per tick.
-        assert body["series"][0]["value"] == pytest.approx(20.0)
+        # Same math as the room_id=NULL case (20 + 30 tail = 50 degree-minutes),
+        # NOT double-counted despite two rooms sampled per tick.
+        assert body["series"][0]["value"] == pytest.approx(50.0)
+
+    @pytest.mark.asyncio
+    async def test_degree_minutes_timeseries_short_cycle_single_sample(
+        self, client, today_iso, today_dt
+    ):
+        """A cycle with only one recorded tick (typical of a short cycle —
+        exactly the cycles short-cycling diagnostics care about) must still
+        contribute its degree-minutes from that sample to the cycle's
+        ended_at, not silently drop to zero.
+        """
+        conn = await _conn(client)
+        await _seed_cycle(
+            conn,
+            cycle_id="dm3",
+            started_at=today_dt,
+            duration=timedelta(minutes=5),
+        )
+        # One sample 2 minutes in, |sp-temp|=4°F. Cycle ends 3 minutes later
+        # (at minute 5) → 4°F × 3 min = 12 degree-minutes.
+        await db.insert_cycle_temp_sample(
+            conn, "dm3", "rA", today_dt + timedelta(minutes=2), 70.0, 70.0, 74.0
+        )
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/timeseries"
+            f"?metric=degree_minutes&granularity=day&start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        assert body["metric"] == "degree_minutes"
+        assert len(body["series"]) == 1
+        assert body["series"][0]["value"] == pytest.approx(12.0)
 
     @pytest.mark.asyncio
     async def test_overshoot_histogram(self, client, today_iso, today_dt):

--- a/smart_vent/backend/tests/integration/test_metrics_phase2.py
+++ b/smart_vent/backend/tests/integration/test_metrics_phase2.py
@@ -282,6 +282,45 @@ class TestPhase4BackendAdditions:
         assert body["series"][0]["value"] == pytest.approx(20.0)
 
     @pytest.mark.asyncio
+    async def test_degree_minutes_timeseries_engine_shaped_samples(
+        self, client, today_iso, today_dt
+    ):
+        """Issue #394: the engine's only writer inserts one row per active
+        room per tick — room_id is always populated, never NULL. The reader
+        must integrate over these real per-room rows rather than a
+        room_id=NULL row production never produces.
+        """
+        conn = await _conn(client)
+        await _seed_cycle(
+            conn,
+            cycle_id="dm2",
+            started_at=today_dt,
+            duration=timedelta(minutes=30),
+        )
+        # Two rooms sampled in the same tick, 10 minutes apart, mirroring
+        # cycle_engine.py's per-room insert loop. Both rows in a tick share
+        # the same thermostat_temp/setpoint (one _read_thermo_temp_and_setpoint()
+        # call per tick).
+        await db.insert_cycle_temp_sample(conn, "dm2", "rA", today_dt, 70.0, 76.0, 74.0)
+        await db.insert_cycle_temp_sample(conn, "dm2", "rB", today_dt, 71.0, 76.0, 74.0)
+        await db.insert_cycle_temp_sample(
+            conn, "dm2", "rA", today_dt + timedelta(minutes=10), 71.0, 75.5, 74.0
+        )
+        await db.insert_cycle_temp_sample(
+            conn, "dm2", "rB", today_dt + timedelta(minutes=10), 72.0, 75.5, 74.0
+        )
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO_A}/timeseries"
+            f"?metric=degree_minutes&granularity=day&start={today_iso}&end={today_iso}"
+        )
+        body = await resp.json()
+        assert body["metric"] == "degree_minutes"
+        assert len(body["series"]) == 1
+        # Same math as the room_id=NULL case: 2°F x 10 min = 20 degree-minutes,
+        # NOT double-counted to 40 despite two rooms sampled per tick.
+        assert body["series"][0]["value"] == pytest.approx(20.0)
+
+    @pytest.mark.asyncio
     async def test_overshoot_histogram(self, client, today_iso, today_dt):
         conn = await _conn(client)
         await db.upsert_room(conn, Room(id="rA", name="A", thermostat_entity_id=THERMO_A))


### PR DESCRIPTION
## Summary

- **Fixes #394**: the Metrics page's **degree-minutes** chart was computed by `_degree_minutes_timeseries` (`smart_vent/backend/db.py`), which integrated only thermostat-level samples (`cycle_temp_samples.room_id IS NULL`). The engine's only writer of `cycle_temp_samples` (the per-tick sampling loop in `cycle_engine.py`) always inserts rows with a real `room_id` — there is no `room_id=NULL` writer — so the chart was silently always empty in production, regardless of accumulated cycle history.
  - Fixed the reader (least invasive of the two options in the issue, and it backfills correctly against all existing history): the query now collapses each tick's duplicate per-room rows via `GROUP BY (cycle_id, started_at, ended_at, timestamp)`, taking `MAX(thermostat_temp)` / `MAX(setpoint)` — safe because every room sampled in the same tick carries an identical thermostat reading (one `_read_thermo_temp_and_setpoint()` call per tick). A multi-room tick is no longer double-counted, and legacy `room_id IS NULL` rows (if any exist) still work unchanged.
  - Added a regression test seeding real engine-shaped samples (two rooms, same tick, non-null `room_id`) asserting nonzero degree-minutes — the scenario the previous test suite never exercised, which is how the empty-chart bug shipped unnoticed.

- **Follow-on fix found while auditing the rest of Metrics for similar issues** (per request): `_degree_minutes_timeseries`'s integration walk never added the interval between a cycle's *last* recorded sample and the cycle's own `ended_at` — it only accumulated when a subsequent sample existed in the same cycle. This silently dropped every cycle's tail contribution, and zeroed out entirely for any cycle with just one tick sample (i.e. the shortest cycles — exactly what short-cycling diagnostics most need to see). Rewrote the walk to group rows per cycle and flush the tail interval after the last sample. Added a regression test for a single-sample short cycle.

- **Two small doc/API-text corrections** found in the same audit: the vent-timeline endpoint's disclosure note (`routes.py`) and `CycleVentEvent`'s `action` comment (`models.py`) both referenced a `closed_at_end` vent action that has no emit site anywhere in `cycle_engine.py` — replaced with the real action set (`reopened_min_runtime_hold`, `closed_overflow_hold`, `opened_overflow_hold` were missing; `closed_at_end` was phantom). Also corrected `docs/metrics.md`'s claim that the daily/monthly rollup tables "back longer-horizon trends" — verified no `/api/metrics/*` route reads them, so charts for date ranges past `cycle_log_retention_days` (default 30 days) currently go empty instead of falling back to rollup data. This is a real product gap but a larger feature (rollups don't carry raw samples, so degree-minutes/overshoot/time-to-target can't be reconstructed from them at all) — documented as-is rather than implemented here; flagged separately for a follow-up decision.

## Test plan

- [x] `python -m pytest backend/tests/integration/test_metrics_phase2.py -v --no-cov` — 27/27 passed, including both new regression tests
- [x] `python -m pytest backend/tests/ -q` — full suite, 920 passed, coverage 93.66% (threshold 92.5%)
- [x] `ruff check backend/` and `ruff format --check backend/` — clean
- [x] `mypy backend/ --ignore-missing-imports` — no issues
- [x] `test_api_spec_enforcement.py`, `test_temperature_field_parity.py`, `test_addon_config.py` — unaffected, all pass
- [x] Backend/docs-only change; no rendered UI touched, so no visual-regression goldens need regenerating
