### PR TITLE
Make metrics & cycle-log APIs date-range queryable (start/end/days, offset) over REST + MCP (#403)

### DIFF
--- a/smart_vent/backend/api/openapi.py
+++ b/smart_vent/backend/api/openapi.py
@@ -97,6 +97,28 @@ def response_schema(schema: Any, code: int = 200, description: str = "") -> Any:
     return decorator
 
 
+def query_params(params: list[dict[str, Any]]) -> Any:
+    """Document query-string parameters for a handler (Issue #403).
+
+    Documentation only — handlers still read ``request.rel_url.query`` and
+    validate the values themselves. But declaring the params here flows them
+    into the OpenAPI spec and, in turn, into the generated MCP tool input
+    schemas (see ``mcp_openapi``), so an MCP caller can discover and pass
+    date-range / paging knobs that were previously invisible.
+
+    Each entry is a dict with keys ``name`` (required), ``schema`` (JSON Schema
+    for the value, defaulting to a string), ``description`` (optional), and
+    ``required`` (optional, default ``False``). Repeated decorations accumulate.
+    """
+
+    def decorator(handler: Any) -> Any:
+        meta = _meta(handler)
+        meta["query_params"] = meta.get("query_params", []) + [dict(p) for p in params]
+        return handler
+
+    return decorator
+
+
 def _build_operation(meta: dict[str, Any]) -> dict[str, Any]:
     """Translate handler ``__apispec__`` metadata into an OpenAPI operation."""
     op: dict[str, Any] = {}
@@ -120,6 +142,18 @@ def _build_operation(meta: dict[str, Any]) -> dict[str, Any]:
         }
     # Every OpenAPI operation must declare at least one response.
     op["responses"] = responses or {"default": {"description": ""}}
+    query = meta.get("query_params")
+    if query:
+        op["parameters"] = [
+            {
+                "in": "query",
+                "name": p["name"],
+                "required": bool(p.get("required", False)),
+                "schema": p.get("schema") or {"type": "string"},
+                **({"description": p["description"]} if p.get("description") else {}),
+            }
+            for p in query
+        ]
     return op
 
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -15,7 +15,7 @@ import shutil
 import signal
 import sqlite3
 import tempfile
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 import aiohttp
@@ -37,7 +37,7 @@ from ..units import from_f as _from_f
 from ..units import from_f_delta as _from_f_delta
 from ..units import to_f as _to_f
 from . import schemas
-from .openapi import docs, request_schema, response_schema
+from .openapi import docs, query_params, request_schema, response_schema
 
 log = logging.getLogger(__name__)
 
@@ -1471,15 +1471,78 @@ def _cycle_log_to_dict(log_entry, had_overflow: bool = False) -> dict:
     }
 
 
+def _int_param(raw: str | None, *, default: int, minimum: int, maximum: int | None = None) -> int:
+    """Parse an optional integer query param, clamping to [minimum, maximum].
+
+    A missing or non-integer value falls back to *default* instead of 500-ing."""
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
+
+
+# Query params for the cycle-log list (Issue #403). Paging is limit+offset;
+# date-range is start/end (with since/until kept as backward-compatible
+# aliases). Declaring them surfaces the knobs over OpenAPI and MCP.
+_LOGS_QUERY_PARAMS: list[dict[str, Any]] = [
+    {
+        "name": "limit",
+        "schema": {"type": "integer", "minimum": 1, "maximum": 1000},
+        "description": "Max cycles to return (default 50, capped at 1000).",
+    },
+    {
+        "name": "offset",
+        "schema": {"type": "integer", "minimum": 0},
+        "description": "Number of cycles to skip, for paging through history (default 0).",
+    },
+    {
+        "name": "start",
+        "schema": {"type": "string"},
+        "description": (
+            "Only cycles started on/after this ISO date/datetime. Alias: `since`. "
+            "Clamped forward to the cycle-log retention window."
+        ),
+    },
+    {
+        "name": "end",
+        "schema": {"type": "string"},
+        "description": "Only cycles started on/before this ISO date/datetime. Alias: `until`.",
+    },
+    {
+        "name": "since",
+        "schema": {"type": "string"},
+        "description": "Backward-compatible alias of `start`.",
+    },
+    {
+        "name": "until",
+        "schema": {"type": "string"},
+        "description": "Backward-compatible alias of `end`.",
+    },
+]
+
+
 @docs(tags=["logs"], summary="Get cycle logs")
+@query_params(_LOGS_QUERY_PARAMS)
 @response_schema(schemas.CycleLogResponseSchema(many=True))
 @routes.get("/api/logs")
 async def get_logs(request: web.Request) -> web.Response:
     conn = await get_conn(request)
-    limit = int(request.rel_url.query.get("limit", 50))
-    offset = int(request.rel_url.query.get("offset", 0))
-    since = request.rel_url.query.get("since") or None
-    until = request.rel_url.query.get("until") or None
+    q = request.rel_url.query
+    limit = _int_param(q.get("limit"), default=50, minimum=1, maximum=1000)
+    offset = _int_param(q.get("offset"), default=0, minimum=0)
+    # `start`/`end` are the date-oriented aliases (mirroring the metrics API);
+    # `since`/`until` stay supported for backward compatibility (Issue #403).
+    since = q.get("since") or q.get("start") or None
+    until = q.get("until") or q.get("end") or None
+    # Never page before the retention horizon — that data has been purged, so a
+    # wider `since` would just misleadingly return the same in-window slice.
+    floor = await _retention_floor(request)
+    if since is not None and since < floor:
+        since = floor
     logs = await db.get_cycle_logs(conn, limit=limit, offset=offset, since=since, until=until)
     overflow_ids = await db.get_cycle_ids_with_overflow(conn, [log_entry.id for log_entry in logs])
     return json_response(
@@ -2055,20 +2118,92 @@ async def trigger_monthly_rollup(request: web.Request) -> web.Response:
 # ---------------------------------------------------------------------------
 
 
-def _parse_date_range(request: web.Request, default_days: int = 7) -> tuple[str, str]:
-    """Parse `start` and `end` query params (YYYY-MM-DD local). Defaults to
-    the last `default_days` days inclusive of today."""
+def _retention_days(raw: str | None, default: int = 30) -> int:
+    """Coerce the stored ``cycle_log_retention_days`` value to a positive int."""
+    try:
+        return max(1, int(raw))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+async def _retention_floor(request: web.Request) -> str:
+    """Earliest local date whose cycle-log data is still retained (YYYY-MM-DD).
+
+    Cycle logs older than ``cycle_log_retention_days`` have been purged, so any
+    date-range query is clamped to start no earlier than this floor (Issue #403)
+    — requesting a wider window would just return an emptier range and mislead.
+    """
+    conn = await get_conn(request)
+    days = _retention_days(await db.get_system_setting(conn, "cycle_log_retention_days", "30"))
+    return (tz.today_local() - timedelta(days=days)).isoformat()
+
+
+async def _parse_date_range(request: web.Request, default_days: int = 7) -> tuple[str, str]:
+    """Parse `start`/`end`/`days` query params (YYYY-MM-DD local) into an
+    effective, retention-bounded ``[start, end]`` range (Issue #403).
+
+    - `end` defaults to today.
+    - When `start` is omitted, the window is the last `days` days (or, absent
+      `days`, the last `default_days` days) ending at `end`.
+    - The resolved `start` is clamped forward to the retention floor so callers
+      cannot request data that has already been purged.
+
+    Omitting every param preserves the historic behaviour: the last
+    `default_days` days inclusive of today."""
     today = tz.today_local()
-    start = request.rel_url.query.get("start")
-    end = request.rel_url.query.get("end")
+    start = request.rel_url.query.get("start") or None
+    end = request.rel_url.query.get("end") or None
     if not end:
         end = today.isoformat()
-    if not start:
-        start = (today - timedelta(days=default_days - 1)).isoformat()
+    if start is None:
+        n = default_days
+        days_param = request.rel_url.query.get("days")
+        if days_param is not None:
+            try:
+                n = max(1, int(days_param))
+            except ValueError:
+                n = default_days
+        try:
+            anchor = date.fromisoformat(end)
+        except ValueError:
+            anchor = today
+        start = (anchor - timedelta(days=n - 1)).isoformat()
+    floor = await _retention_floor(request)
+    if start < floor:
+        start = floor
     return start, end
 
 
+# Date-range query params shared by every metrics endpoint that calls
+# ``_parse_date_range`` (Issue #403). Declaring them here surfaces the knobs in
+# the OpenAPI spec and the generated MCP tool schemas; the handlers still read
+# them from ``request.rel_url.query``.
+_DATE_RANGE_QUERY_PARAMS: list[dict[str, Any]] = [
+    {
+        "name": "start",
+        "schema": {"type": "string", "format": "date"},
+        "description": (
+            "Inclusive start date (YYYY-MM-DD, local). Clamped forward to the "
+            "cycle-log retention window. Defaults to a fixed window before `end`."
+        ),
+    },
+    {
+        "name": "end",
+        "schema": {"type": "string", "format": "date"},
+        "description": "Inclusive end date (YYYY-MM-DD, local). Defaults to today.",
+    },
+    {
+        "name": "days",
+        "schema": {"type": "integer", "minimum": 1},
+        "description": (
+            "Shorthand for the last N days ending at `end`. Ignored when `start` is provided."
+        ),
+    },
+]
+
+
 @docs(tags=["metrics"], summary="Get thermostat metrics summary")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.MetricsSummarySchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/summary")
 async def metrics_thermostat_summary(request: web.Request) -> web.Response:
@@ -2076,23 +2211,39 @@ async def metrics_thermostat_summary(request: web.Request) -> web.Response:
     completion + source breakdown for the date range."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     summary = await db.compute_thermostat_summary(conn, entity_id, start, end)
     return json_response(summary)
 
 
 @docs(tags=["metrics"], summary="Get home metrics summary")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.MetricsSummarySchema)
 @routes.get("/api/metrics/thermostats/summary")
 async def metrics_home_summary(request: web.Request) -> web.Response:
     """2b — same shape as 2a, aggregated across all thermostats (home view)."""
     conn = await get_conn(request)
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     summary = await db.compute_thermostat_summary(conn, None, start, end)
     return json_response(summary)
 
 
 @docs(tags=["metrics"], summary="Get thermostat metrics timeseries")
+@query_params(
+    [
+        *_DATE_RANGE_QUERY_PARAMS,
+        {
+            "name": "metric",
+            "schema": {"type": "string"},
+            "description": "Which series to compute (e.g. hours, cycles, degree_minutes, time_to_target).",
+        },
+        {
+            "name": "granularity",
+            "schema": {"type": "string", "enum": ["day", "week", "month"]},
+            "description": "Bucket size for the series (default day).",
+        },
+    ]
+)
 @response_schema(schemas.MetricsTimeseriesSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/timeseries")
 async def metrics_thermostat_timeseries(request: web.Request) -> web.Response:
@@ -2101,7 +2252,7 @@ async def metrics_thermostat_timeseries(request: web.Request) -> web.Response:
     entity_id = request.match_info["entity_id"]
     metric = request.rel_url.query.get("metric", "hours")
     granularity = request.rel_url.query.get("granularity", "day")
-    start, end = _parse_date_range(request, default_days=30 if granularity == "day" else 365)
+    start, end = await _parse_date_range(request, default_days=30 if granularity == "day" else 365)
     try:
         series = await db.compute_thermostat_timeseries(
             conn, entity_id, metric, granularity, start, end
@@ -2121,13 +2272,14 @@ async def metrics_thermostat_timeseries(request: web.Request) -> web.Response:
 
 
 @docs(tags=["metrics"], summary="Get room participation metrics")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.RoomMetricsResponseSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/rooms")
 async def metrics_thermostat_rooms(request: web.Request) -> web.Response:
     """2d — per-room participation rate, heating/cooling time, time-to-target."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     rooms = await db.compute_room_metrics(conn, entity_id, start, end)
     return json_response(
         {
@@ -2140,13 +2292,14 @@ async def metrics_thermostat_rooms(request: web.Request) -> web.Response:
 
 
 @docs(tags=["metrics"], summary="Get cycles vs outside temperature data")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.CyclesVsOutsideTempResponseSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/cycles-vs-outside-temp")
 async def metrics_cycles_vs_outside_temp(request: web.Request) -> web.Response:
     """2e — scatter data: each completed cycle as (outside_temp, duration)."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     points = await db.compute_cycles_vs_outside_temp(conn, entity_id, start, end)
     return json_response(
         {
@@ -2159,6 +2312,21 @@ async def metrics_cycles_vs_outside_temp(request: web.Request) -> web.Response:
 
 
 @docs(tags=["metrics"], summary="Get overshoot histogram data")
+@query_params(
+    [
+        *_DATE_RANGE_QUERY_PARAMS,
+        {
+            "name": "bin_size",
+            "schema": {"type": "number"},
+            "description": "Histogram bin width in degrees (default 1).",
+        },
+        {
+            "name": "max_bins",
+            "schema": {"type": "integer", "minimum": 1},
+            "description": "Number of histogram bins (default 6).",
+        },
+    ]
+)
 @response_schema(schemas.OvershootHistogramSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/overshoot-histogram")
 async def metrics_overshoot_histogram(request: web.Request) -> web.Response:
@@ -2166,7 +2334,7 @@ async def metrics_overshoot_histogram(request: web.Request) -> web.Response:
     actually went, computed from cycle_temp_samples."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     bin_size = float(request.rel_url.query.get("bin_size", "1"))
     max_bins = int(request.rel_url.query.get("max_bins", "6"))
     data = await db.compute_overshoot_histogram(
@@ -2176,18 +2344,20 @@ async def metrics_overshoot_histogram(request: web.Request) -> web.Response:
 
 
 @docs(tags=["metrics"], summary="Get HVAC hour heatmap")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.HourHeatmapSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/hour-heatmap")
 async def metrics_thermostat_hour_heatmap(request: web.Request) -> web.Response:
     """2f — 7×24 grid of HVAC seconds (Mon..Sun × hour)."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     grid = await db.compute_hour_heatmap(conn, entity_id, start, end)
     return json_response(grid)
 
 
 @docs(tags=["metrics"], summary="Get vent event timeline")
+@query_params(_DATE_RANGE_QUERY_PARAMS)
 @response_schema(schemas.VentTimelineResponseSchema)
 @routes.get("/api/metrics/thermostats/{entity_id:.*}/vent-timeline")
 async def metrics_thermostat_vent_timeline(request: web.Request) -> web.Response:
@@ -2195,7 +2365,7 @@ async def metrics_thermostat_vent_timeline(request: web.Request) -> web.Response
     "boundary-only, not every vent movement" disclosure."""
     conn = await get_conn(request)
     entity_id = request.match_info["entity_id"]
-    start, end = _parse_date_range(request)
+    start, end = await _parse_date_range(request)
     events = await db.get_vent_events_in_range(conn, entity_id, start, end)
     return json_response(
         {
@@ -2261,6 +2431,21 @@ async def metrics_thermostat_live(request: web.Request) -> web.Response:
 
 
 @docs(tags=["metrics"], summary="Export metrics as CSV")
+@query_params(
+    [
+        *_DATE_RANGE_QUERY_PARAMS,
+        {
+            "name": "scope",
+            "schema": {"type": "string", "enum": ["home", "thermostat"]},
+            "description": "home (default) covers all thermostats; thermostat requires entity_id.",
+        },
+        {
+            "name": "entity_id",
+            "schema": {"type": "string"},
+            "description": "Thermostat entity id, required when scope=thermostat.",
+        },
+    ]
+)
 @routes.get("/api/metrics/export.csv")
 async def metrics_export_csv(request: web.Request) -> web.Response:
     """2i — CSV export of completed cycles in the range. scope=thermostat
@@ -2272,7 +2457,7 @@ async def metrics_export_csv(request: web.Request) -> web.Response:
     unit = request.app["scheduler"].get_temperature_unit()
     unit_label = "°C" if unit == "C" else "°F"
     scope = request.rel_url.query.get("scope", "home")
-    start, end = _parse_date_range(request, default_days=30)
+    start, end = await _parse_date_range(request, default_days=30)
     if scope not in ("home", "thermostat"):
         return error("scope must be 'home' or 'thermostat'")
     thermostat_id = request.rel_url.query.get("entity_id")

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -1397,6 +1397,25 @@ async def ha_states(request: web.Request) -> web.Response:
 
 
 @docs(tags=["ha"], summary="List HA entities, optionally filtered by domain")
+@query_params(
+    [
+        {
+            "name": "domain",
+            "schema": {"type": "string"},
+            "description": "Comma-separated HA domains to filter by (e.g. 'sensor,weather').",
+        },
+        {
+            "name": "has_attribute",
+            "schema": {"type": "string"},
+            "description": "Only entities exposing this state attribute (e.g. 'hvac_action').",
+        },
+        {
+            "name": "exclude_icon",
+            "schema": {"type": "string"},
+            "description": "Exclude entities whose icon matches (e.g. 'mdi:door-open').",
+        },
+    ]
+)
 @response_schema(schemas.HAEntitySchema(many=True))
 @routes.get("/api/ha/entities")
 async def ha_entities(request: web.Request) -> web.Response:
@@ -1639,6 +1658,15 @@ async def get_log_detail(request: web.Request) -> web.Response:
 
 
 @docs(tags=["logs"], summary="Get temperature samples for a cycle")
+@query_params(
+    [
+        {
+            "name": "room_id",
+            "schema": {"type": "string"},
+            "description": "Filter samples to a single room.",
+        }
+    ]
+)
 @response_schema(schemas.CycleTempSampleSchema(many=True))
 @routes.get("/api/logs/{cycle_id}/temp-samples")
 async def get_log_temp_samples(request: web.Request) -> web.Response:
@@ -1664,6 +1692,40 @@ async def get_log_temp_samples(request: web.Request) -> web.Response:
 
 
 @docs(tags=["logs"], summary="Get event logs")
+@query_params(
+    [
+        {
+            "name": "limit",
+            "schema": {"type": "integer", "minimum": 1},
+            "description": "Max events to return (default 100).",
+        },
+        {
+            "name": "offset",
+            "schema": {"type": "integer", "minimum": 0},
+            "description": "Number of events to skip, for paging (default 0).",
+        },
+        {
+            "name": "category",
+            "schema": {"type": "string"},
+            "description": "Filter to a single event category (e.g. 'dev').",
+        },
+        {
+            "name": "since",
+            "schema": {"type": "string"},
+            "description": "Only events on/after this ISO date/datetime.",
+        },
+        {
+            "name": "until",
+            "schema": {"type": "string"},
+            "description": "Only events on/before this ISO date/datetime.",
+        },
+        {
+            "name": "level",
+            "schema": {"type": "string"},
+            "description": "Comma-separated levels to include (e.g. 'warning,error').",
+        },
+    ]
+)
 @response_schema(schemas.EventLogEntrySchema(many=True))
 @routes.get("/api/logs/events")
 async def get_event_logs(request: web.Request) -> web.Response:

--- a/smart_vent/backend/mcp_openapi.py
+++ b/smart_vent/backend/mcp_openapi.py
@@ -3,7 +3,8 @@
 This is the single source of truth that lets the HTTP MCP server expose 100% of
 the REST surface without hand-writing a tool per endpoint. Each documented
 ``/api/`` operation becomes one MCP tool whose JSON input schema is derived from
-the route's path parameters and its marshmallow request-body schema. The tool,
+the route's path parameters, its declared query parameters (Issue #403), and its
+marshmallow request-body schema. The tool,
 when called, is dispatched back through the *running* aiohttp server over
 loopback (see ``mcp_http.py``) — so validation, unit conversion (``_to_f`` /
 ``_delta_to_f``), logging, and WebSocket broadcasts all happen exactly once in
@@ -20,6 +21,7 @@ import copy
 import re
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlencode
 
 from aiohttp import web
 
@@ -46,19 +48,25 @@ class ToolSpec:
     input_schema: dict[str, Any]
     path_params: list[str] = field(default_factory=list)
     body_props: set[str] = field(default_factory=set)
+    query_props: set[str] = field(default_factory=set)
 
     def build_request(self, arguments: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
         """Turn tool arguments into a concrete (relative URL, JSON body).
 
-        Path parameters fill the template; the remaining known body fields form
-        the JSON payload. Query parameters are not modelled (Plenum's OpenAPI
-        spec does not declare them), so query-only knobs fall back to their
-        endpoint defaults.
+        Path parameters fill the template; declared query parameters (Issue
+        #403) are appended as the URL query string; the remaining known body
+        fields form the JSON payload. Query params the OpenAPI spec does not
+        declare still fall back to their endpoint defaults.
         """
         url = self.path_template
         for name in self.path_params:
             value = arguments.get(name, "")
             url = _fill_path_param(url, name, str(value))
+        query = {
+            k: arguments[k] for k in self.query_props if k in arguments and arguments[k] is not None
+        }
+        if query:
+            url = f"{url}?{urlencode(query, doseq=True)}"
         body = {k: v for k, v in arguments.items() if k in self.body_props}
         # GET/DELETE never carry a body; write verbs send one even if empty so
         # the handler's ``await request.json()`` does not blow up on no payload.
@@ -129,6 +137,24 @@ def build_tool_specs(app: web.Application) -> list[ToolSpec]:
                 properties[p] = {"type": "string", "description": f"Path parameter '{p}'"}
                 required.append(p)
 
+            # Query parameters (Issue #403): surface declared ?start/?end/?days/
+            # ?limit/?offset knobs as tool inputs so date-range and paged history
+            # are reachable over MCP, not just via the REST UI.
+            query_props: set[str] = set()
+            for param in op.get("parameters", []):
+                if param.get("in") != "query":
+                    continue
+                pname = param.get("name")
+                if not pname or pname in properties:
+                    continue
+                pschema = dict(param.get("schema") or {"type": "string"})
+                if param.get("description") and "description" not in pschema:
+                    pschema["description"] = param["description"]
+                properties[pname] = pschema
+                query_props.add(pname)
+                if param.get("required"):
+                    required.append(pname)
+
             body_props: set[str] = set()
             request_body = op.get("requestBody")
             if request_body:
@@ -165,6 +191,7 @@ def build_tool_specs(app: web.Application) -> list[ToolSpec]:
                     input_schema=input_schema,
                     path_params=path_params,
                     body_props=body_props,
+                    query_props=query_props,
                 )
             )
 

--- a/smart_vent/backend/tests/integration/test_metrics_date_range.py
+++ b/smart_vent/backend/tests/integration/test_metrics_date_range.py
@@ -1,0 +1,192 @@
+"""Date-range, paging, and retention-clamp behaviour for the metrics and
+cycle-log APIs (Issue #403).
+
+The metrics endpoints already accepted ``start``/``end``; this suite covers the
+new ``days=N`` shorthand, the retention-window clamp on both the metrics and
+cycle-log surfaces, and ``limit``/``offset``/``start``/``end`` paging on
+``/api/logs``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from backend import db
+from backend.models import CycleLog
+
+THERMO = "climate.thermo_a"
+
+
+async def _conn(client):
+    return await client.app["scheduler"].get_db()
+
+
+async def _seed(
+    conn,
+    *,
+    cycle_id: str,
+    started_at: datetime,
+    duration: timedelta = timedelta(minutes=20),
+    mode: str = "cooling",
+) -> None:
+    log_ = CycleLog(
+        id=cycle_id,
+        thermostat_entity_id=THERMO,
+        started_at=started_at,
+        mode=mode,
+        rooms_json="{}",
+    )
+    await db.insert_cycle_log(conn, log_)
+    await db.close_cycle_log(
+        conn, cycle_id, ended_at=started_at + duration, ended_reason="completed"
+    )
+
+
+def _noon(days_ago: int) -> datetime:
+    """`days_ago` days before today at 12:00 UTC — far from local midnight so
+    the local-date bucketing never flips the calendar day."""
+    return datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0) - timedelta(
+        days=days_ago
+    )
+
+
+def _local_date(days_ago: int) -> str:
+    return (datetime.now().date() - timedelta(days=days_ago)).isoformat()  # noqa: DTZ005
+
+
+# ---------------------------------------------------------------------------
+# Metrics: explicit range, default window, days shorthand, retention clamp
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsDateRange:
+    @pytest.mark.asyncio
+    async def test_explicit_range_returns_only_that_range(self, client):
+        conn = await _conn(client)
+        await _seed(conn, cycle_id="today", started_at=_noon(0))
+        await _seed(conn, cycle_id="old", started_at=_noon(20))
+
+        # A single-day window on today sees only today's cycle.
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO}/summary?start={_local_date(0)}&end={_local_date(0)}"
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["cycle_count"] == 1
+        assert data["start_date"] == _local_date(0)
+        assert data["end_date"] == _local_date(0)
+
+        # A single-day window 20 days back sees only the old cycle.
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO}/summary"
+            f"?start={_local_date(20)}&end={_local_date(20)}"
+        )
+        data = await resp.json()
+        assert data["cycle_count"] == 1
+        assert data["start_date"] == _local_date(20)
+
+    @pytest.mark.asyncio
+    async def test_default_window_is_last_seven_days(self, client):
+        conn = await _conn(client)
+        await _seed(conn, cycle_id="today", started_at=_noon(0))
+        await _seed(conn, cycle_id="old", started_at=_noon(20))
+
+        resp = await client.get(f"/api/metrics/thermostats/{THERMO}/summary")
+        assert resp.status == 200
+        data = await resp.json()
+        # Default retention is 30 days, so the 20-day-old cycle is retained but
+        # falls outside the default 7-day window.
+        assert data["start_date"] == _local_date(6)
+        assert data["end_date"] == _local_date(0)
+        assert data["cycle_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_days_shorthand_sets_window(self, client):
+        conn = await _conn(client)
+        await _seed(conn, cycle_id="today", started_at=_noon(0))
+        await _seed(conn, cycle_id="d2", started_at=_noon(2))
+        await _seed(conn, cycle_id="d5", started_at=_noon(5))
+
+        resp = await client.get(f"/api/metrics/thermostats/{THERMO}/summary?days=3")
+        assert resp.status == 200
+        data = await resp.json()
+        # Last 3 days inclusive of today: today, -1, -2. The -5 cycle is out.
+        assert data["start_date"] == _local_date(2)
+        assert data["end_date"] == _local_date(0)
+        assert data["cycle_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_start_clamped_to_retention_floor(self, client):
+        conn = await _conn(client)
+        await db.set_system_setting(conn, "cycle_log_retention_days", "5")
+
+        # Ask for a 30-day window; the effective start is clamped to today-5.
+        resp = await client.get(
+            f"/api/metrics/thermostats/{THERMO}/summary"
+            f"?start={_local_date(30)}&end={_local_date(0)}"
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["start_date"] == _local_date(5)
+        assert data["end_date"] == _local_date(0)
+
+
+# ---------------------------------------------------------------------------
+# Cycle logs: paging + date range + retention clamp
+# ---------------------------------------------------------------------------
+
+
+class TestLogsPagingAndRange:
+    @pytest.mark.asyncio
+    async def test_limit_and_offset_page_history(self, client):
+        conn = await _conn(client)
+        # Ordered started_at DESC → newest first.
+        await _seed(conn, cycle_id="c0", started_at=_noon(0))
+        await _seed(conn, cycle_id="c1", started_at=_noon(1))
+        await _seed(conn, cycle_id="c2", started_at=_noon(2))
+
+        resp = await client.get("/api/logs?limit=1&offset=0")
+        assert resp.status == 200
+        page0 = await resp.json()
+        assert [c["id"] for c in page0] == ["c0"]
+
+        resp = await client.get("/api/logs?limit=1&offset=1")
+        page1 = await resp.json()
+        assert [c["id"] for c in page1] == ["c1"]
+
+    @pytest.mark.asyncio
+    async def test_start_end_filter_by_date(self, client):
+        conn = await _conn(client)
+        await _seed(conn, cycle_id="recent", started_at=_noon(1))
+        await _seed(conn, cycle_id="older", started_at=_noon(10))
+
+        # start on day -5 (ISO date) excludes the 10-day-old cycle.
+        resp = await client.get(f"/api/logs?start={_local_date(5)}")
+        assert resp.status == 200
+        ids = {c["id"] for c in await resp.json()}
+        assert ids == {"recent"}
+
+    @pytest.mark.asyncio
+    async def test_start_clamped_to_retention_excludes_purged_window(self, client):
+        conn = await _conn(client)
+        await db.set_system_setting(conn, "cycle_log_retention_days", "5")
+        await _seed(conn, cycle_id="recent", started_at=_noon(2))
+        await _seed(conn, cycle_id="ancient", started_at=_noon(30))
+
+        # Without clamping, start 40 days back would surface the 30-day-old
+        # cycle. Clamped to the retention floor (today-5) it must not.
+        resp = await client.get(f"/api/logs?start={_local_date(40)}")
+        assert resp.status == 200
+        ids = {c["id"] for c in await resp.json()}
+        assert ids == {"recent"}
+
+    @pytest.mark.asyncio
+    async def test_bad_limit_falls_back_to_default(self, client):
+        conn = await _conn(client)
+        await _seed(conn, cycle_id="c0", started_at=_noon(0))
+
+        resp = await client.get("/api/logs?limit=not-a-number")
+        assert resp.status == 200
+        assert len(await resp.json()) == 1

--- a/smart_vent/backend/tests/integration/test_security.py
+++ b/smart_vent/backend/tests/integration/test_security.py
@@ -48,9 +48,14 @@ async def test_security_headers_on_spa_route(client) -> None:
 @pytest.mark.asyncio
 async def test_500_security_headers(client) -> None:
     """Verify that security headers are present even on 500 Internal Server Error."""
-    # Passing a non-integer limit causes a ValueError in routes.py get_logs
-    # which is not caught as an HTTPException, thus resulting in a 500.
-    resp = await client.get("/api/logs", params={"limit": "not-an-int"})
+    # Passing a non-numeric bin_size raises a ValueError in the overshoot
+    # histogram handler which is not caught as an HTTPException, thus resulting
+    # in a 500. (The /api/logs paging params are validated gracefully now — see
+    # Issue #403 — so they no longer serve as a 500 trigger.)
+    resp = await client.get(
+        "/api/metrics/thermostats/climate.x/overshoot-histogram",
+        params={"bin_size": "not-a-number"},
+    )
     assert resp.status == 500
 
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"

--- a/smart_vent/backend/tests/test_mcp_openapi.py
+++ b/smart_vent/backend/tests/test_mcp_openapi.py
@@ -159,3 +159,49 @@ def test_toolspec_is_constructible() -> None:
     )
     assert spec.path_params == []
     assert spec.body_props == set()
+    assert spec.query_props == set()
+
+
+def _query_app() -> web.Application:
+    app = web.Application()
+
+    @openapi.docs(tags=["metrics"], summary="Ranged")
+    @openapi.query_params(
+        [
+            {"name": "start", "schema": {"type": "string", "format": "date"}},
+            {"name": "days", "schema": {"type": "integer"}, "description": "N days"},
+        ]
+    )
+    @openapi.response_schema(_Resp)
+    async def ranged(_r):
+        return web.Response()
+
+    app.router.add_get("/api/ranged", ranged)
+    return app
+
+
+def test_query_params_become_tool_inputs() -> None:
+    # Issue #403 — declared query params surface as MCP tool input properties.
+    spec = next(s for s in build_tool_specs(_query_app()) if s.name == "get_ranged")
+    assert spec.query_props == {"start", "days"}
+    props = spec.input_schema["properties"]
+    assert props["start"]["type"] == "string"
+    assert props["days"]["type"] == "integer"
+    assert props["days"]["description"] == "N days"
+    # Optional query params are never forced required.
+    assert spec.input_schema.get("required") is None
+
+
+def test_build_request_appends_declared_query_string() -> None:
+    spec = next(s for s in build_tool_specs(_query_app()) if s.name == "get_ranged")
+    url, body = spec.build_request({"start": "2026-01-01", "days": 3, "bogus": "x"})
+    assert body is None  # GET carries no body
+    assert url.startswith("/api/ranged?")
+    # Only declared query params are forwarded; unknown keys are dropped.
+    assert "start=2026-01-01" in url
+    assert "days=3" in url
+    assert "bogus" not in url
+
+    # Omitted query params produce a bare path (no trailing "?").
+    url_bare, _ = spec.build_request({})
+    assert url_bare == "/api/ranged"

--- a/smart_vent/backend/tests/test_openapi.py
+++ b/smart_vent/backend/tests/test_openapi.py
@@ -96,6 +96,38 @@ def test_build_spec_produces_paths_components_and_path_params() -> None:
     assert spec["components"]["schemas"]
 
 
+def test_query_params_decorator_emitted_as_operation_parameters() -> None:
+    # Issue #403 — @query_params flows into the operation's OpenAPI parameters.
+    app = web.Application()
+
+    @openapi.docs(tags=["metrics"], summary="Ranged")
+    @openapi.query_params(
+        [
+            {"name": "start", "schema": {"type": "string", "format": "date"}},
+            {
+                "name": "days",
+                "schema": {"type": "integer"},
+                "description": "N days",
+                "required": True,
+            },
+        ]
+    )
+    @openapi.response_schema(_RespSchema)
+    async def ranged(_request):
+        return web.Response()
+
+    app.router.add_get("/api/ranged", ranged)
+    spec = openapi.build_spec(app, title="Plenum API", version="v1")
+
+    params = spec["paths"]["/api/ranged"]["get"]["parameters"]
+    by_name = {p["name"]: p for p in params}
+    assert by_name["start"]["in"] == "query"
+    assert by_name["start"]["required"] is False
+    assert by_name["start"]["schema"] == {"type": "string", "format": "date"}
+    assert by_name["days"]["required"] is True
+    assert by_name["days"]["description"] == "N days"
+
+
 async def test_setup_openapi_serves_json_ui_and_redirect() -> None:
     from aiohttp.test_utils import TestClient, TestServer
 

--- a/smart_vent/backend/tests/test_query_param_exposure.py
+++ b/smart_vent/backend/tests/test_query_param_exposure.py
@@ -1,0 +1,118 @@
+"""Enforce that every query parameter a route handler reads is declared via
+``@query_params`` (Issue #403).
+
+The MCP tool surface is generated from the OpenAPI spec, which now models query
+parameters — but only the ones a handler *declares*. A handler that reads
+``request.rel_url.query.get("foo")`` without declaring ``foo`` leaves that knob
+invisible over MCP (and undocumented in Swagger). This test statically scans
+each ``/api/`` handler's source for the query keys it reads and asserts they are
+all declared, so new endpoints cannot regress the exposure.
+
+Detection is AST-based and covers the two read forms used in the codebase:
+``<expr>.query.get("k")`` / ``.getone`` / ``.getall`` and ``<expr>.query["k"]``,
+including the ``q = request.rel_url.query`` alias pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from backend.main import build_app
+from backend.tests.integration.fake_ha import FakeHomeAssistant
+
+_QUERY_READ_METHODS = {"get", "getone", "getall"}
+
+
+def _query_alias_names(tree: ast.AST) -> set[str]:
+    """Local names bound to ``<expr>.query`` (e.g. ``q = request.rel_url.query``)."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "query"
+        ):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+def _is_query_receiver(node: ast.expr, aliases: set[str]) -> bool:
+    """True if *node* refers to a query multidict (``.query`` attr or an alias)."""
+    if isinstance(node, ast.Attribute) and node.attr == "query":
+        return True
+    return isinstance(node, ast.Name) and node.id in aliases
+
+
+def _read_query_keys(func) -> set[str]:
+    """Static set of query-string keys *func* reads with a string literal."""
+    src = textwrap.dedent(inspect.getsource(func))
+    tree = ast.parse(src)
+    aliases = _query_alias_names(tree)
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        # <query>.get("k") / .getone("k") / .getall("k")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _QUERY_READ_METHODS
+            and node.args
+            and _is_query_receiver(node.func.value, aliases)
+        ):
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                keys.add(arg.value)
+        # <query>["k"]
+        if isinstance(node, ast.Subscript) and _is_query_receiver(node.value, aliases):
+            sl = node.slice
+            if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+                keys.add(sl.value)
+    return keys
+
+
+def test_every_read_query_param_is_declared_for_mcp() -> None:
+    app = build_app(FakeHomeAssistant(), ":memory:", frontend_dist=None, start_ha=False)  # type: ignore[arg-type]
+
+    problems: list[str] = []
+    seen: set = set()
+    for route in app.router.routes():
+        handler = route.handler
+        meta = getattr(handler, "__apispec__", None)
+        if not meta:
+            continue
+        resource = route.resource
+        path = resource.canonical if resource is not None else None
+        if not path or not path.startswith("/api/"):
+            continue
+        if handler in seen:
+            continue
+        seen.add(handler)
+
+        read = _read_query_keys(handler)
+        declared = {p["name"] for p in meta.get("query_params", [])}
+        missing = read - declared
+        if missing:
+            problems.append(
+                f"{route.method} {path} reads undeclared query params: {sorted(missing)}"
+            )
+
+    assert not problems, (
+        "Every query param a handler reads must be declared via @query_params so it "
+        "is exposed over OpenAPI/MCP (Issue #403):\n" + "\n".join(problems)
+    )
+
+
+def test_detector_finds_alias_and_subscript_reads() -> None:
+    # Guards the detector itself so a false-negative can't hide a real gap.
+    async def handler(request):
+        q = request.rel_url.query
+        _a = q.get("aliased")
+        _b = request.rel_url.query.get("direct")
+        _c = request.query["subscript"]
+        _d = q.getall("multi")
+        return _a, _b, _c, _d
+
+    assert _read_query_keys(handler) == {"aliased", "direct", "subscript", "multi"}


### PR DESCRIPTION
## What changed & why

Closes #403. Cycle logs are retained for `cycle_log_retention_days`, but the API/MCP surface previously only exposed the most recent ~7-day window (metrics) / ~55 cycles (`/api/logs`), so multi-week and seasonal questions couldn't be answered even though the data was retained. This PR makes that retained history queryable by date range and page, over both REST and MCP.

### Metrics endpoints (`/summary`, `/{id}/summary`, `/rooms`, `/cycles-vs-outside-temp`, `/overshoot-histogram`, `/hour-heatmap`, `/timeseries`, `/vent-timeline`, `export.csv`)
- `_parse_date_range` (now async) gains a **`days=N` shorthand** (last N days ending at `end`) and **clamps the resolved `start` forward to the retention horizon** — a caller can't request a window whose data has already been purged.
- Omitting all params preserves today's behavior (last 7 days inclusive of today; 30/365 where those defaults already applied).
- The effective, clamped range is echoed back via the existing `start_date`/`end_date` response fields.

### Cycle-log list (`/api/logs`)
- Adds `start`/`end` as date-oriented aliases of the existing `since`/`until`, alongside `limit`/`offset` paging, with `since` clamped to the retention floor.
- `limit`/`offset` are now parsed gracefully (bad input falls back to the default instead of returning 500) and `limit` is capped at 1000.

### MCP exposure — now complete across the whole surface
- OpenAPI now models query parameters: a new `@query_params` decorator records them and `_build_operation` emits them as operation `parameters`.
- The OpenAPI→MCP generator (`mcp_openapi.py`) turns declared query params into tool inputs (`query_props`) and appends them to the loopback request URL, so the same knobs are reachable over MCP — previously query params were not modelled at all.
- **Every** `/api/` GET handler that reads query params is now declared, not just the date-range ones. Audited the full route surface and added declarations for the endpoints I'd initially missed:
  - `/api/ha/entities`: `domain`, `has_attribute`, `exclude_icon`
  - `/api/logs/{cycle_id}/temp-samples`: `room_id`
  - `/api/logs/events`: `limit`, `offset`, `category`, `since`, `until`, `level`
- **Regression guard:** `backend/tests/test_query_param_exposure.py` AST-scans every route handler for the query keys it reads (handling the `q = request.rel_url.query` alias and subscript forms) and fails CI if any read key isn't declared via `@query_params`. A future endpoint therefore cannot silently drop a param from the MCP/Swagger surface.

No UI change is included: these are read-only query params on GET endpoints (not a write-boundary tunable or persisted setting), and the issue explicitly scopes a Metrics date-range picker as an optional follow-up.

## Test plan
- `backend/tests/integration/test_metrics_date_range.py` (new): explicit range returns exactly that range; default window is last 7 days; `days=N` shorthand; `start` clamped to the retention floor on both metrics and `/api/logs`; `limit`/`offset` paging; date filtering; graceful bad-`limit` fallback.
- `backend/tests/test_query_param_exposure.py` (new): every handler's read query params are declared; plus a self-test of the AST detector (alias + subscript + `getall`).
- `backend/tests/test_openapi.py`: `@query_params` is emitted as operation-level OpenAPI `parameters`.
- `backend/tests/test_mcp_openapi.py`: declared query params become MCP tool inputs and `build_request` appends only declared params to the URL.
- `backend/tests/integration/test_security.py`: 500-headers test repointed to `overshoot-histogram?bin_size=…` (which still raises on malformed input) since `/api/logs` no longer 500s on bad `limit`.
- Full backend suite: **948 passed**, coverage **93.67%** (≥ 92.5% gate). `ruff check`/`format` clean, `mypy` clean. Frontend `lint` + `test:coverage` unaffected and green.
