### PR TITLE
fix(auth+beta): X-Supervisor-Token login + monotonic beta version (#373)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -65,20 +65,46 @@ jobs:
         run: |
           git fetch --tags --quiet origin
           git fetch --quiet origin main
-          # Betas build toward the NEXT MINOR, counted from the last minor tag
-          # (v*.*.0), excluding the workflow's own smart_vent_beta/ commits.
+          # Betas build toward the NEXT MINOR after the last minor tag (v*.*.0).
           LAST_MINOR_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.0' 2>/dev/null || echo "")
           if [ -z "$LAST_MINOR_TAG" ]; then
             BASE="0.0.0"
-            BUILD=$(git rev-list --count HEAD)
           else
             BASE="${LAST_MINOR_TAG#v}"
-            BUILD=$(git rev-list --count "${LAST_MINOR_TAG}..HEAD" -- ':!smart_vent_beta' 2>/dev/null \
-                    || git rev-list --count "${LAST_MINOR_TAG}..HEAD")
           fi
           IFS=. read -r MAJ MIN PAT <<< "$BASE"
-          BETA="${MAJ}.$((MIN + 1)).0-beta.${BUILD}"
-          echo "Beta version for this PR: ${BETA} (toward the next minor)"
+          NEXT_MINOR="${MAJ}.$((MIN + 1)).0"
+
+          # Build counter is derived from origin/main (the linear, squash-merged
+          # mainline) — NOT this PR's branch. Counting the branch was the bug: a
+          # large feature branch inflated the count while a fix branched off the
+          # squash-merged main deflated it, so the beta version went BACKWARDS
+          # (0.31.0-beta.20 -> -beta.7) and Home Assistant stopped offering the
+          # update. main only ever grows, so counting it is monotonic across
+          # squash merges. ':!smart_vent_beta' excludes this job's own pointer
+          # commits from the count.
+          if [ -z "$LAST_MINOR_TAG" ]; then
+            BUILD=$(git rev-list --count origin/main)
+          else
+            BUILD=$(git rev-list --count "${LAST_MINOR_TAG}..origin/main" -- ':!smart_vent_beta' 2>/dev/null \
+                    || git rev-list --count "${LAST_MINOR_TAG}..origin/main")
+          fi
+
+          # Anti-regression floor: never emit a beta number <= the highest one
+          # ALREADY recorded on main for this minor line. Scanning the full history
+          # of the beta manifest (not just its current value) keeps the counter
+          # monotonic even across the one-time history rewrite that lowered it, and
+          # regardless of the order PRs merge in. A new minor line has no prior
+          # betas, so it resets naturally (a higher minor sorts above regardless).
+          NEXT_MINOR_RE=$(printf '%s' "$NEXT_MINOR" | sed 's/\./\\./g')
+          HIST_MAX=$(git log origin/main -p -- smart_vent_beta/config.yaml 2>/dev/null \
+            | grep -oE "${NEXT_MINOR_RE}-beta\.[0-9]+" | sed 's/.*-beta\.//' | sort -n | tail -1)
+          if [ -n "$HIST_MAX" ] && [ "$BUILD" -le "$HIST_MAX" ]; then
+            BUILD=$((HIST_MAX + 1))
+          fi
+
+          BETA="${NEXT_MINOR}-beta.${BUILD}"
+          echo "Beta version for this PR: ${BETA} (monotonic on main; floored at prior betas)"
 
           sed -i "s/^version:.*/version: \"${BETA}\"/" smart_vent_beta/config.yaml
           bash .github/scripts/gen-beta-changelog.sh "${BETA}" > smart_vent_beta/CHANGELOG.md

--- a/smart_vent/backend/auth.py
+++ b/smart_vent/backend/auth.py
@@ -187,10 +187,14 @@ async def validate_ha_credentials(username: str, password: str) -> bool:
     the caller can return a 503 ("login backend unreachable") rather than a
     misleading 401.
 
-    NOTE (unverified against a live Supervisor — no HA in dev): the request shape
-    follows the developers.home-assistant.io "App security → Home Assistant user
-    backend" doc. Confirm the exact success/failure codes on a real supervised
-    install; only 200 is treated as success here.
+    The add-on token MUST be sent in the ``X-Supervisor-Token`` header, **not**
+    ``Authorization``. The ``/auth`` endpoint reserves the ``Authorization``
+    header for the *user's* Basic credentials, so a ``Bearer <supervisor-token>``
+    there is parsed as a (malformed) user login and **every** attempt fails with
+    a misleading 401 — regardless of the real password or whether MFA is set.
+    Send the add-on token via ``X-Supervisor-Token`` and the user credentials in
+    the JSON body (developers.home-assistant.io "Supervisor → Endpoints → auth").
+    Only HTTP 200 is treated as success.
     """
     token = os.environ.get("SUPERVISOR_TOKEN")
     if not token:
@@ -201,10 +205,16 @@ async def validate_ha_credentials(username: str, password: str) -> bool:
         http.post(
             SUPERVISOR_AUTH_URL,
             headers={
-                "Authorization": f"Bearer {token}",
+                "X-Supervisor-Token": token,
                 "Content-Type": "application/json",
             },
             json={"username": username, "password": password},
         ) as resp,
     ):
+        if resp.status != 200:
+            # A non-200 is not necessarily a bad password: 403 (auth_api not
+            # granted), 400 (bad request shape), or 5xx (Core/Supervisor down)
+            # all land here. Log the status so the cause is diagnosable in the
+            # add-on logs; the caller still returns a generic client message.
+            log.warning("Supervisor /auth returned HTTP %s", resp.status)
         return resp.status == 200

--- a/smart_vent/backend/tests/test_auth.py
+++ b/smart_vent/backend/tests/test_auth.py
@@ -178,7 +178,12 @@ async def test_validate_credentials_200_is_true(monkeypatch):
     assert await auth.validate_ha_credentials("alice", "pw") is True
     # Request shape: the add-on's Supervisor token + the exact credentials body.
     assert capture["url"] == auth.SUPERVISOR_AUTH_URL
-    assert capture["headers"]["Authorization"] == "Bearer tok"
+    # The add-on token goes in X-Supervisor-Token. It must NOT be sent in the
+    # Authorization header — the /auth endpoint treats Authorization as the
+    # user's Basic credentials, so a Bearer there fails every login (regression
+    # guard for the live-Supervisor login bug).
+    assert capture["headers"]["X-Supervisor-Token"] == "tok"
+    assert "Authorization" not in capture["headers"]
     assert capture["json"] == {"username": "alice", "password": "pw"}
 
 

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.31.0-beta.7 — building toward v0.31.0
+## 0.31.0-beta.21 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.31.0-beta.20 — building toward v0.31.0
+## 0.31.0-beta.7 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -13,3 +13,4 @@
 - Add Beta release track: prebuilt-image add-on auto-built on every main merge ([#466](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/466))
 - fix(beta.yml): valid YAML for the version-stamp step (unblock the beta workflow) ([#467](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/467))
 - beta: write the changelog inside each PR; build the image only on push to main ([#468](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/468))
+- fix(auth): use X-Supervisor-Token for the /auth login backend (#373) ([#469](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/469))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.31.0-beta.7"
+version: "0.31.0-beta.21"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.31.0-beta.20"
+version: "0.31.0-beta.7"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
Follow-up to #373 (#463). Two beta-channel fixes from testing the merged auth work on a live supervised install. Bundled into one PR (#470 folded in here and closed).

---

## Fix 1 — Direct-port login: use `X-Supervisor-Token`, not `Authorization`

**Symptom:** on the beta add-on, direct-port login failed for **every** HA user — with **and** without 2FA — with `Invalid username or password`:
```
[WARNING] backend.event_logger: [AUTH] Failed direct-port login attempt
"POST /api/auth/login HTTP/1.1" 401
```

**Root cause:** `validate_ha_credentials` sent the add-on's Supervisor token in the `Authorization` header as `Bearer <token>`. The Supervisor `/auth` endpoint reserves `Authorization` for the **user's** Basic credentials, so it parsed our add-on token as a malformed user login and returned a non-200; the route flattens any non-200 to `401`. `auth_api: true` was already set — the request shape was wrong.

**Fix:** send the add-on token in `X-Supervisor-Token` (the documented contract) with credentials in the JSON body, and log the Supervisor status on any non-200 so a future `403`/`5xx` is diagnosable instead of masked as a bad password. The data-path WebSocket auth to HA Core is unaffected.

Ref: developers.home-assistant.io — Supervisor → Endpoints → auth (`curl -H "X-Supervisor-Token: $SUPERVISOR_TOKEN" http://supervisor/auth`).

## Fix 2 — Beta version counter went backwards (`beta.20 → beta.7`)

**Symptom:** the `Update beta pointer (in PR)` job produced a **lower** beta number, so HA no longer offered updates.

**Root cause:** the build number was `git rev-list --count <tag>..HEAD` on the **PR branch** — not monotonic across squash merges. PR #463's large feature branch (~20 commits since `v0.30.0`) → `beta.20`; once squash-merged into main (1 commit), a fresh branch counts only ~6–7 → `beta.7`.

**Fix:**
- Count `origin/main` (linear, squash-merged mainline), not the PR branch → monotonic.
- Anti-regression floor: never emit a number `≤` the highest `beta.N` ever recorded in main's **history** of `smart_vent_beta/config.yaml`, so it's correct across the one-time regression and regardless of merge order.

Validated against the repo: now yields `0.31.0-beta.21` (> published `beta.20`). This PR carries the fixed workflow, so its own pointer job self-corrects the branch pointer to `beta.21`.

---

## Test plan

- `test_auth.py`: updated `test_validate_credentials_200_is_true` to assert `X-Supervisor-Token` is sent and `Authorization` is absent (regression guard). Full auth suite: **20 passed**; ruff + mypy clean.
- `beta.yml`: validated as well-formed YAML; the embedded version logic dry-run produces `0.31.0-beta.21`.
- Neither Supervisor path is exercisable in dev (no Supervisor), but the login header now matches the documented contract the live failure violated.

## Notes

- The MFA limitation is unchanged and tracked in #464 (direct-port login is first-factor-only; ingress enforces MFA). This PR just makes first-factor login work at all.
- "Where's the new auth UI?" was the same root cause: with `require_auth` on, the MCP-token card + login/logout are gated behind a successful login (or ingress). Direct-port login always 401'd, so that UI never rendered on the direct port. Via HA **ingress** the MCP-token card already shows on the **Thermostats** page; after this fix the direct port works too.