### PR TITLE
Versioned DB schema migrations with automatic pre-migration backup

### DIFF
--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -6,8 +6,12 @@ Call `init_db(conn)` once at startup to create tables.
 
 from __future__ import annotations
 
+import glob
 import json
 import logging
+import os
+import re
+from dataclasses import dataclass
 from datetime import UTC, datetime, time, timedelta
 from itertools import groupby
 
@@ -100,6 +104,8 @@ CREATE TABLE IF NOT EXISTS thermostat_configs (
     max_vent_closed_min INTEGER NOT NULL DEFAULT 0,
     overshoot_delta REAL NOT NULL DEFAULT 2.0,
     cycle_timeout_hours REAL NOT NULL DEFAULT 3.0,
+    reconciliation_interval_min INTEGER NOT NULL DEFAULT 0,
+    vacation_hvac_mode TEXT NOT NULL DEFAULT 'single',
     min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0,
     min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0,
     cooling_lockout_below_f REAL,
@@ -249,19 +255,201 @@ CREATE INDEX IF NOT EXISTS idx_monthly_metrics_thermostat ON monthly_thermostat_
 
 
 async def init_db(conn: aiosqlite.Connection) -> None:
-    await conn.executescript(SCHEMA)
-    # Migrations for columns added after initial schema
-    for migration in _MIGRATIONS:
-        try:
-            await conn.execute(migration)
-            await conn.commit()
-        except Exception:
-            pass  # column already exists
+    await run_migrations(conn)
     # Data migration: fix holdover timestamps stored in local time (Issue #65)
     await _migrate_holdover_timestamps_to_utc(conn)
     # Data migration: enable short-cycle protection on pre-existing thermostats
     await _migrate_short_cycle_defaults(conn)
     log.info("Database initialised")
+
+
+# ---------------------------------------------------------------------------
+# Versioned schema migrations (Issue #21)
+#
+# ``SCHEMA`` above is the complete fresh-install snapshot; ``MIGRATIONS`` is
+# the versioned upgrade path for databases created by older builds. Adding a
+# column therefore means touching BOTH: add it to the table in ``SCHEMA`` and
+# append a new ``Migration`` here (never edit or delete existing entries —
+# ``test_schema_migrations.py`` enforces snapshot/migration parity).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    description: str
+    statements: tuple[str, ...]
+
+
+_ADD_COLUMN_RE = re.compile(r"ALTER TABLE (\w+) ADD COLUMN (\w+)", re.IGNORECASE)
+_DROP_COLUMN_RE = re.compile(r"ALTER TABLE (\w+) DROP COLUMN (\w+)", re.IGNORECASE)
+
+# How many pre-migration backup files to keep next to the DB.
+_BACKUP_KEEP = 3
+
+
+async def _column_exists(conn: aiosqlite.Connection, table: str, column: str) -> bool:
+    async with conn.execute(f"PRAGMA table_info({table})") as cur:
+        return any(row[1] == column for row in await cur.fetchall())
+
+
+async def _statement_effect_present(conn: aiosqlite.Connection, sql: str) -> bool | None:
+    """Whether a migration statement's effect is already in the live schema.
+
+    Returns True/False for the recognised ``ALTER TABLE … ADD/DROP COLUMN``
+    forms, and None for anything else (cannot be determined by introspection,
+    so callers must treat it as not-yet-applied).
+    """
+    if m := _ADD_COLUMN_RE.match(sql):
+        return await _column_exists(conn, m[1], m[2])
+    if m := _DROP_COLUMN_RE.match(sql):
+        return not await _column_exists(conn, m[1], m[2])
+    return None
+
+
+async def _db_has_user_tables(conn: aiosqlite.Connection) -> bool:
+    async with conn.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    ) as cur:
+        row = await cur.fetchone()
+    return bool(row and row[0] > 0)
+
+
+async def _stamp_baseline(conn: aiosqlite.Connection) -> set[int]:
+    """Adopt a database that predates version tracking.
+
+    The old ad-hoc runner (and ``SCHEMA`` for fresh installs) left no record of
+    what ran, so on the first startup with an empty ``schema_migrations`` table
+    every migration whose effect is already present in the live schema is
+    stamped as applied without re-running it. Returns the stamped versions.
+    """
+    stamped: set[int] = set()
+    for migration in MIGRATIONS:
+        checks = [await _statement_effect_present(conn, sql) for sql in migration.statements]
+        if all(checks):  # every statement recognised AND already in effect
+            await conn.execute(
+                "INSERT INTO schema_migrations (version, description) VALUES (?, ?)",
+                (migration.version, f"{migration.description} (baseline)"),
+            )
+            stamped.add(migration.version)
+    await conn.commit()
+    if stamped:
+        log.info("Adopted existing schema: stamped %d migration(s) as baseline", len(stamped))
+    return stamped
+
+
+def _prune_old_backups(db_file: str, keep: int) -> None:
+    """Delete all but the ``keep`` newest pre-migration backups. Best-effort:
+    a pruning failure must never block startup."""
+    try:
+        backups = sorted(
+            glob.glob(glob.escape(db_file) + ".pre-migration-v*.bak"),
+            key=os.path.getmtime,
+            reverse=True,
+        )
+        for stale in backups[keep:]:
+            os.unlink(stale)
+            log.info("Pruned old pre-migration backup %s", stale)
+    except OSError:
+        log.warning("Could not prune old pre-migration backups", exc_info=True)
+
+
+async def _backup_before_migrations(conn: aiosqlite.Connection, target_version: int) -> str | None:
+    """Snapshot the DB file before pending migrations run, so a failed
+    migration can be rolled back manually: revert the add-on version, remove
+    ``app.db`` (and ``-wal``/``-shm`` sidecars), rename the backup over it.
+
+    Returns the backup path, or None for in-memory/temporary databases.
+    """
+    async with conn.execute("PRAGMA database_list") as cur:
+        rows = await cur.fetchall()
+    db_file = next((row[2] for row in rows if row[1] == "main"), "")
+    if not db_file:
+        return None  # in-memory DB (tests) — nothing to back up
+
+    backup_path = f"{db_file}.pre-migration-v{target_version}.bak"
+    if os.path.exists(backup_path):
+        # A crash-loop must not overwrite the good snapshot with a
+        # half-migrated database — first backup for a target version wins.
+        log.info("Pre-migration backup already exists, keeping it: %s", backup_path)
+        return backup_path
+
+    await conn.commit()  # VACUUM INTO cannot run inside a transaction
+    await conn.execute("VACUUM INTO ?", (backup_path,))
+    log.info("Pre-migration DB backup written to %s", backup_path)
+    _prune_old_backups(db_file, keep=_BACKUP_KEEP)
+    return backup_path
+
+
+async def run_migrations(conn: aiosqlite.Connection) -> None:
+    """Bring the database schema up to date, tracking every step.
+
+    Fresh databases get the full ``SCHEMA`` snapshot and have all migrations
+    stamped as baseline; databases from older builds are adopted the same way
+    (see ``_stamp_baseline``) and then any genuinely pending migrations are
+    applied — after a file backup — exactly once, in version order, failing
+    fast instead of silently swallowing errors.
+    """
+    had_data = await _db_has_user_tables(conn)
+    await conn.executescript(SCHEMA)
+    await conn.execute(
+        """CREATE TABLE IF NOT EXISTS schema_migrations (
+               version INTEGER PRIMARY KEY,
+               applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+               description TEXT NOT NULL
+           )"""
+    )
+    await conn.commit()
+
+    async with conn.execute("SELECT version FROM schema_migrations") as cur:
+        applied = {row[0] for row in await cur.fetchall()}
+    if not applied:
+        applied = await _stamp_baseline(conn)
+
+    pending = [m for m in MIGRATIONS if m.version not in applied]
+    if not pending:
+        return
+
+    backup_path = None
+    if had_data:
+        backup_path = await _backup_before_migrations(conn, pending[-1].version)
+
+    current: Migration | None = None
+    try:
+        for migration in pending:
+            current = migration
+            for sql in migration.statements:
+                if await _statement_effect_present(conn, sql):
+                    # Partial application by the old per-statement runner —
+                    # recognised via introspection, recorded, not re-run.
+                    log.info(
+                        "Migration %d: statement already in effect, skipping: %s",
+                        migration.version,
+                        sql,
+                    )
+                    continue
+                await conn.execute(sql)
+            await conn.execute(
+                "INSERT INTO schema_migrations (version, description) VALUES (?, ?)",
+                (migration.version, migration.description),
+            )
+            await conn.commit()
+            log.info("Applied migration %d: %s", migration.version, migration.description)
+    except Exception:
+        rollback_hint = (
+            f"a pre-migration backup was saved at {backup_path}. To roll back manually: "
+            "stop the add-on, revert to the previous add-on version, delete app.db "
+            "(and app.db-wal / app.db-shm) in the data directory, rename the backup "
+            "file to app.db, then start the add-on"
+            if backup_path
+            else "no file backup was taken (empty or in-memory database)"
+        )
+        log.exception(
+            "Schema migration %s failed — startup aborted; %s",
+            f"{current.version} ({current.description})" if current else "run",
+            rollback_hint,
+        )
+        raise
 
 
 async def _migrate_holdover_timestamps_to_utc(conn: aiosqlite.Connection) -> None:
@@ -355,75 +543,174 @@ async def _migrate_short_cycle_defaults(conn: aiosqlite.Connection) -> None:
     await conn.commit()
 
 
-_MIGRATIONS = [
-    "ALTER TABLE rooms ADD COLUMN temp_offset REAL NOT NULL DEFAULT 0.0",
-    "ALTER TABLE thermostat_configs ADD COLUMN name TEXT NOT NULL DEFAULT ''",
-    "ALTER TABLE thermostat_configs ADD COLUMN default_temp REAL",
-    "ALTER TABLE thermostat_configs ADD COLUMN reconciliation_interval_min INTEGER NOT NULL DEFAULT 0",
-    "ALTER TABLE room_vents ADD COLUMN control_method TEXT NOT NULL DEFAULT 'open_close'",
+# Versioned upgrade history, reconstructed from the pre-#21 ad-hoc ALTER list.
+# Append-only: never edit or delete an existing entry — create a new version.
+MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        1,
+        "Add temp_offset to rooms",
+        ("ALTER TABLE rooms ADD COLUMN temp_offset REAL NOT NULL DEFAULT 0.0",),
+    ),
+    Migration(
+        2,
+        "Add name and default_temp to thermostat_configs",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN name TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE thermostat_configs ADD COLUMN default_temp REAL",
+        ),
+    ),
+    Migration(
+        3,
+        "Add reconciliation_interval_min to thermostat_configs",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN reconciliation_interval_min "
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+    ),
+    Migration(
+        4,
+        "Add control_method to room_vents",
+        ("ALTER TABLE room_vents ADD COLUMN control_method TEXT NOT NULL DEFAULT 'open_close'",),
+    ),
     # Cycle diagnostics (Issue #60)
-    "ALTER TABLE cycle_logs ADD COLUMN ended_reason TEXT",
-    "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_start REAL",
-    "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_end REAL",
-    "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_start REAL",
-    "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_end REAL",
-    "ALTER TABLE cycle_logs ADD COLUMN vents_at_start TEXT",
-    "ALTER TABLE cycle_logs ADD COLUMN vents_at_end TEXT",
-    "ALTER TABLE room_cycle_states ADD COLUMN temp_at_start REAL",
-    "ALTER TABLE room_cycle_states ADD COLUMN temp_at_end REAL",
-    "ALTER TABLE room_cycle_states ADD COLUMN trigger_detail TEXT",
-    "ALTER TABLE room_cycle_states ADD COLUMN joined_at TEXT",
+    Migration(
+        5,
+        "Cycle diagnostics columns (Issue #60)",
+        (
+            "ALTER TABLE cycle_logs ADD COLUMN ended_reason TEXT",
+            "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_start REAL",
+            "ALTER TABLE cycle_logs ADD COLUMN thermostat_temp_at_end REAL",
+            "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_start REAL",
+            "ALTER TABLE cycle_logs ADD COLUMN setpoint_at_end REAL",
+            "ALTER TABLE cycle_logs ADD COLUMN vents_at_start TEXT",
+            "ALTER TABLE cycle_logs ADD COLUMN vents_at_end TEXT",
+            "ALTER TABLE room_cycle_states ADD COLUMN temp_at_start REAL",
+            "ALTER TABLE room_cycle_states ADD COLUMN temp_at_end REAL",
+            "ALTER TABLE room_cycle_states ADD COLUMN trigger_detail TEXT",
+            "ALTER TABLE room_cycle_states ADD COLUMN joined_at TEXT",
+        ),
+    ),
     # Outside-temperature capture (Issue #85 Phase 1c)
-    "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_start REAL",
-    "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_end REAL",
+    Migration(
+        6,
+        "Outside-temperature capture on cycle_logs (Issue #85)",
+        (
+            "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_start REAL",
+            "ALTER TABLE cycle_logs ADD COLUMN outside_temp_at_end REAL",
+        ),
+    ),
     # Vacation mode thermostat hold strategy
-    "ALTER TABLE thermostat_configs ADD COLUMN vacation_hvac_mode TEXT NOT NULL DEFAULT 'single'",
+    Migration(
+        7,
+        "Add vacation_hvac_mode to thermostat_configs",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN vacation_hvac_mode "
+            "TEXT NOT NULL DEFAULT 'single'",
+        ),
+    ),
     # Short-cycle protection (Issue #208)
-    "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_runtime_min INTEGER NOT NULL DEFAULT 0",
-    "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_offtime_min INTEGER NOT NULL DEFAULT 0",
+    Migration(
+        8,
+        "Short-cycle protection columns (Issue #208)",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_runtime_min "
+            "INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE thermostat_configs ADD COLUMN min_cycle_offtime_min "
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+    ),
     # Outdoor-temperature cooling lockout (Issue #209)
-    "ALTER TABLE thermostat_configs ADD COLUMN cooling_lockout_below_f REAL",
+    Migration(
+        9,
+        "Add cooling_lockout_below_f to thermostat_configs (Issue #209)",
+        ("ALTER TABLE thermostat_configs ADD COLUMN cooling_lockout_below_f REAL",),
+    ),
     # Airflow-floor / dead-head protection (Issue #213). Replaces the prior
     # count-based ``min_open_vents`` with a fraction-of-total calculation that
-    # accounts for passive vents and an optional bypass damper.
-    "ALTER TABLE thermostat_configs ADD COLUMN total_vents_count INTEGER",
-    "ALTER TABLE thermostat_configs ADD COLUMN has_bypass_damper INTEGER NOT NULL DEFAULT 0",
-    "ALTER TABLE thermostat_configs ADD COLUMN min_open_vents_fraction REAL NOT NULL DEFAULT 0.333",
-    # Drop the legacy column once the new fields are in place.  Existing rows
-    # had ``min_open_vents`` defaulting to 1, which matches the transitional
+    # accounts for passive vents and an optional bypass damper. The legacy
+    # column is dropped once the new fields are in place: existing rows had
+    # ``min_open_vents`` defaulting to 1, which matches the transitional
     # fallback the engine uses when ``total_vents_count`` is NULL.
-    "ALTER TABLE thermostat_configs DROP COLUMN min_open_vents",
+    Migration(
+        10,
+        "Airflow-floor protection, drop legacy min_open_vents (Issue #213)",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN total_vents_count INTEGER",
+            "ALTER TABLE thermostat_configs ADD COLUMN has_bypass_damper "
+            "INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE thermostat_configs ADD COLUMN min_open_vents_fraction "
+            "REAL NOT NULL DEFAULT 0.333",
+            "ALTER TABLE thermostat_configs DROP COLUMN min_open_vents",
+        ),
+    ),
     # Vent-thrashing / overflow conditioning (Issue #237). The hold flag lets
     # the engine remember across ticks that a cycle is past its goal but
     # waiting for min_cycle_runtime_min to elapse — the per-room close-vent
     # loop gates on this to stop reopened vents from flapping back closed.
-    "ALTER TABLE cycle_logs ADD COLUMN in_min_runtime_hold INTEGER NOT NULL DEFAULT 0",
-    "ALTER TABLE thermostat_configs ADD COLUMN overflow_during_min_runtime INTEGER NOT NULL DEFAULT 1",
+    Migration(
+        11,
+        "Overflow conditioning during min-runtime hold (Issue #237)",
+        (
+            "ALTER TABLE cycle_logs ADD COLUMN in_min_runtime_hold INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE thermostat_configs ADD COLUMN overflow_during_min_runtime "
+            "INTEGER NOT NULL DEFAULT 1",
+        ),
+    ),
     # Overflow-room cycle data points (Issue #254). Non-active rooms opened
     # during the minimum-runtime hold are now recorded as room_cycle_states
     # rows tagged role='overflow' so the Logs page can show their start/end
     # temperatures alongside the cycle that triggered them.
-    "ALTER TABLE room_cycle_states ADD COLUMN role TEXT NOT NULL DEFAULT 'active'",
+    Migration(
+        12,
+        "Add role to room_cycle_states (Issue #254)",
+        ("ALTER TABLE room_cycle_states ADD COLUMN role TEXT NOT NULL DEFAULT 'active'",),
+    ),
     # Ambient-aware presence suppression / pre-cool / pre-heat (Issue #248)
-    "ALTER TABLE rooms ADD COLUMN ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0",
-    "ALTER TABLE rooms ADD COLUMN ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence'",
-    "ALTER TABLE rooms ADD COLUMN ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0",
-    "ALTER TABLE rooms ADD COLUMN ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0",
-    "ALTER TABLE rooms ADD COLUMN ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60",
+    Migration(
+        13,
+        "Ambient-aware presence suppression columns (Issue #248)",
+        (
+            "ALTER TABLE rooms ADD COLUMN ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE rooms ADD COLUMN ambient_suppression_mode "
+            "TEXT NOT NULL DEFAULT 'any_presence'",
+            "ALTER TABLE rooms ADD COLUMN ambient_suppression_min_differential "
+            "REAL NOT NULL DEFAULT 5.0",
+            "ALTER TABLE rooms ADD COLUMN ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0",
+            "ALTER TABLE rooms ADD COLUMN ambient_suppression_off_schedule_window_min "
+            "INTEGER NOT NULL DEFAULT 60",
+        ),
+    ),
     # Thermostat-unavailability abort (Issue #267). Minutes of sustained
     # climate-entity unavailability before a running cycle is aborted and all
     # zone vents re-opened. 0 = never abort.
-    "ALTER TABLE thermostat_configs ADD COLUMN unavailable_abort_after_min INTEGER NOT NULL DEFAULT 5",
+    Migration(
+        14,
+        "Add unavailable_abort_after_min to thermostat_configs (Issue #267)",
+        (
+            "ALTER TABLE thermostat_configs ADD COLUMN unavailable_abort_after_min "
+            "INTEGER NOT NULL DEFAULT 5",
+        ),
+    ),
     # Per-room deadband override (Issue #277). NULL = inherit the thermostat's
     # deadband, so existing rooms keep their current behaviour after upgrade.
-    "ALTER TABLE rooms ADD COLUMN deadband_override REAL",
+    Migration(
+        15,
+        "Add deadband_override to rooms (Issue #277)",
+        ("ALTER TABLE rooms ADD COLUMN deadband_override REAL",),
+    ),
     # Schedule lifecycle (Issue #359). `enabled` parks a block without deleting
     # it; `expires_at` (naive LOCAL wall-clock ISO, NULL = never) drives the
     # self-disable sweep. Existing rows backfill to enabled=1 / expires_at=NULL,
     # i.e. exactly the pre-#359 behaviour.
-    "ALTER TABLE schedules ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1",
-    "ALTER TABLE schedules ADD COLUMN expires_at TEXT",
-]
+    Migration(
+        16,
+        "Schedule lifecycle columns (Issue #359)",
+        (
+            "ALTER TABLE schedules ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE schedules ADD COLUMN expires_at TEXT",
+        ),
+    ),
+)
 
 
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/tests/test_db_migration.py
+++ b/smart_vent/backend/tests/test_db_migration.py
@@ -20,7 +20,7 @@ _SHORT_CYCLE_SENTINEL = "migration_short_cycle_defaults_v1"
 # The exact `rooms` schema as it shipped *before* the per-room deadband override
 # (Issue #277) — i.e. the current schema minus the `deadband_override` column.
 # Used to simulate an upgrade: an existing DB whose rooms table predates the new
-# column, where the column is added only by the ALTER in db._MIGRATIONS.
+# column, where the column is added only by the ALTER in db.MIGRATIONS.
 _PRE_DEADBAND_OVERRIDE_ROOMS_SCHEMA = """
 CREATE TABLE rooms (
     id TEXT PRIMARY KEY,
@@ -224,7 +224,7 @@ async def _upgraded_db_with_legacy_room(room_id: str = "room-legacy") -> aiosqli
     )
     await conn.commit()
     # Upgrade. CREATE TABLE IF NOT EXISTS leaves the existing table alone, so the
-    # new column arrives solely via the ALTER in db._MIGRATIONS.
+    # new column arrives solely via the ALTER in db.MIGRATIONS.
     await db.init_db(conn)
     return conn
 

--- a/smart_vent/backend/tests/test_schema_migrations.py
+++ b/smart_vent/backend/tests/test_schema_migrations.py
@@ -1,0 +1,312 @@
+"""
+Tests for the versioned schema-migration system (Issue #21).
+
+Covers: fresh-install stamping, baseline adoption of pre-versioning databases,
+idempotency, fail-fast on genuine errors, SCHEMA-snapshot/MIGRATIONS parity,
+and the automatic pre-migration file backup + pruning.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from backend import db
+from backend.db import MIGRATIONS, Migration
+
+# The `rooms` schema as it shipped before the per-room deadband override
+# (Issue #277) — the newest historical migration target. A DB carrying only
+# this table simulates a real upgrade from an old build: adoption must stamp
+# everything already present and apply only the deadband_override migration.
+_LEGACY_ROOMS_SCHEMA = """
+CREATE TABLE rooms (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    thermostat_entity_id TEXT NOT NULL,
+    include_thermostat_sensor INTEGER NOT NULL DEFAULT 0,
+    system_wide_temp REAL,
+    presence_holdover_hours REAL NOT NULL DEFAULT 2.0,
+    notes TEXT NOT NULL DEFAULT '',
+    temp_offset REAL NOT NULL DEFAULT 0.0,
+    ambient_suppression_enabled INTEGER NOT NULL DEFAULT 0,
+    ambient_suppression_mode TEXT NOT NULL DEFAULT 'any_presence',
+    ambient_suppression_min_differential REAL NOT NULL DEFAULT 5.0,
+    ambient_suppression_deadband REAL NOT NULL DEFAULT 2.0,
+    ambient_suppression_off_schedule_window_min INTEGER NOT NULL DEFAULT 60
+);
+"""
+
+_DEADBAND_OVERRIDE_VERSION = 15  # "Add deadband_override to rooms (Issue #277)"
+
+
+async def _fetch_migrations(conn: aiosqlite.Connection) -> dict[int, str]:
+    async with conn.execute("SELECT version, description FROM schema_migrations") as cur:
+        return {row[0]: row[1] for row in await cur.fetchall()}
+
+
+async def _column_names(conn: aiosqlite.Connection, table: str) -> set[str]:
+    async with conn.execute(f"PRAGMA table_info({table})") as cur:
+        return {row[1] for row in await cur.fetchall()}
+
+
+async def _make_legacy_db(path: str | None = None) -> aiosqlite.Connection:
+    """A pre-versioning DB: only the (pre-#277) rooms table plus one row."""
+    conn = await aiosqlite.connect(path or ":memory:")
+    conn.row_factory = aiosqlite.Row
+    await conn.executescript(_LEGACY_ROOMS_SCHEMA)
+    await conn.execute(
+        "INSERT INTO rooms (id, name, thermostat_entity_id) VALUES (?, ?, ?)",
+        ("room-1", "Bedroom", "climate.house"),
+    )
+    await conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Static properties of the MIGRATIONS list
+# ---------------------------------------------------------------------------
+
+
+def test_versions_are_unique_and_strictly_increasing() -> None:
+    versions = [m.version for m in MIGRATIONS]
+    assert versions == sorted(set(versions))
+    assert len(versions) == len(set(versions))
+
+
+def test_every_statement_is_introspectable() -> None:
+    """Every historical migration statement must match the ADD/DROP COLUMN
+    forms the baseline-adoption introspection understands — otherwise adoption
+    of a pre-versioning DB would re-run it. Future non-ALTER migrations are
+    allowed, but only from versions appended after the versioning system
+    shipped (they will be tracked from day one)."""
+    for migration in MIGRATIONS:
+        for sql in migration.statements:
+            assert db._ADD_COLUMN_RE.match(sql) or db._DROP_COLUMN_RE.match(sql), (
+                f"migration {migration.version} statement not introspectable: {sql}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fresh install and idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_stamps_all_migrations_as_baseline() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await db.init_db(conn)
+        recorded = await _fetch_migrations(conn)
+        assert set(recorded) == {m.version for m in MIGRATIONS}
+        # A fresh SCHEMA already contains every migration's effect, so nothing
+        # is applied — everything is adopted as baseline.
+        assert all(desc.endswith("(baseline)") for desc in recorded.values())
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await db.init_db(conn)
+        await db.init_db(conn)  # second run must not raise or duplicate rows
+        recorded = await _fetch_migrations(conn)
+        assert len(recorded) == len(MIGRATIONS)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_applied_at_is_recorded() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await db.init_db(conn)
+        async with conn.execute("SELECT applied_at FROM schema_migrations") as cur:
+            stamps = [row[0] for row in await cur.fetchall()]
+        assert stamps and all(stamps)
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# SCHEMA snapshot / MIGRATIONS parity (guards the drift this issue found:
+# reconciliation_interval_min and vacation_hvac_mode existed only as ALTERs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_snapshot_matches_migration_history() -> None:
+    """A DB created purely from the SCHEMA snapshot must already contain the
+    effect of every migration: added columns present, dropped columns absent."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.executescript(db.SCHEMA)
+        for migration in MIGRATIONS:
+            for sql in migration.statements:
+                if m := db._ADD_COLUMN_RE.match(sql):
+                    assert m[2] in await _column_names(conn, m[1]), (
+                        f"SCHEMA is missing {m[1]}.{m[2]} (migration {migration.version})"
+                    )
+                elif m := db._DROP_COLUMN_RE.match(sql):
+                    assert m[2] not in await _column_names(conn, m[1]), (
+                        f"SCHEMA still contains dropped {m[1]}.{m[2]} "
+                        f"(migration {migration.version})"
+                    )
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Baseline adoption of a pre-versioning database
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_db_is_adopted_and_pending_migration_applied() -> None:
+    conn = await _make_legacy_db()
+    try:
+        await db.init_db(conn)
+
+        # The one genuinely missing column arrived via the migration…
+        assert "deadband_override" in await _column_names(conn, "rooms")
+        # …and existing data survived.
+        async with conn.execute("SELECT name FROM rooms WHERE id='room-1'") as cur:
+            row = await cur.fetchone()
+        assert row is not None and row["name"] == "Bedroom"
+
+        recorded = await _fetch_migrations(conn)
+        assert set(recorded) == {m.version for m in MIGRATIONS}
+        # Already-present effects were stamped as baseline; the deadband
+        # override was actually applied, so it carries the plain description.
+        assert not recorded[_DEADBAND_OVERRIDE_VERSION].endswith("(baseline)")
+        baseline = {v for v, desc in recorded.items() if desc.endswith("(baseline)")}
+        assert baseline == {m.version for m in MIGRATIONS} - {_DEADBAND_OVERRIDE_VERSION}
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_partially_applied_migration_is_completed_not_rerun() -> None:
+    """The old runner executed statements independently, so a crash could
+    leave a multi-statement migration half-applied. The new runner must skip
+    the statements already in effect and apply only the missing ones."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await db.init_db(conn)
+        # Simulate: migration 16 (schedules enabled + expires_at) half-applied —
+        # expires_at missing, enabled present, and no version row.
+        await conn.execute("ALTER TABLE schedules DROP COLUMN expires_at")
+        await conn.execute("DELETE FROM schema_migrations WHERE version=16")
+        await conn.commit()
+
+        await db.run_migrations(conn)
+
+        assert "expires_at" in await _column_names(conn, "schedules")
+        recorded = await _fetch_migrations(conn)
+        assert 16 in recorded
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fail fast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failing_migration_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = Migration(999, "bad migration", ("ALTER TABLE nonexistent ADD COLUMN x TEXT",))
+    monkeypatch.setattr(db, "MIGRATIONS", (*MIGRATIONS, bad))
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        with pytest.raises(aiosqlite.OperationalError):
+            await db.init_db(conn)
+        # The failed migration must not be recorded as applied.
+        recorded = await _fetch_migrations(conn)
+        assert 999 not in recorded
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pre-migration file backup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backup_written_before_pending_migrations(tmp_path: Path) -> None:
+    db_file = tmp_path / "app.db"
+    conn = await _make_legacy_db(str(db_file))
+    try:
+        await db.init_db(conn)
+    finally:
+        await conn.close()
+
+    backup = tmp_path / f"app.db.pre-migration-v{_DEADBAND_OVERRIDE_VERSION}.bak"
+    assert backup.exists()
+
+    # The backup is the PRE-migration state: the legacy row is there, the
+    # migrated column is not — exactly what a manual rollback needs.
+    bconn = await aiosqlite.connect(str(backup))
+    try:
+        async with bconn.execute("SELECT COUNT(*) FROM rooms") as cur:
+            row = await cur.fetchone()
+        assert row is not None and row[0] == 1
+        assert "deadband_override" not in await _column_names(bconn, "rooms")
+    finally:
+        await bconn.close()
+
+
+@pytest.mark.asyncio
+async def test_no_backup_for_fresh_file_db(tmp_path: Path) -> None:
+    conn = await aiosqlite.connect(str(tmp_path / "app.db"))
+    try:
+        await db.init_db(conn)
+    finally:
+        await conn.close()
+    assert not list(tmp_path.glob("*.bak"))
+
+
+@pytest.mark.asyncio
+async def test_existing_backup_is_not_overwritten(tmp_path: Path) -> None:
+    """A crash-loop (backup → migration fails → restart) must not replace the
+    good snapshot with the half-migrated database."""
+    db_file = tmp_path / "app.db"
+    backup = tmp_path / f"app.db.pre-migration-v{_DEADBAND_OVERRIDE_VERSION}.bak"
+    backup.write_bytes(b"KEEP-ME")
+
+    conn = await _make_legacy_db(str(db_file))
+    try:
+        await db.init_db(conn)
+        assert "deadband_override" in await _column_names(conn, "rooms")
+    finally:
+        await conn.close()
+
+    assert backup.read_bytes() == b"KEEP-ME"
+
+
+@pytest.mark.asyncio
+async def test_old_backups_are_pruned(tmp_path: Path) -> None:
+    db_file = tmp_path / "app.db"
+    # Four stale backups from earlier upgrades, oldest first.
+    for i, version in enumerate((3, 5, 7, 9)):
+        stale = tmp_path / f"app.db.pre-migration-v{version}.bak"
+        stale.write_bytes(b"old")
+        os.utime(stale, (1_000_000 + i, 1_000_000 + i))
+
+    conn = await _make_legacy_db(str(db_file))
+    try:
+        await db.init_db(conn)
+    finally:
+        await conn.close()
+
+    backups = sorted(p.name for p in tmp_path.glob("*.bak"))
+    assert len(backups) == db._BACKUP_KEEP
+    # The newest (just-written) backup survives; the oldest ones are gone.
+    assert f"app.db.pre-migration-v{_DEADBAND_OVERRIDE_VERSION}.bak" in backups
+    assert "app.db.pre-migration-v3.bak" not in backups
+    assert "app.db.pre-migration-v5.bak" not in backups


### PR DESCRIPTION
Closes #21.

## What changed

`init_db()` previously ran 34 bare `ALTER TABLE` strings on every startup with `try/except: pass`, so there was no record of what ran, real failures were indistinguishable from "column already exists", and a genuinely failed migration could silently leave the schema broken. This PR replaces that with a lightweight versioned migration system (no Alembic), per the plan updated in issue #21:

- **`schema_migrations` table** (`version`, `applied_at`, `description`) plus a `run_migrations()` runner in `backend/db.py`; `init_db()` delegates to it. The two sentinel-guarded *data* migrations (#65 holdover timestamps, #208 short-cycle defaults) are unchanged.
- **Versioned history**: the ad-hoc list is reconstructed into 16 append-only `Migration` entries grouped by feature (issues #60, #85, #208, #209, #213, #237, #248, #254, #267, #277, #359), original comments preserved.
- **Baseline adoption**: existing production DBs have no `schema_migrations` table, and their schema state depends on which build last ran. On first startup, every migration whose effect is already present (checked via `PRAGMA table_info` introspection of the `ADD COLUMN` / `DROP COLUMN` statements) is stamped `… (baseline)` without re-running; anything genuinely missing is applied normally. The same mechanism completes a migration the old per-statement runner left half-applied, and lets fresh installs (built from the `SCHEMA` snapshot) stamp everything without executing a single ALTER.
- **Automatic pre-migration backup**: before pending migrations run against a DB that already contains data, the file is snapshotted with `VACUUM INTO` to `app.db.pre-migration-v<N>.bak` next to the DB. If a migration fails the user can roll back manually: revert the add-on version, delete `app.db` (and `-wal`/`-shm`), rename the backup over it. An existing backup for the same target version is never overwritten (a crash-loop can't clobber the good snapshot), and only the newest 3 backups are kept. In-memory/fresh DBs skip the backup.
- **Fail fast**: migration errors now propagate and abort startup, after logging the failing version and the rollback instructions (including the backup path).
- **`SCHEMA` snapshot drift fixed**: `thermostat_configs.reconciliation_interval_min` and `vacation_hvac_mode` existed only as ALTERs — fresh installs got them only because the ad-hoc ALTER happened to succeed. Both are now in `SCHEMA`, and a new parity test asserts every migration's effect is present in a pure-`SCHEMA` DB so the snapshot and the history can't diverge again.

## Why

Issue #21 (see the refreshed issue body for the current-state audit). The migration list had grown from 6 to 34 statements since the issue was filed, including a `DROP COLUMN`, all still silently swallowed.

## Test plan

- New `backend/tests/test_schema_migrations.py` (13 tests): fresh-install stamping, `init_db` idempotency, `applied_at` audit trail, static version-ordering and introspectability checks, `SCHEMA`↔`MIGRATIONS` parity, legacy-DB adoption (pre-#277 rooms table with data: baseline stamps + only `deadband_override` applied, data preserved), partial-application recovery, fail-fast propagation (failed version not recorded), backup created with pre-migration content, no backup for fresh DBs, existing backup preserved across a crash-loop, pruning to the newest 3.
- Existing upgrade-path tests (`test_db_migration.py`, `test_schedule_migration.py`, `test_metrics_phase1.py` idempotency) pass unchanged — they exercise the same legacy-schema → `init_db` upgrade flows through the new runner.
- Full backend suite: **935 passed**, coverage **93.71%** (gate 92.5). `ruff check` / `ruff format --check` / `mypy` clean.

No API, UI, or config surface changes — backend-only infra, so no golden regeneration, parity-manifest, or `run.sh` changes are involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe2FvdDpoxpnvzjpehYY5L)_