### PR TITLE
fix(beta): monotonic beta version counter (count main + anti-regression floor)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -65,20 +65,46 @@ jobs:
         run: |
           git fetch --tags --quiet origin
           git fetch --quiet origin main
-          # Betas build toward the NEXT MINOR, counted from the last minor tag
-          # (v*.*.0), excluding the workflow's own smart_vent_beta/ commits.
+          # Betas build toward the NEXT MINOR after the last minor tag (v*.*.0).
           LAST_MINOR_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.0' 2>/dev/null || echo "")
           if [ -z "$LAST_MINOR_TAG" ]; then
             BASE="0.0.0"
-            BUILD=$(git rev-list --count HEAD)
           else
             BASE="${LAST_MINOR_TAG#v}"
-            BUILD=$(git rev-list --count "${LAST_MINOR_TAG}..HEAD" -- ':!smart_vent_beta' 2>/dev/null \
-                    || git rev-list --count "${LAST_MINOR_TAG}..HEAD")
           fi
           IFS=. read -r MAJ MIN PAT <<< "$BASE"
-          BETA="${MAJ}.$((MIN + 1)).0-beta.${BUILD}"
-          echo "Beta version for this PR: ${BETA} (toward the next minor)"
+          NEXT_MINOR="${MAJ}.$((MIN + 1)).0"
+
+          # Build counter is derived from origin/main (the linear, squash-merged
+          # mainline) — NOT this PR's branch. Counting the branch was the bug: a
+          # large feature branch inflated the count while a fix branched off the
+          # squash-merged main deflated it, so the beta version went BACKWARDS
+          # (0.31.0-beta.20 -> -beta.7) and Home Assistant stopped offering the
+          # update. main only ever grows, so counting it is monotonic across
+          # squash merges. ':!smart_vent_beta' excludes this job's own pointer
+          # commits from the count.
+          if [ -z "$LAST_MINOR_TAG" ]; then
+            BUILD=$(git rev-list --count origin/main)
+          else
+            BUILD=$(git rev-list --count "${LAST_MINOR_TAG}..origin/main" -- ':!smart_vent_beta' 2>/dev/null \
+                    || git rev-list --count "${LAST_MINOR_TAG}..origin/main")
+          fi
+
+          # Anti-regression floor: never emit a beta number <= the highest one
+          # ALREADY recorded on main for this minor line. Scanning the full history
+          # of the beta manifest (not just its current value) keeps the counter
+          # monotonic even across the one-time history rewrite that lowered it, and
+          # regardless of the order PRs merge in. A new minor line has no prior
+          # betas, so it resets naturally (a higher minor sorts above regardless).
+          NEXT_MINOR_RE=$(printf '%s' "$NEXT_MINOR" | sed 's/\./\\./g')
+          HIST_MAX=$(git log origin/main -p -- smart_vent_beta/config.yaml 2>/dev/null \
+            | grep -oE "${NEXT_MINOR_RE}-beta\.[0-9]+" | sed 's/.*-beta\.//' | sort -n | tail -1)
+          if [ -n "$HIST_MAX" ] && [ "$BUILD" -le "$HIST_MAX" ]; then
+            BUILD=$((HIST_MAX + 1))
+          fi
+
+          BETA="${NEXT_MINOR}-beta.${BUILD}"
+          echo "Beta version for this PR: ${BETA} (monotonic on main; floored at prior betas)"
 
           sed -i "s/^version:.*/version: \"${BETA}\"/" smart_vent_beta/config.yaml
           bash .github/scripts/gen-beta-changelog.sh "${BETA}" > smart_vent_beta/CHANGELOG.md

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.31.0-beta.20 — building toward v0.31.0
+## 0.31.0-beta.21 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -13,3 +13,4 @@
 - Add Beta release track: prebuilt-image add-on auto-built on every main merge ([#466](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/466))
 - fix(beta.yml): valid YAML for the version-stamp step (unblock the beta workflow) ([#467](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/467))
 - beta: write the changelog inside each PR; build the image only on push to main ([#468](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/468))
+- fix(beta): monotonic beta version counter (count main + anti-regression floor) ([#470](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/470))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.31.0-beta.20"
+version: "0.31.0-beta.21"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## Problem

The **"Update beta pointer (in PR)"** job made the beta version go **backwards** — `0.31.0-beta.20 → 0.31.0-beta.7` — so Home Assistant no longer sees new betas as updates and the channel silently stalls.

## Root cause

The build number was `git rev-list --count <last-minor-tag>..HEAD` measured on the **PR branch**. That is not monotonic across **squash merges**:

| | commits since `v0.30.0` |
|---|---|
| PR #463's feature branch (unsquashed, ~20 commits) | **20** → `beta.20` |
| `origin/main` after #463 squash-merged (1 commit) | 6 |
| a fresh fix branch off that main | **7** → `beta.7` ⬇️ |

A large feature branch inflates the count; once it squash-merges into main, the same "commits since tag" measured on any later branch is far lower — so the pointer regresses.

## Fix

- **Count `origin/main`, not the PR branch.** main is linear and only grows, so the count is monotonic across squash merges.
- **Anti-regression floor.** Never emit a beta number `<=` the highest already recorded on main for this minor line. It scans the **full git history** of `smart_vent_beta/config.yaml` (not just the current value), so the counter stays monotonic even across the one-time history rewrite that lowered it — and regardless of the order PRs merge in. A new minor line has no prior betas and resets naturally (a higher minor sorts above regardless of the beta number).

## Result (validated against the current repo state)

```
NEXT_MINOR=0.31.0   raw count(main)=6   HIST_MAX(history)=20   =>  0.31.0-beta.21
```

`0.31.0-beta.21 > 0.31.0-beta.20`, so HA offers it as an update, and every subsequent merge increments by one. Once the natural main count overtakes the historical max, the floor stops applying and it reverts to plain "commits since minor."

## Test plan

- Dry-ran the exact embedded logic against this repo: produces `0.31.0-beta.21` (previously would have produced `0.31.0-beta.7`).
- `beta.yml` validated as well-formed YAML; both jobs (`update-pointer`, `publish-image`) parse.
- The `publish-image` job (reads the version and builds on push to main) is unchanged.

## Notes

- Known, pre-existing limitation left as-is: two PRs open concurrently can compute the same number; sequential merges (the norm here) are strictly monotonic.
- Because the floor reads main's history, this fix corrects the counter **regardless of merge order** relative to other open PRs (e.g. #469) — the historical `beta.20` anchor survives even if a branch with the old logic lands first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke5R9SXFp5mse8Nx1Ffd6g)_