### PR TITLE
fix(beta.yml): valid YAML for the version-stamp step (unblock the beta workflow)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -74,7 +74,8 @@ jobs:
           echo "Computed beta version ${BETA} (from last minor ${LAST_MINOR_TAG:-<none>}, +${BUILD} changes)"
 
       - name: Stamp version into the build context (runner-only)
-        run: sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml
+        run: |
+          sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
## Problem

The beta track merged in #466 shipped an **invalid `beta.yml`**: line 77's inline `run:` contained `version: "…"` — a colon-space that YAML parses as a nested mapping. GitHub rejected the whole file (`Invalid workflow file: .github/workflows/beta.yml#L77 — error in your yaml syntax on line 77`), so **every `beta.yml` run failed at startup in 0s**, including on the merge to `main`. The beta auto-publish never actually ran. Nothing else was affected — this workflow fails in isolation (stable add-on, `lint.yml`, `container-ci`, `docker.yml` are all fine).

## Fix

Make the version-stamp step a `run: |` block scalar — the same pattern `container-ci.yml` and `validate-release.yml` already use for their `sed` steps. No behavior change.

```diff
       - name: Stamp version into the build context (runner-only)
-        run: sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml
+        run: |
+          sed -i "s/^version:.*/version: \"${{ steps.ver.outputs.beta }}\"/" smart_vent/config.yaml
```

## Validation

- Parsed the fixed file with a YAML parser locally → OK.
- `beta.yml` only triggers on push-to-`main` / `workflow_dispatch`, so it can't run on this PR. Once merged it will parse and run on the next push to `main`. (After merge, the first real run can be kicked via **Actions → Build & Push Beta Image → Run workflow** — note the two one-time setup items from #465 still apply: make the `plenum-beta` GHCR package public, and allow the bot to push the pointer commit to `main`.)

Refs #466, #465.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qo2ahC1J919VgpDzLYWJN8)_