### PR TITLE
Add Beta release track: prebuilt-image add-on auto-built on every main merge

### DIFF
--- a/.github/scripts/gen-beta-changelog.sh
+++ b/.github/scripts/gen-beta-changelog.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Generate the rolling Plenum Beta changelog to stdout: a single
+# "building toward vX.Y.Z" section listing the pull requests merged to `main`
+# since the last stable v#.#.# tag. Mirrors the PR-title harvesting in
+# .github/workflows/release-pr.yml so the beta and stable changelogs read alike.
+#
+# Usage: gen-beta-changelog.sh <beta-version>          # e.g. 0.30.1-beta.7
+# Env:   REPO=<owner/name> (defaults to the origin remote); GH_TOKEN for gh.
+set -euo pipefail
+
+BETA_VERSION="${1:?usage: gen-beta-changelog.sh <beta-version>}"
+TARGET="${BETA_VERSION%%-beta.*}"          # 0.30.1-beta.7 -> 0.30.1
+
+if [ -z "${REPO:-}" ]; then
+  REPO=$(git config --get remote.origin.url 2>/dev/null \
+    | sed -E 's#(git@|https://)github.com[:/]##; s#\.git$##' || echo "")
+fi
+
+LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+  RANGE="${LAST_TAG}..HEAD"
+  SINCE="$LAST_TAG"
+else
+  RANGE="HEAD"
+  SINCE="the first commit"
+fi
+SHORT_SHA=$(git rev-parse --short HEAD)
+
+# PR numbers referenced by commit subjects in range (deduped, numeric).
+PR_NUMS=$(git log "$RANGE" --pretty=format:'%s' \
+  | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un || true)
+
+BULLETS=""
+for NUM in $PR_NUMS; do
+  PR_JSON=$(gh pr view "$NUM" --repo "$REPO" --json number,title,url 2>/dev/null || echo "")
+  if [ -z "$PR_JSON" ]; then
+    continue
+  fi
+  TITLE=$(printf '%s' "$PR_JSON" | jq -r '.title')
+  if printf '%s' "$TITLE" | grep -qE '^Release v[0-9]'; then
+    continue
+  fi
+  URL=$(printf '%s' "$PR_JSON" | jq -r '.url')
+  BULLETS="${BULLETS}- ${TITLE} ([#${NUM}](${URL}))\n"
+done
+if [ -z "$BULLETS" ]; then
+  BULLETS="- No merged pull requests since ${SINCE} yet.\n"
+fi
+
+printf '# Plenum Beta — Changelog\n\n'
+printf '## %s — building toward v%s\n\n' "$BETA_VERSION" "$TARGET"
+printf '> ⚠️ **Beta channel.** Built from the tip of `main` (commit `%s`). May be\n' "$SHORT_SHA"
+printf '> unstable. For a production install, use the **Plenum** (stable) add-on.\n'
+printf '> This channel is currently exercising the auth refactor (#373).\n\n'
+printf '**Changes since %s:**\n\n' "$SINCE"
+printf '%b' "$BULLETS"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,8 +1,8 @@
 name: Build & Push Beta Image
 
 # On every non-release merge to main, publish a rolling BETA build of Plenum:
-#   1. Compute a beta version from the last v#.#.# tag
-#      (MAJOR.MINOR.(PATCH+1)-beta.<commits-since-tag>).
+#   1. Compute a beta version from the last minor tag
+#      (MAJOR.(MINOR+1).0-beta.<commits-since-that-tag>).
 #   2. Stamp it into smart_vent/config.yaml IN THE RUNNER ONLY, so the existing
 #      Dockerfile bakes it into VITE_APP_VERSION (the UI footer) — no Dockerfile
 #      or app change. The stamped file is never committed.
@@ -52,22 +52,26 @@ jobs:
       - name: Compute beta version
         id: ver
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
+          # Betas build toward the NEXT MINOR (e.g. after v0.30.x -> 0.31.0-beta.N).
+          # Base the target and the build counter on the last MINOR release
+          # (v*.*.0) so an interim patch release (e.g. v0.30.1) during the beta
+          # cycle can't reset the beta number and stall HA update-detection.
+          LAST_MINOR_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.0' 2>/dev/null || echo "")
+          if [ -z "$LAST_MINOR_TAG" ]; then
             BASE="0.0.0"
             BUILD=$(git rev-list --count HEAD)
           else
-            BASE="${LAST_TAG#v}"
-            # Count real changes since the tag, excluding this workflow's own
-            # pointer-only commits under smart_vent_beta/ (fallback if the
+            BASE="${LAST_MINOR_TAG#v}"
+            # Count real changes since that minor tag, excluding this workflow's
+            # own pointer-only commits under smart_vent_beta/ (fallback if the
             # exclude pathspec is unsupported).
-            BUILD=$(git rev-list --count "${LAST_TAG}..HEAD" -- ':!smart_vent_beta' 2>/dev/null \
-                    || git rev-list --count "${LAST_TAG}..HEAD")
+            BUILD=$(git rev-list --count "${LAST_MINOR_TAG}..HEAD" -- ':!smart_vent_beta' 2>/dev/null \
+                    || git rev-list --count "${LAST_MINOR_TAG}..HEAD")
           fi
           IFS=. read -r MAJ MIN PAT <<< "$BASE"
-          BETA="${MAJ}.${MIN}.$((PAT + 1))-beta.${BUILD}"
+          BETA="${MAJ}.$((MIN + 1)).0-beta.${BUILD}"
           echo "beta=${BETA}" >> "$GITHUB_OUTPUT"
-          echo "Computed beta version ${BETA} (base ${LAST_TAG:-<none>}, +${BUILD} changes)"
+          echo "Computed beta version ${BETA} (from last minor ${LAST_MINOR_TAG:-<none>}, +${BUILD} changes)"
 
       - name: Stamp version into the build context (runner-only)
         run: sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,126 @@
+name: Build & Push Beta Image
+
+# On every non-release merge to main, publish a rolling BETA build of Plenum:
+#   1. Compute a beta version from the last v#.#.# tag
+#      (MAJOR.MINOR.(PATCH+1)-beta.<commits-since-tag>).
+#   2. Stamp it into smart_vent/config.yaml IN THE RUNNER ONLY, so the existing
+#      Dockerfile bakes it into VITE_APP_VERSION (the UI footer) — no Dockerfile
+#      or app change. The stamped file is never committed.
+#   3. Build the same ./smart_vent context and push a multi-arch image to
+#      ghcr.io/dhruvb14/plenum-beta:<version> (+ :latest).
+#   4. Commit the new version: and a regenerated changelog into the beta pointer
+#      add-on (smart_vent_beta/) so Home Assistant surfaces the update. That push
+#      uses GITHUB_TOKEN, which does not re-trigger any workflow.
+#
+# Stable/release publishing is unchanged (tag -> release-pr.yml -> release/v* PR
+# -> container-ci publishes :version + :latest). Skipped on release-PR merges.
+# See issue #465.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'e2e/screenshots/**'
+      - 'smart_vent_beta/**'   # ignore this workflow's own pointer-bump commit
+  workflow_dispatch:           # manual publish (e.g. to bootstrap the first beta image)
+
+# Serialise beta publishes so two quick merges can't race on the pointer commit.
+concurrency:
+  group: beta-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # commit the version/changelog bump to smart_vent_beta/
+  packages: write   # push the beta image to GHCR
+
+env:
+  REGISTRY: ghcr.io
+  BETA_IMAGE: ghcr.io/dhruvb14/plenum-beta
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build-beta:
+    name: Build & Push Beta
+    # Skip release-PR merges — the stable/release flow owns those.
+    if: ${{ !contains(github.event.head_commit.message, 'release/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need tags + full history for describe/rev-list
+
+      - name: Compute beta version
+        id: ver
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            BASE="0.0.0"
+            BUILD=$(git rev-list --count HEAD)
+          else
+            BASE="${LAST_TAG#v}"
+            # Count real changes since the tag, excluding this workflow's own
+            # pointer-only commits under smart_vent_beta/ (fallback if the
+            # exclude pathspec is unsupported).
+            BUILD=$(git rev-list --count "${LAST_TAG}..HEAD" -- ':!smart_vent_beta' 2>/dev/null \
+                    || git rev-list --count "${LAST_TAG}..HEAD")
+          fi
+          IFS=. read -r MAJ MIN PAT <<< "$BASE"
+          BETA="${MAJ}.${MIN}.$((PAT + 1))-beta.${BUILD}"
+          echo "beta=${BETA}" >> "$GITHUB_OUTPUT"
+          echo "Computed beta version ${BETA} (base ${LAST_TAG:-<none>}, +${BUILD} changes)"
+
+      - name: Stamp version into the build context (runner-only)
+        run: sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push beta image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./smart_vent
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.BETA_IMAGE }}:${{ steps.ver.outputs.beta }}
+            ${{ env.BETA_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Publish beta pointer (version + changelog + store icons)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BETA: ${{ steps.ver.outputs.beta }}
+        run: |
+          # Undo the runner-only version stamp so only the beta pointer changes.
+          git checkout -- smart_vent/config.yaml
+          # Bump the beta pointer to the version we just published.
+          sed -i "s/^version:.*/version: \"${BETA}\"/" smart_vent_beta/config.yaml
+          # Regenerate the rolling "building toward vX.Y.Z" changelog.
+          bash .github/scripts/gen-beta-changelog.sh "${BETA}" > smart_vent_beta/CHANGELOG.md
+          # Keep the beta store icons in sync with stable (first run seeds them).
+          cp -f smart_vent/icon.png smart_vent_beta/icon.png
+          cp -f smart_vent/logo.png smart_vent_beta/logo.png
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add smart_vent_beta/
+          if git diff --cached --quiet; then
+            echo "No pointer changes to publish."
+            exit 0
+          fi
+          git commit -m "chore(beta): publish ${BETA}"
+          git fetch origin main
+          git rebase origin/main
+          git push origin HEAD:main
+          echo "Published ${BETA}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -88,7 +88,7 @@ Never push directly to `main`, even under pressure. It bypasses CI and creates t
 | Any PR or push to main | `lint.yml` | Ruff, pytest, mypy, frontend lint+tests, Trivy source scan |
 | Any PR | `container-ci.yml` | Docker smoke test, °F/°C round-trip E2E, visual-regression legs + golden fan-in commit |
 | Non-release branch merged → main | `docker.yml` → `build-and-push` | Build + push, only when `smart_vent/config.yaml` changed (version bump outside the release flow) |
-| Merge to `main` (non-release) | `beta.yml` → `Build & Push Beta` | Builds `./smart_vent`, pushes `ghcr.io/dhruvb14/plenum-beta:X.Y.(Z+1)-beta.N` + `:latest`, then commits the version + changelog bump into `smart_vent_beta/` via `GITHUB_TOKEN` (no CI re-trigger). Skipped on release-PR merges. |
+| Merge to `main` (non-release) | `beta.yml` → `Build & Push Beta` | Builds `./smart_vent`, pushes `ghcr.io/dhruvb14/plenum-beta:X.(Y+1).0-beta.N` + `:latest`, then commits the version + changelog bump into `smart_vent_beta/` via `GITHUB_TOKEN` (no CI re-trigger). Skipped on release-PR merges. |
 
 ## Beta track (rolling)
 
@@ -97,9 +97,9 @@ publishes a **beta** build via `.github/workflows/beta.yml`:
 
 - The image is built from the same `./smart_vent` context and pushed to
   `ghcr.io/dhruvb14/plenum-beta:<version>` (multi-arch) + `:latest`.
-- The version is derived from the last `v#.#.#` tag as
-  `MAJOR.MINOR.(PATCH+1)-beta.<commits-since-tag>` (e.g. `0.30.1-beta.7`), so it
-  sorts above the last stable and below the next one for HA update detection.
+- The version is derived from the last minor release (`v#.#.0`) as
+  `MAJOR.(MINOR+1).0-beta.<commits-since-that-tag>` (e.g. `0.31.0-beta.7`), so it
+  sorts above the last stable and below the next minor for HA update detection.
 - The workflow then commits the new `version:` and a regenerated
   `smart_vent_beta/CHANGELOG.md` into the beta pointer add-on, so Home Assistant
   surfaces the update. That push uses `GITHUB_TOKEN`, which does not re-trigger CI.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -88,3 +88,27 @@ Never push directly to `main`, even under pressure. It bypasses CI and creates t
 | Any PR or push to main | `lint.yml` | Ruff, pytest, mypy, frontend lint+tests, Trivy source scan |
 | Any PR | `container-ci.yml` | Docker smoke test, °F/°C round-trip E2E, visual-regression legs + golden fan-in commit |
 | Non-release branch merged → main | `docker.yml` → `build-and-push` | Build + push, only when `smart_vent/config.yaml` changed (version bump outside the release flow) |
+| Merge to `main` (non-release) | `beta.yml` → `Build & Push Beta` | Builds `./smart_vent`, pushes `ghcr.io/dhruvb14/plenum-beta:X.Y.(Z+1)-beta.N` + `:latest`, then commits the version + changelog bump into `smart_vent_beta/` via `GITHUB_TOKEN` (no CI re-trigger). Skipped on release-PR merges. |
+
+## Beta track (rolling)
+
+Alongside the tagged **stable** track, every non-release merge to `main`
+publishes a **beta** build via `.github/workflows/beta.yml`:
+
+- The image is built from the same `./smart_vent` context and pushed to
+  `ghcr.io/dhruvb14/plenum-beta:<version>` (multi-arch) + `:latest`.
+- The version is derived from the last `v#.#.#` tag as
+  `MAJOR.MINOR.(PATCH+1)-beta.<commits-since-tag>` (e.g. `0.30.1-beta.7`), so it
+  sorts above the last stable and below the next one for HA update detection.
+- The workflow then commits the new `version:` and a regenerated
+  `smart_vent_beta/CHANGELOG.md` into the beta pointer add-on, so Home Assistant
+  surfaces the update. That push uses `GITHUB_TOKEN`, which does not re-trigger CI.
+
+Beta is a **separate add-on** (`slug: plenum_beta`) with its own database and its
+own host ports, so it can be installed alongside stable Plenum. It exists to soak
+large or risky changes (currently the auth refactor, #373) before they reach the
+stable track — stable only advances when a human pushes a `v#.#.#` tag.
+
+**One-time setup:** make the `ghcr.io/dhruvb14/plenum-beta` GHCR package
+**public** (HA Supervisor pulls anonymously) and allow the bot to push the
+pointer commit to `main` (branch-protection bypass for `github-actions[bot]`).

--- a/smart_vent/backend/tests/test_addon_config.py
+++ b/smart_vent/backend/tests/test_addon_config.py
@@ -5,6 +5,10 @@ bashio::config in run.sh.
 This catches the class of bug where a new add-on option is added to
 config.yaml but the shell entry-point is never updated to read and
 export it, so the user's setting silently has no effect at runtime.
+
+The beta pointer add-on (smart_vent_beta/config.yaml) shares the same
+run.sh, so its options block must stay in lockstep with the stable one;
+that is asserted separately below.
 """
 
 from __future__ import annotations
@@ -14,14 +18,15 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).parents[3]
 _CONFIG_YAML = _REPO_ROOT / "smart_vent" / "config.yaml"
+_CONFIG_YAML_BETA = _REPO_ROOT / "smart_vent_beta" / "config.yaml"
 _RUN_SH = _REPO_ROOT / "smart_vent" / "run.sh"
 
 
-def _option_keys() -> list[str]:
-    """Extract keys from the 'options:' block in config.yaml without PyYAML."""
+def _option_keys(config_yaml: Path) -> list[str]:
+    """Extract keys from the 'options:' block in a config.yaml without PyYAML."""
     keys: list[str] = []
     in_options = False
-    for line in _CONFIG_YAML.read_text().splitlines():
+    for line in config_yaml.read_text().splitlines():
         if line.rstrip() == "options:":
             in_options = True
             continue
@@ -44,11 +49,24 @@ class TestAddonConfigParity:
         # Check for either literal bashio::config calls OR get_config helper usage
         missing = [
             key
-            for key in _option_keys()
+            for key in _option_keys(_CONFIG_YAML)
             if f"bashio::config '{key}'" not in run_sh and f"get_config '{key}'" not in run_sh
         ]
         assert not missing, (
             f"Option(s) defined in config.yaml but never read in run.sh "
             f"via bashio::config or get_config: {missing}. "
             f"Add a line like: VAR=$(get_config '{missing[0]}' 'default_value')"
+        )
+
+    def test_beta_options_match_stable(self):
+        """The beta pointer add-on (smart_vent_beta/config.yaml) runs the same
+        image and the same run.sh as stable, so its 'options' block must stay
+        identical to stable's. If they drift, a beta option would silently go
+        unread by run.sh (which only the stable parity test above guards)."""
+        stable = _option_keys(_CONFIG_YAML)
+        beta = _option_keys(_CONFIG_YAML_BETA)
+        assert beta == stable, (
+            "smart_vent_beta/config.yaml options drifted from smart_vent/config.yaml. "
+            f"stable={stable} beta={beta}. Keep the beta manifest's options/schema "
+            "block a verbatim copy of stable's (only name/slug/image/version/ports differ)."
         )

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.30.1-beta.0 — building toward v0.30.1
+## 0.31.0-beta.0 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** This add-on tracks the tip of `main` and may be unstable.
 > For a production install, use the **Plenum** (stable) add-on. This channel is

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Plenum Beta — Changelog
+
+## 0.30.1-beta.0 — building toward v0.30.1
+
+> ⚠️ **Beta channel.** This add-on tracks the tip of `main` and may be unstable.
+> For a production install, use the **Plenum** (stable) add-on. This channel is
+> currently exercising the auth refactor (#373).
+
+This file is regenerated automatically on every merge to `main` by
+`.github/workflows/beta.yml` (via `.github/scripts/gen-beta-changelog.sh`); it
+always lists the changes on `main` since the last stable `v#.#.#` release. Until
+the first beta build runs, this is a placeholder.

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,0 +1,47 @@
+name: "Plenum (Beta)"
+description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
+version: "0.30.1-beta.0"
+slug: "plenum_beta"
+image: "ghcr.io/dhruvb14/plenum-beta"
+url: "https://github.com/dhruvb14/smart-thermostat-with-vents"
+stage: experimental
+arch:
+  - aarch64
+  - amd64
+init: false
+ingress: true
+ingress_port: 8099
+panel_icon: mdi:thermostat
+panel_title: Plenum (Beta)
+homeassistant_api: true
+hassio_api: true
+auth_api: true
+ports:
+  8099/tcp: null
+  9099/tcp: null
+ports_description:
+  8099/tcp: "Beta Web UI — leave blank for ingress-only (recommended). To expose it on the host, pick a port distinct from stable Plenum (e.g. 8199)."
+  9099/tcp: "Beta MCP server — leave blank for ingress-only (recommended). To expose it on the host, pick a port distinct from stable Plenum (e.g. 9199), then enable MCP in Plenum's settings."
+options:
+  ha_url: ""
+  ha_token: ""
+  use_wss: false
+  ssl_verify: true
+  # Timezone for schedule evaluation. Examples: America/New_York, America/Chicago,
+  # America/Denver, America/Los_Angeles, Europe/London, Europe/Paris, Asia/Tokyo
+  timezone: "America/New_York"
+  # Temperature unit override. Set to "F" or "C" to lock the display unit.
+  # Leave blank to auto-detect from Home Assistant's unit_system setting.
+  temperature_unit: ""
+schema:
+  ha_url: str
+  ha_token: str
+  use_wss: bool
+  ssl_verify: bool
+  timezone: str
+  temperature_unit: str
+environment:
+  DATA_DIR: /config
+map:
+  - data
+  - addon_config:rw

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.30.1-beta.0"
+version: "0.31.0-beta.0"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## What & why

Implements the two-track (stable + beta) design from #465. Stable is unchanged and keeps advancing only on a human `v#.#.#` tag. A new **beta** add-on tracks the tip of `main`, so the incoming auth refactor (#373) — large and possibly unstable — can soak on real installs without any risk to stable users.

## What changed

- **`smart_vent_beta/`** — a pure metadata pointer add-on (no code, no Dockerfile):
  - `config.yaml`: `slug: plenum_beta`, `image: ghcr.io/dhruvb14/plenum-beta`, `stage: experimental`. Identical `options`/`schema` to stable, and it reuses the same `run.sh` and image.
  - **Isolated data** — per-slug `/data` + `/config` (`addon_config`) mounts give it its own `app.db` and `options.json`, never shared with stable.
  - **Isolated ports** — host `ports` left `null` (ingress-only; the safe default while the raw port is unauthenticated pre-#373); `ports_description` guides toward `8199`/`9199` if exposed, so both tracks can run side-by-side with no host-port collision.
  - `CHANGELOG.md`: placeholder, regenerated per build.
- **`.github/workflows/beta.yml`** — on every non-release merge to `main` (and manual `workflow_dispatch`): compute a beta version building toward the **next minor** (`MAJOR.(MINOR+1).0-beta.<commits-since-last-minor-tag>` — e.g. `0.31.0-beta.N`, since the auth refactor is a minor bump), stamp it into `smart_vent/config.yaml` **in the runner only** so the existing Dockerfile bakes it into `VITE_APP_VERSION` (the UI footer), build the same `./smart_vent` context, push a multi-arch image to `ghcr.io/dhruvb14/plenum-beta`, then commit the version + regenerated changelog into `smart_vent_beta/` via `GITHUB_TOKEN` (no CI re-trigger). The build counter is based on the last **minor** tag (`v*.*.0`) so an interim patch release can't reset it and stall HA update-detection. Skipped on release-PR merges; serialized with a concurrency group.
- **`.github/scripts/gen-beta-changelog.sh`** — rolling "building toward vX.Y.Z" changelog, reusing `release-pr.yml`'s PR-title harvesting.
- **`smart_vent/backend/tests/test_addon_config.py`** — assert the beta options block stays in lockstep with stable, so the shared `run.sh` reads every beta option.
- **`RELEASE.md`** — document the beta track and its one-time setup.

## Not changed

The single `smart_vent/Dockerfile`, all app code, and the entire stable/release flow (`release-pr.yml`, `container-ci.yml`, `docker.yml`, `validate-release.yml`) are untouched. Both tracks run the same image; the beta differences are manifest-only.

## Test plan

- **CI on this PR:** `lint.yml` (ruff / pytest / mypy / frontend) runs the new `test_beta_options_match_stable`; `container-ci.yml` builds and smoke-tests the (unchanged) stable image. Visual-regression legs skip — no UI-affecting paths are touched.
- **`beta.yml`** only triggers on push to `main` / dispatch, so it can't run until this is merged. After merge, run it once via **Actions → Build & Push Beta Image → Run workflow** to bootstrap the first `ghcr.io/dhruvb14/plenum-beta` image and pointer bump, then verify "Plenum (Beta)" installs in Home Assistant alongside stable and reports a `0.31.0-beta.N` version in the footer.

## One-time owner setup before beta installs work (see #465 decision points)

- [ ] Make the new `ghcr.io/dhruvb14/plenum-beta` GHCR package **public** (Supervisor pulls anonymously; the package is created private on first push).
- [ ] Allow `github-actions[bot]` to push the pointer commit to `main` (branch-protection bypass), since the RELEASE.md policy blocks direct pushes.

Refs #465, #373.