### PR TITLE
Document OIDC/OAuth2 auth-proxy option for cloud MCP connectors

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -81,6 +81,110 @@ management). A call that exceeds the token's scope is rejected with `403`. See
 > **unauthenticated** — anyone who can reach the published port has full
 > read/write control. Only do this on a trusted network.
 
+## Cloud connectors & OIDC clients (an OAuth2 auth proxy)
+
+The bearer-token flow above works for any client that lets you set a static
+`Authorization` header — a local `mcpServers` config, a script, `curl`. Some
+clients don't work that way. **Hosted "custom connectors"** — Claude's cloud/web
+custom connectors, OpenAI's connectors, and other remote MCP providers — expect
+the server to speak the MCP **OAuth 2.1 authorization flow** (metadata discovery,
+dynamic client registration, an interactive login) and to be reachable at a
+public HTTPS URL. Plenum only issues **static bearer tokens**, so those clients
+cannot attach to `/mcp` directly.
+
+The bridge is to put an **OIDC-aware auth proxy in front of Plenum's MCP port**.
+The proxy presents the OAuth/OIDC front end the connector expects, authenticates
+each user against *your own* identity provider (Authelia, Authentik, Keycloak,
+Google, Microsoft Entra ID, …), and — once a user is allowed through — forwards
+the request upstream to Plenum's `/mcp` with a static bearer token attached:
+
+```
+Claude / OpenAI connector ──OAuth 2.1 / OIDC──▶ auth proxy ──Bearer token──▶ Plenum :9099 /mcp
+      (interactive login via your IdP)                     (injected upstream)
+```
+
+> **⚠️ Third-party software — not part of Plenum, not endorsed, no affiliation.**
+> The example below uses [`sigbit/mcp-auth-proxy`](https://github.com/sigbit/mcp-auth-proxy),
+> a third-party project and container image. **Plenum's maintainer does not
+> endorse it, is not affiliated with the `sigbit/mcp-auth-proxy` project or its
+> image in any way, and has not vetted or hardened it.** It is shown here only as
+> one personal setup that happens to work — *not* a recommendation, and it is
+> neither shipped nor supported by Plenum. Any OAuth2/OIDC proxy that can inject
+> an upstream bearer token will do the same job. If you run one, the security
+> review is yours: read its source, pin the image to a digest, and keep it
+> patched.
+
+### Example: `mcp-auth-proxy` via Docker Compose
+
+```yaml
+services:
+  plenum-mcp-auth-proxy:
+    container_name: plenum-mcp-auth
+    image: ghcr.io/sigbit/mcp-auth-proxy:latest
+    mem_limit: 128m
+    ports:
+      - "6479:80"
+    environment:
+      - EXTERNAL_URL=https://plenum-mcp.your-fqdn.com
+      - TLS_ACCEPT_TOS=false
+      - NO_AUTO_TLS=true
+      - OIDC_CONFIGURATION_URL=https://auth.your-fqdn.com/.well-known/openid-configuration
+      - OIDC_CLIENT_ID=XXXXXXXX-1XX8-4XX3-bXX7-aXXXXXXXXXXc
+      - OIDC_CLIENT_SECRET=REPLACE_WITH_YOUR_OIDC_CLIENT_SECRET
+      - OIDC_SCOPES=openid,email,groups
+      - OIDC_ALLOWED_USERS_GLOB=*
+      - PROXY_BEARER_TOKEN=REPLACE_WITH_YOUR_MINTED_TOKEN
+      - TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    volumes:
+      - ./data:/data
+    command: ["http://HOME-ASSISTANT-IP:9099/mcp"]
+    restart: always
+```
+
+What the pieces do (consult the proxy's own docs for the authoritative list):
+
+| Setting | What it does |
+|---|---|
+| **`EXTERNAL_URL`** | Public HTTPS URL your connector points at. Must match the address your reverse proxy serves. |
+| **`TLS_ACCEPT_TOS` / `NO_AUTO_TLS`** | Both are set here to **disable** the proxy's built-in ACME/Let's Encrypt, because TLS is terminated by a separate reverse proxy (below). Flip them if you want the proxy to obtain its own certificate instead. |
+| **`OIDC_CONFIGURATION_URL`** | Your identity provider's OpenID Connect discovery document (`…/.well-known/openid-configuration`). |
+| **`OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET`** | The OAuth client you register with that IdP for this proxy. |
+| **`OIDC_SCOPES`** | Scopes requested at login. |
+| **`OIDC_ALLOWED_USERS_GLOB`** | Which authenticated users may pass. `*` allows **everyone** your IdP authenticates — narrow this to specific users/emails/groups in production. |
+| **`PROXY_BEARER_TOKEN`** | The **Plenum-minted MCP token** the proxy injects on every upstream request. Mint it in Plenum (**Settings** → **MCP access tokens**) and paste it here. |
+| **`TRUSTED_PROXIES`** | CIDRs the proxy trusts for `X-Forwarded-*` headers (your reverse proxy / LAN). |
+| **`command: ["http://HOME-ASSISTANT-IP:9099/mcp"]`** | The **upstream** MCP endpoint the proxy forwards to — Plenum's host + published `9099/tcp` + `/mcp`. |
+| **`ports: "6479:80"`** | Host port your reverse proxy targets. |
+
+> **Reverse proxy / TLS is out of scope.** This example assumes you *already*
+> have a reverse proxy terminating TLS for `https://plenum-mcp.your-fqdn.com` and
+> forwarding it to host port `6479`. Standing up that proxy and its certificate
+> is your responsibility and is not covered here — any mainstream reverse proxy
+> (Nginx Proxy Manager, Traefik, Caddy, or Home Assistant's own) will do.
+
+### Wiring it up
+
+1. **Turn MCP on in Plenum** (settings cog (⚙️) → **MCP**) and publish `9099/tcp`
+   only on the internal network the proxy can reach. **Do not expose `9099`
+   publicly** — the auth proxy is meant to be the *only* public door; firewall
+   the raw port off the internet.
+2. **Keep `require_auth` on.** The proxy authenticates *who* connects; Plenum's
+   own bearer check is still what protects `/mcp`, so leave it enabled and give
+   the proxy a real token.
+3. **Mint the token with least privilege.** Every user allowed through the proxy
+   shares the single `PROXY_BEARER_TOKEN`, so they all inherit its scope. Pick the
+   smallest scope you need — `read` for inspection-only, `write` to allow config
+   changes — rather than `destructive`. The OIDC allowlist gates *who* connects;
+   the token scope gates *what* they can do, and it is the same for everyone
+   behind the proxy.
+4. **Register an OAuth client** with your identity provider and fill in the
+   `OIDC_*` values.
+5. **Add the server in your connector** (Claude custom connector, OpenAI, or
+   another OAuth-capable MCP client) by its public URL. The connector runs the
+   OAuth login against your IdP; on success the proxy forwards the session to
+   Plenum's `/mcp`. The exact path to enter (e.g. `…/mcp`) is dictated by the
+   proxy — check its documentation.
+
 ## Use cases
 
 - "List all my rooms and show me which ones don't have a presence sensor."

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.31.0-beta.23 — building toward v0.31.0
+## 0.31.0-beta.24 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -16,3 +16,4 @@
 - fix(auth+beta): X-Supervisor-Token login + monotonic beta version (#373) ([#469](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/469))
 - Dedicated Settings page: MCP server + tokens + Backup/Restore, fix cramped MCP modal (#471) ([#472](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/472))
 - chore(Increment Beta Version) ([#473](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/473))
+- Document OIDC/OAuth2 auth-proxy option for cloud MCP connectors ([#474](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/474))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.31.0-beta.23"
+version: "0.31.0-beta.24"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## What changed

Adds a new **"Cloud connectors & OIDC clients (an OAuth2 auth proxy)"** section to `docs/mcp.md`, between the existing Authentication and Use cases sections. It documents how to attach hosted MCP "custom connectors" — Claude's cloud/web custom connectors, OpenAI's connectors, and other remote MCP providers — to Plenum's MCP server.

The section covers:
- **Why a bridge is needed:** those clients speak the MCP OAuth 2.1 authorization flow (metadata discovery, dynamic client registration, interactive login) against a public HTTPS URL, whereas Plenum only issues static bearer tokens — so they can't attach to `/mcp` directly.
- **The pattern:** put an OIDC-aware auth proxy in front of Plenum's MCP port. It presents the OAuth/OIDC front end the connector expects, authenticates each user against your own identity provider, and forwards upstream to `/mcp` with a minted Plenum bearer token injected.
- **A Docker Compose example** using `sigbit/mcp-auth-proxy`, an **env-var reference table** explaining each setting, and a **wiring checklist** (turn MCP on, keep `require_auth` on, mint a least-privilege token, register the OAuth client, add the server in your connector).
- A callout that the **TLS-terminating reverse proxy is out of scope**.
- A prominent disclaimer that the example image is **third-party, unaffiliated, and unendorsed** — shown only as one personal setup, not a recommendation, and neither shipped nor supported by Plenum.

## Why

Requested by the maintainer to give users a documented path for OIDC-based cloud connectors. Plenum's built-in MCP auth is static-bearer-only (per `docs/auth.md`), which hosted connectors can't consume; this documents the standard front-a-proxy bridge without changing any code.

## Notes

- Docs-only change — one file (`docs/mcp.md`, +104 lines). No code, config, or API surface touched.
- The maintainer's supplied example was sanitized before publishing: the real-looking `OIDC_CLIENT_SECRET` was replaced with a `REPLACE_WITH_…` placeholder, and the `authyour-fqdn.com` typo corrected to `auth.your-fqdn.com`.

## Test plan

- [x] Reviewed the rendered Markdown for correct headings, table, code fences, and blockquote callouts; house style (sentence-case noun-phrase headings, bold UI paths, backticked env vars) matches the rest of `docs/`.
- [x] Verified no secrets or real hostnames are committed.
- [x] Pre-commit gate (frontend ESLint + vitest coverage, backend ruff) ran green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012MN1Hr6vPbvrFibwqhbRjg)_