### PR TITLE
Add OIDC single sign-on for the web UI (#464)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -68,12 +68,15 @@ and, if unauthenticated, renders a login screen.
   MFA/TOTP step, so direct-port login is not MFA-enforced (see known
   limitations). It also requires a Supervisor, so it is unavailable in
   standalone/plain-Docker deployments.
-- **Session:** on success the backend sets a **stateless, HMAC-signed session
-  cookie** — `HttpOnly` (invisible to JavaScript, so XSS can't steal it),
-  `SameSite=Strict` (not sent cross-site), and `Secure` **whenever the request
-  is over TLS**. The signing secret is a per-install random value persisted to a
-  file **outside `app.db`** (`<data-dir>/.session_secret`, mode `0600`), so a
-  downloaded database backup cannot be used to forge sessions.
+- **Session:** on success the backend sets a **stateless, signed session
+  cookie** — an **HS256 JWT** (minted/verified with `joserfc`, the same JOSE
+  library the OIDC login uses; decoding pins the algorithm so a token claiming a
+  different `alg` is refused) — marked `HttpOnly` (invisible to JavaScript, so
+  XSS can't steal it), `SameSite=Strict` (not sent cross-site), and `Secure`
+  **whenever the request is over TLS**. The signing secret is a per-install
+  random value persisted to a file **outside `app.db`**
+  (`<data-dir>/.session_secret`, mode `0600`), so a downloaded database backup
+  cannot be used to forge sessions.
 
 The SPA shell and static assets are always served (they carry no data); the
 trust boundary is the API underneath, plus `/api/healthz` stays open for the
@@ -120,7 +123,7 @@ partial configuration logs a warning and leaves the HA-password login in place.
   claims (`joserfc`), checks the allowlist, then issues the **same** signed
   session cookie as the password path (so the session model is identical).
 - **CSRF / state.** The `state`, PKCE `code_verifier`, and `nonce` ride in a
-  short-lived, HMAC-signed `plenum_oidc_state` cookie (`SameSite=Lax` so it
+  short-lived, signed (HS256 JWT) `plenum_oidc_state` cookie (`SameSite=Lax` so it
   survives the redirect back from the IdP) — nothing is written to `app.db`, so a
   backup still can't forge a login.
 - **Algorithm pinning.** ID tokens must be signed with an asymmetric algorithm

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -20,7 +20,7 @@ the *non-ingress* surfaces are gated:
 
 | `require_auth` | HA ingress | Direct port (8099) | MCP (9099) |
 |---|---|---|---|
-| `true` (default) | trusted, no login | **login required** (HA account → session cookie) | **bearer token required** |
+| `true` (default) | trusted, no login | **login required** (HA account, or OIDC SSO — see below — → session cookie) | **bearer token required** |
 | `false` (legacy) | trusted, no login | open (pre-#373 behavior) | open |
 
 Because ingress is always trusted, turning the switch **on by default does not
@@ -78,6 +78,57 @@ and, if unauthenticated, renders a login screen.
 The SPA shell and static assets are always served (they carry no data); the
 trust boundary is the API underneath, plus `/api/healthz` stays open for the
 container health probe.
+
+## OIDC single sign-on (optional, closes the two direct-port gaps)
+
+The HA-account login above has two limitations: it validates only the first
+factor (no MFA — HA's TOTP step runs in its interactive login flow, not the
+add-on `/auth` backend), and it needs a Supervisor (so standalone / plain-Docker
+installs can't use it). **OpenID Connect single sign-on** closes both: you point
+Plenum at your own identity provider (Authelia, Authentik, Keycloak, Google,
+Microsoft Entra ID, …), the IdP enforces MFA, and no Supervisor is required.
+
+When OIDC is configured, the direct-port login screen shows a **"Sign in with
+&lt;provider&gt;"** button instead of the username/password form, and the
+HA-password login route is **disabled server-side** (returns `403`) — so the
+weaker first-factor-only path can't be reached even by calling the endpoint
+directly. **Ingress is unaffected** (always trusted, never sees this). **MCP is
+unaffected** — it keeps its bearer tokens; to add SSO in front of the MCP port,
+see `docs/mcp.md`.
+
+**OIDC is configured entirely outside the Plenum UI** — via add-on options (the
+Supervisor **Configuration** tab) or container environment variables — so an
+unauthenticated visitor can never reach the configuration, and you never have to
+disable auth to reach the UI off-HAOS. Each add-on option key uppercases to the
+env var of the same name, so standalone Docker sets the env var directly:
+
+| Add-on option / env var | Required | Meaning |
+|---|---|---|
+| `oidc_configuration_url` / `OIDC_CONFIGURATION_URL` | yes | Your IdP's `…/.well-known/openid-configuration` discovery URL. |
+| `oidc_client_id` / `OIDC_CLIENT_ID` | yes | The OAuth client you register with the IdP for Plenum. |
+| `oidc_client_secret` / `OIDC_CLIENT_SECRET` | yes | That client's secret (a `password`-typed option, masked in the add-on UI). |
+| `plenum_external_url` / `PLENUM_EXTERNAL_URL` | yes | Public base URL of the Plenum web UI. The **redirect URI** is `<plenum_external_url>/api/auth/oidc/callback` — register exactly that at your IdP. |
+| `oidc_scopes` / `OIDC_SCOPES` | no | Space-separated scopes (default `openid email profile`; `openid` is added if you omit it). |
+| `oidc_allowed_users_glob` / `OIDC_ALLOWED_USERS_GLOB` | no | Glob over the authenticated identity (email, then username, then `sub`) allowed in. Default `*` (**anyone** your IdP authenticates — narrow this in production, e.g. `*@example.com`). |
+| `oidc_provider_name` / `OIDC_PROVIDER_NAME` | no | Label for the button, e.g. `Authelia` (default `SSO`). |
+
+OIDC is treated as configured only when the four required values are all set; a
+partial configuration logs a warning and leaves the HA-password login in place.
+
+- **Flow.** Standard OAuth 2.1 **Authorization Code + PKCE**. The IdP validates
+  the login (and MFA); Plenum validates the returned ID token's signature and
+  claims (`joserfc`), checks the allowlist, then issues the **same** signed
+  session cookie as the password path (so the session model is identical).
+- **CSRF / state.** The `state`, PKCE `code_verifier`, and `nonce` ride in a
+  short-lived, HMAC-signed `plenum_oidc_state` cookie (`SameSite=Lax` so it
+  survives the redirect back from the IdP) — nothing is written to `app.db`, so a
+  backup still can't forge a login.
+- **Algorithm pinning.** ID tokens must be signed with an asymmetric algorithm
+  (`RS*`/`ES*`/`PS*`); `alg: none` and symmetric `HS*` are refused, defeating the
+  classic key-confusion attack.
+- **Run behind TLS.** As with the password path, the session cookie is `Secure`
+  only over TLS, and OAuth redirect URIs should be HTTPS — terminate TLS in front
+  and forward the original `Host`/scheme so the redirect URI matches.
 
 ## MCP bearer tokens
 
@@ -144,24 +195,25 @@ backwards-compatibility guarantee.
   relying on it in production. The exact resolved Supervisor IP, the `/auth`
   success/failure codes, and whether the ingress **WebSocket** upgrade carries
   the expected headers each need a real supervised environment to verify.
-- **Direct-port login is first-factor only (no MFA/2FA).** The web-UI login
-  validates your HA username + password against the Supervisor `/auth` backend,
-  which does **not** run Home Assistant's MFA/TOTP step — MFA lives in HA's
-  interactive `login_flow`, not the add-on auth backend. A user with 2FA enabled
-  can therefore sign in to a published port with just their password. **Ingress
-  is unaffected:** ingress users authenticate through HA's real login flow, so
-  MFA *is* enforced on the ingress path. If you need MFA end-to-end for external
-  access, use ingress, or front the direct port with an authenticating reverse
-  proxy. An MFA-aware login via HA's `login_flow` is tracked as a follow-up.
-- **Standalone / plain-Docker (no Supervisor) can't use `require_auth` login.**
-  Direct-port login needs the Supervisor `/auth` backend; with no Supervisor the
-  login endpoint returns `503`, and since nothing is classifiable as ingress
-  either, the UI becomes unreachable when `require_auth` is on. Run the add-on
-  under Home Assistant to use `require_auth`, or in standalone Docker keep
-  `require_auth=false` and put an authenticating reverse proxy (e.g. oauth2-proxy
-  / Authelia) in front of the port. The long-lived `HA_TOKEN` used for the HA
-  data connection **cannot** validate user credentials, so it is not a
-  substitute. Supervisor-independent login is tracked as a follow-up.
+- **HA-password direct-port login is first-factor only (no MFA/2FA) — configure
+  OIDC for MFA.** The HA username/password login validates against the Supervisor
+  `/auth` backend, which does **not** run Home Assistant's MFA/TOTP step (that
+  lives in HA's interactive login flow). A user with 2FA enabled can therefore
+  sign in to a published port with just their password. **Ingress is unaffected**
+  (ingress users go through HA's real login flow, so MFA *is* enforced there). To
+  enforce MFA on the direct port, configure **OIDC single sign-on** (above) — the
+  IdP enforces MFA and the HA-password path is then disabled — or front the port
+  with an authenticating reverse proxy.
+- **Standalone / plain-Docker (no Supervisor): use OIDC, or keep
+  `require_auth=false`.** The HA-password login needs the Supervisor `/auth`
+  backend; with no Supervisor it returns `503`, and since nothing is classifiable
+  as ingress either, the UI would be unreachable when `require_auth` is on **and**
+  OIDC is not configured. Fixes, in order of preference: (1) configure **OIDC
+  single sign-on** (above) — it needs no Supervisor and gives a working,
+  MFA-capable login; (2) keep `require_auth=false` and put an authenticating
+  reverse proxy (oauth2-proxy / Authelia) in front of the port. The long-lived
+  `HA_TOKEN` used for the HA data connection **cannot** validate user credentials,
+  so it is not a substitute.
 - **No login rate-limiting yet.** Brute-force protection relies on the Home
   Assistant backend and the fact that the direct port is unpublished by default;
   a per-IP throttle is a candidate future hardening.

--- a/e2e/auth-cookie.ts
+++ b/e2e/auth-cookie.ts
@@ -1,4 +1,4 @@
-// Session-cookie helper for the authentication visual-regression leg (#373).
+// Session-cookie helper for the authentication visual-regression leg (#373/#476).
 //
 // The auth E2E stack (docker-compose.test.auth.yml) runs Plenum with
 // require_auth=true and no Home Assistant Supervisor, so every request is
@@ -8,6 +8,12 @@
 // mirrors backend/session.py::issue_token exactly — verified to round-trip
 // against the Python verifier.
 //
+// Since #476 the session cookie is an HS256 JWT (backend/session.py mints/checks
+// it via joserfc), so this produces the JWS compact serialization
+// `base64url(header).base64url(payload).base64url(HMAC_SHA256(input))`. The
+// backend decodes with algorithms=["HS256"], so the minimal `{"alg":"HS256"}`
+// header is sufficient.
+//
 // The secret below is a TEST-ONLY fixed value; it is used only by this E2E
 // stack and never appears in a real deployment.
 
@@ -16,22 +22,22 @@ import { createHmac } from "crypto";
 export const E2E_SESSION_SECRET = "gjncHw3UQkBNvHhgRDhN5hQRcNpmvK48UPmZz-IV1PA";
 export const SESSION_COOKIE = "plenum_session";
 
+const b64url = (s: string): string => Buffer.from(s, "utf-8").toString("base64url");
+
 /**
- * Mint a Plenum session token, byte-for-byte compatible with
- * backend/session.py::issue_token:
- *   token = base64url(payload) + "." + base64url(HMAC_SHA256(secret, payload))
- *   payload = {"exp","iat","sub"}  (keys sorted, compact separators)
- * exp/iat use real time (session verification checks the wall clock, not the
- * pinned test clock) — the token itself is never rendered, so this doesn't
- * affect golden determinism.
+ * Mint a Plenum session token — an HS256 JWT accepted by
+ * backend/session.py::verify_token (joserfc, pinned to HS256). exp/iat use real
+ * time (session verification checks the wall clock, not the pinned test clock);
+ * the token itself is never rendered, so this doesn't affect golden determinism.
  */
 export function mintSession(user = "e2e-admin", ttlSeconds = 7 * 24 * 3600): string {
   const secret = Buffer.from(E2E_SESSION_SECRET, "base64url");
   const now = Math.floor(Date.now() / 1000);
-  const payload = JSON.stringify({ exp: now + ttlSeconds, iat: now, sub: user });
-  const raw = Buffer.from(payload, "utf-8").toString("base64url");
-  const sig = createHmac("sha256", secret).update(raw).digest("base64url");
-  return `${raw}.${sig}`;
+  const header = b64url(JSON.stringify({ alg: "HS256" }));
+  const payload = b64url(JSON.stringify({ sub: user, iat: now, exp: now + ttlSeconds }));
+  const signingInput = `${header}.${payload}`;
+  const sig = createHmac("sha256", secret).update(signingInput).digest("base64url");
+  return `${signingInput}.${sig}`;
 }
 
 /** True when the current E2E run targets the auth (require_auth=true) stack. */

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -23,7 +24,7 @@ from typing import Any
 import aiohttp
 from aiohttp import web
 
-from .. import auth, db, demo_seed, scopes, session, tz
+from .. import auth, db, demo_seed, oidc, scopes, session, tz
 from ..engine import room_manager
 from ..models import (
     VALID_CONTROL_METHODS,
@@ -413,8 +414,19 @@ async def auth_status(request: web.Request) -> web.Response:
     else:
         method = "none"
     authenticated = method != "none"
+    provider = request.app.get("oidc")
     return json_response(
-        {"require_auth": require_auth, "authenticated": authenticated, "method": method}
+        {
+            "require_auth": require_auth,
+            "authenticated": authenticated,
+            "method": method,
+            # OIDC single sign-on (#464). When enabled, the login screen renders a
+            # "Sign in with <provider>" button pointing at oidc_login_url instead
+            # of the (server-side-disabled) HA username/password form.
+            "oidc_enabled": provider is not None,
+            "oidc_provider_name": provider.config.provider_name if provider else "",
+            "oidc_login_url": oidc.LOGIN_PATH if provider else "",
+        }
     )
 
 
@@ -430,7 +442,17 @@ async def login(request: web.Request) -> web.Response:
     ``require_auth`` is on and the caller is on a direct port — ingress users are
     already trusted and never see this. The password is forwarded to Home
     Assistant and never stored.
+
+    When OIDC single sign-on is configured (#464) this route is **disabled**
+    (403): OIDC replaces the password path, so we refuse the weaker
+    first-factor-only login here too — not just hide it in the UI — so knowing
+    the endpoint can't be used to bypass the IdP (and its MFA).
     """
+    if request.app.get("oidc") is not None:
+        return error(
+            "Password login is disabled; sign in with single sign-on instead",
+            status=403,
+        )
     try:
         body = await request.json()
     except json.JSONDecodeError:
@@ -477,6 +499,146 @@ async def logout(request: web.Request) -> web.Response:
     auth middleware so a stale/expired session can still log out cleanly."""
     resp = json_response({"ok": True})
     session.clear_session_cookie(resp)
+    return resp
+
+
+def _found(location: str) -> web.Response:
+    """A 302 redirect as a plain ``web.Response``.
+
+    We deliberately do NOT use ``web.HTTPFound``: *returning* an HTTPException is
+    deprecated in aiohttp, and a plain response also flows through the middleware
+    chain (so it still gets security headers) and lets us attach cookies before
+    returning it."""
+    return web.Response(status=302, headers={"Location": location})
+
+
+def _oidc_redirect(location: str, reason: str) -> web.Response:
+    """Redirect the browser back to the SPA after an OIDC failure, tagging the URL
+    with ``?login_error=<reason>`` so the login page can show a message. ``reason``
+    is always an internal constant (never user input), so there is nothing to
+    escape."""
+    sep = "&" if "?" in location else "?"
+    return _found(f"{location}{sep}login_error={reason}")
+
+
+@docs(tags=["auth"], summary="Begin OIDC single sign-on (redirects to the identity provider)")
+@response_schema(schemas.SuccessSchema)
+@routes.get("/api/auth/oidc/login")
+async def oidc_login(request: web.Request) -> web.StreamResponse:
+    """Start the Authorization Code + PKCE flow (#464): build the IdP
+    authorization URL, stash the login-flow state (CSRF ``state`` + PKCE verifier
+    + nonce) in a short-lived HMAC-signed cookie, and 302 the browser to the IdP.
+
+    404 when OIDC is not configured (there is nothing to sign in to)."""
+    provider = request.app.get("oidc")
+    if provider is None:
+        return error("OIDC single sign-on is not configured", status=404)
+    try:
+        auth_url, state_blob = await provider.authorization_url()
+    except Exception:
+        # Discovery/network failure — never leak upstream detail (CWE-209).
+        log.exception("Failed to build the OIDC authorization URL")
+        return error("Single sign-on is temporarily unavailable", status=502)
+    resp = _found(auth_url)
+    blob = session.issue_signed_blob(
+        request.app["session_secret"], state_blob, ttl=oidc.STATE_TTL_SECONDS
+    )
+    # SameSite=Lax (not Strict): the browser must send this on the top-level
+    # cross-site redirect back from the IdP, which Strict would drop.
+    resp.set_cookie(
+        oidc.STATE_COOKIE,
+        blob,
+        max_age=oidc.STATE_TTL_SECONDS,
+        httponly=True,
+        secure=request.secure,
+        samesite="Lax",
+        path="/",
+    )
+    return resp
+
+
+@docs(tags=["auth"], summary="OIDC redirect callback (completes single sign-on)")
+@query_params(
+    [
+        {
+            "name": "code",
+            "schema": {"type": "string"},
+            "description": "Authorization code returned by the identity provider.",
+        },
+        {
+            "name": "state",
+            "schema": {"type": "string"},
+            "description": "Opaque CSRF state echoed by the IdP; must match the signed state cookie.",
+        },
+        {
+            "name": "error",
+            "schema": {"type": "string"},
+            "description": "Error code when the IdP aborts the sign-in (e.g. access_denied).",
+        },
+    ]
+)
+@response_schema(schemas.SuccessSchema)
+@routes.get("/api/auth/oidc/callback")
+async def oidc_callback(request: web.Request) -> web.StreamResponse:
+    """Handle the IdP redirect (#464): validate the CSRF ``state`` against the
+    signed cookie, exchange the code, validate the ID token (incl. nonce),
+    enforce the allowlist, and on success mint the standard session cookie and
+    redirect into the app. Any failure redirects back to the login screen with a
+    generic ``?login_error`` tag — never an upstream error string."""
+    provider = request.app.get("oidc")
+    if provider is None:
+        return error("OIDC single sign-on is not configured", status=404)
+    app_root = provider.config.app_root
+
+    if request.query.get("error"):
+        # The IdP itself rejected/aborted (e.g. the user cancelled consent).
+        await emit(
+            request,
+            "warning",
+            "auth",
+            "OIDC sign-in was not completed at the identity provider",
+            {"error": request.query.get("error")},
+        )
+        return _oidc_redirect(app_root, "sso_cancelled")
+
+    code = request.query.get("code")
+    state = request.query.get("state")
+    raw_cookie = request.cookies.get(oidc.STATE_COOKIE)
+    blob = (
+        session.verify_signed_blob(request.app["session_secret"], raw_cookie)
+        if raw_cookie
+        else None
+    )
+    if (
+        not code
+        or not state
+        or blob is None
+        or not hmac.compare_digest(state, str(blob.get("state", "")))
+    ):
+        # Missing/expired/mismatched state — CSRF guard or a stale login tab.
+        return _oidc_redirect(app_root, "sso_state")
+
+    try:
+        identity = await provider.complete_login(code, str(blob["verifier"]), str(blob["nonce"]))
+    except oidc.OIDCForbidden as exc:
+        await emit(
+            request,
+            "warning",
+            "auth",
+            "OIDC sign-in rejected: user not on the allowlist",
+            {"user": exc.identity},
+        )
+        return _oidc_redirect(app_root, "sso_forbidden")
+    except Exception:
+        # Token exchange / ID-token validation failed. Log for diagnosis; the
+        # user gets a generic failure (CWE-209).
+        log.exception("OIDC callback failed during token exchange / validation")
+        return _oidc_redirect(app_root, "sso_failed")
+
+    resp = _found(app_root)
+    session.set_session_cookie(resp, request.app["session_secret"], identity, secure=request.secure)
+    resp.del_cookie(oidc.STATE_COOKIE, path="/")
+    await emit(request, "info", "auth", "OIDC sign-in succeeded", {"user": identity})
     return resp
 
 

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -218,6 +218,12 @@ class AuthStatusSchema(Schema):
     # | "none" (require_auth on, no credential → the SPA shows login). Lets the UI
     # show a logout control only for "session" (ingress users have no cookie).
     method = fields.Str()
+    # OIDC single sign-on (#464). When enabled, the direct-port login screen shows
+    # a "Sign in with <provider>" button (navigating to oidc_login_url) instead of
+    # the HA username/password form, which is disabled server-side in this mode.
+    oidc_enabled = fields.Bool()
+    oidc_provider_name = fields.Str()
+    oidc_login_url = fields.Str()
 
 
 class LoginRequestSchema(Schema):

--- a/smart_vent/backend/auth.py
+++ b/smart_vent/backend/auth.py
@@ -80,12 +80,18 @@ INGRESS_USER_HEADER = "X-Remote-User-Id"
 #   * the ``/api/auth/*`` endpoints below — the way *in* (login) and *out*
 #     (logout), plus a public status probe the SPA reads to decide whether to
 #     render the login screen. 401-ing these would make login impossible.
+#   * the OIDC login/callback endpoints (#464) — the way *in* via single
+#     sign-on. Both must be reachable without a credential (you have none yet),
+#     and the callback carries only the IdP's ``code``/``state`` on its query
+#     string, which is validated against the signed state cookie.
 _PUBLIC_API_PATHS = frozenset(
     {
         "/api/healthz",
         "/api/auth/login",
         "/api/auth/logout",
         "/api/auth/status",
+        "/api/auth/oidc/login",
+        "/api/auth/oidc/callback",
     }
 )
 

--- a/smart_vent/backend/main.py
+++ b/smart_vent/backend/main.py
@@ -25,7 +25,7 @@ from aiohttp import web
 from aiohttp.typedefs import Handler
 from dotenv import load_dotenv
 
-from . import auth, db, scopes, session, tz
+from . import auth, db, oidc, scopes, session, tz
 from .api.openapi import setup_openapi
 from .api.routes import routes
 from .api.ws_handler import WSManager
@@ -306,6 +306,22 @@ def build_app(
         log.info("Authentication ENABLED (require_auth=true) — direct-port callers must log in")
     else:
         log.info("Authentication DISABLED (require_auth=false) — legacy open access")
+    # OIDC single sign-on for the direct-port web UI (Issue #464). Configured
+    # entirely via env / add-on options (never the UI), read once at boot. When
+    # present it REPLACES the HA username/password login (which the login route
+    # then refuses) and closes the #464 gaps: the IdP enforces MFA and needs no
+    # Supervisor. None → OIDC off, password path unchanged. Web UI only; MCP is
+    # untouched.
+    app["oidc"] = None
+    oidc_provider_config = oidc.load_config()
+    if oidc_provider_config is not None:
+        app["oidc"] = oidc.OIDCProvider(oidc_provider_config)
+        log.info(
+            "OIDC single sign-on ENABLED — provider=%r, redirect_uri=%s, allowlist=%s",
+            oidc_provider_config.provider_name,
+            oidc_provider_config.redirect_uri,
+            oidc_provider_config.allowed_users_glob,
+        )
     app["ha"] = ha
     app["scheduler"] = scheduler
     app["ws_manager"] = ws_manager

--- a/smart_vent/backend/oidc.py
+++ b/smart_vent/backend/oidc.py
@@ -1,0 +1,368 @@
+"""OpenID Connect single sign-on for the Plenum web UI (Issue #464).
+
+Follow-up to the authentication work in #373. The direct-port login shipped in
+#373 validates a Home Assistant username + password against the Supervisor
+``/auth`` backend. That path has two gaps:
+
+* it validates the **first factor only** — HA's MFA/TOTP step runs in the
+  interactive ``login_flow``, not the add-on ``/auth`` backend, so a user with
+  2FA enabled can sign in with just a password; and
+* it **requires a Supervisor**, so standalone / plain-Docker installs (no
+  Supervisor) get a 503 and a locked-out UI when ``require_auth`` is on.
+
+This module closes both by adding an **Authorization Code + PKCE** login against
+an external OpenID Connect provider the operator configures. The IdP enforces
+MFA (gap 1) and needs no Supervisor (gap 2).
+
+Design constraints (carried over from the #373 campaign and the #464 decision):
+
+* **Web UI only.** MCP keeps its minted bearer tokens; ``docs/mcp.md`` documents
+  fronting the MCP port with an OIDC proxy. Nothing here touches ``/mcp``.
+* **Configured entirely outside the Plenum UI** — add-on options (the Supervisor
+  Configuration tab) and/or container env vars, read at boot. There is no in-app
+  OIDC setup screen, so an unauthenticated visitor can never reach configuration
+  and you never have to disable auth to reach the UI off-HAOS.
+* **When OIDC is configured it REPLACES the password path.** The HA
+  username/password login route refuses with 403 (see ``routes.login``) so the
+  weaker first-factor-only login cannot be reached even by someone who knows the
+  endpoint.
+* **No server-side session table.** The short-lived login-flow state (CSRF
+  ``state`` + PKCE ``code_verifier`` + ``nonce``) rides in an HMAC-signed cookie
+  (``session.issue_signed_blob``); on success we mint the same stateless
+  ``plenum_session`` cookie the password path uses. A ``/api/backup`` download
+  still cannot leak a live session or the signing key.
+
+The IdP is trusted to authenticate the user and enforce MFA. Authorization —
+*which* authenticated users may enter — is a simple glob over the identity
+(email, then ``preferred_username``, then ``sub``), defaulting to ``*``
+(everyone the IdP admits), mirroring the ``OIDC_ALLOWED_USERS_GLOB`` knob already
+documented for the MCP auth proxy.
+
+Libraries: **Authlib** provides the OAuth primitives (a CSPRNG ``state`` /
+``nonce`` / PKCE ``verifier`` via ``generate_token`` and the RFC 7636 S256
+``create_s256_code_challenge``); **joserfc** (the maintained successor to the
+now-deprecated ``authlib.jose`` submodule, by the same author) does the
+security-critical ID-token signature + claims validation. We deliberately avoid
+``authlib.jose`` so nothing depends on a deprecated module.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+from authlib.common.security import generate_token
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+from joserfc import jwt
+from joserfc.jwk import KeySet
+
+log = logging.getLogger(__name__)
+
+# Path the IdP redirects back to after login. Combined with the operator's
+# configured external base URL to form the exact ``redirect_uri`` registered at
+# the IdP. Kept in sync with the route registered in ``routes.py``.
+CALLBACK_PATH = "/api/auth/oidc/callback"
+LOGIN_PATH = "/api/auth/oidc/login"
+
+# Short-lived cookie carrying the signed login-flow state. SameSite=Lax (NOT
+# Strict) so the browser sends it on the top-level redirect back from the IdP,
+# which is a cross-site navigation — Strict would drop it and break every login.
+STATE_COOKIE = "plenum_oidc_state"
+STATE_TTL_SECONDS = 600  # 10 minutes to complete the login round-trip
+
+# How long to wait on the IdP's HTTP endpoints (discovery, JWKS, token).
+_HTTP_TIMEOUT_SECONDS = 10
+
+# Minimum scope set. "openid" is mandatory for OIDC; "email"/"profile" give us a
+# human identity to allowlist and log.
+_DEFAULT_SCOPES = "openid email profile"
+
+# Signing algorithms an ID token is allowed to use. Pinning this allow-list on
+# jwt.decode is defense-in-depth against algorithm-substitution / "alg: none"
+# downgrade attacks: unsigned and symmetric (HS*) tokens are refused outright, so
+# an attacker who holds only the IdP's *public* key can never forge one. These
+# are the asymmetric families OIDC providers use in practice.
+_ID_TOKEN_ALGS = (
+    "RS256",
+    "RS384",
+    "RS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "PS256",
+    "PS384",
+    "PS512",
+)
+
+
+class OIDCError(Exception):
+    """A protocol/validation failure in the OIDC flow (bad state, token
+    exchange failed, ID token invalid). Surfaced to the user as a generic
+    "login failed" — never with upstream detail (CWE-209)."""
+
+
+class OIDCForbidden(Exception):
+    """The IdP authenticated the user, but they are not on the allowlist. The
+    identity is kept for the audit log; the user sees a generic rejection."""
+
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+        super().__init__(f"user {identity!r} is not permitted")
+
+
+@dataclass(frozen=True)
+class OIDCConfig:
+    """Resolved OIDC configuration. Built from env / add-on options at boot;
+    absent (``load_config`` returns ``None``) means OIDC login is off."""
+
+    configuration_url: str  # the IdP's .well-known/openid-configuration
+    client_id: str
+    client_secret: str
+    external_url: str  # public base URL of the web UI (redirect_uri origin)
+    scopes: str = _DEFAULT_SCOPES
+    allowed_users_glob: str = "*"
+    provider_name: str = "SSO"
+
+    @property
+    def redirect_uri(self) -> str:
+        return self.external_url.rstrip("/") + CALLBACK_PATH
+
+    @property
+    def app_root(self) -> str:
+        return self.external_url.rstrip("/") + "/"
+
+
+def load_config(env: Mapping[str, str] | None = None) -> OIDCConfig | None:
+    """Build an :class:`OIDCConfig` from the environment, or ``None`` if OIDC is
+    not (fully) configured.
+
+    The four required values are the discovery URL, client id, client secret and
+    the public external URL. If **some but not all** are set we log a warning
+    (an operator half-way through configuration) and treat OIDC as off, so a
+    partial config never half-enables a broken login. The password path stays in
+    place until OIDC is fully configured.
+    """
+    env = os.environ if env is None else env
+    url = env.get("OIDC_CONFIGURATION_URL", "").strip()
+    client_id = env.get("OIDC_CLIENT_ID", "").strip()
+    client_secret = env.get("OIDC_CLIENT_SECRET", "").strip()
+    external_url = env.get("PLENUM_EXTERNAL_URL", "").strip()
+
+    required = {
+        "OIDC_CONFIGURATION_URL": url,
+        "OIDC_CLIENT_ID": client_id,
+        "OIDC_CLIENT_SECRET": client_secret,
+        "PLENUM_EXTERNAL_URL": external_url,
+    }
+    if not all(required.values()):
+        if any(required.values()):
+            missing = [k for k, v in required.items() if not v]
+            log.warning(
+                "OIDC is partially configured (missing %s) — OIDC login disabled; "
+                "set all of OIDC_CONFIGURATION_URL, OIDC_CLIENT_ID, "
+                "OIDC_CLIENT_SECRET, PLENUM_EXTERNAL_URL to enable it",
+                ", ".join(missing),
+            )
+        return None
+
+    scopes = env.get("OIDC_SCOPES", "").strip() or _DEFAULT_SCOPES
+    if "openid" not in scopes.split():
+        # "openid" is mandatory; a missing one is almost certainly an oversight.
+        scopes = "openid " + scopes
+    allowed = env.get("OIDC_ALLOWED_USERS_GLOB", "").strip() or "*"
+    name = env.get("OIDC_PROVIDER_NAME", "").strip() or "SSO"
+    return OIDCConfig(
+        configuration_url=url,
+        client_id=client_id,
+        client_secret=client_secret,
+        external_url=external_url,
+        scopes=scopes,
+        allowed_users_glob=allowed,
+        provider_name=name,
+    )
+
+
+class OIDCProvider:
+    """Drives the Authorization Code + PKCE flow against one configured IdP.
+
+    Network access is isolated in three small ``async`` seams
+    (:meth:`_http_get_json`, :meth:`_http_post_form`) so tests can monkeypatch
+    them — the project pins aiohttp >= 3.14, which ``aioresponses`` cannot mock.
+    Discovery metadata and the JWKS are fetched once and cached on the instance.
+    """
+
+    def __init__(self, config: OIDCConfig) -> None:
+        self.config = config
+        self._metadata: dict[str, Any] | None = None
+        self._jwks: KeySet | None = None
+
+    # --- network seams (monkeypatched in tests) ---------------------------
+
+    async def _http_get_json(self, url: str) -> dict[str, Any]:
+        timeout = aiohttp.ClientTimeout(total=_HTTP_TIMEOUT_SECONDS)
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as http,
+            http.get(url) as resp,
+        ):
+            if resp.status != 200:
+                raise OIDCError(f"GET {url} returned HTTP {resp.status}")
+            data: dict[str, Any] = await resp.json()
+            return data
+
+    async def _http_post_form(self, url: str, data: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        timeout = aiohttp.ClientTimeout(total=_HTTP_TIMEOUT_SECONDS)
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as http,
+            http.post(url, data=data) as resp,
+        ):
+            try:
+                body = await resp.json()
+            except (aiohttp.ContentTypeError, ValueError):
+                body = {}
+            return resp.status, body
+
+    # --- cached discovery -------------------------------------------------
+
+    async def metadata(self) -> dict[str, Any]:
+        if self._metadata is None:
+            self._metadata = await self._http_get_json(self.config.configuration_url)
+        return self._metadata
+
+    async def _key_set(self) -> KeySet:
+        if self._jwks is None:
+            md = await self.metadata()
+            jwks_uri = md.get("jwks_uri")
+            if not jwks_uri:
+                raise OIDCError("IdP metadata has no jwks_uri")
+            # The JWKS response is a plain dict at runtime; joserfc validates it.
+            jwks = await self._http_get_json(jwks_uri)
+            self._jwks = KeySet.import_key_set(jwks)  # type: ignore[arg-type]
+        return self._jwks
+
+    # --- flow -------------------------------------------------------------
+
+    async def authorization_url(self) -> tuple[str, dict[str, str]]:
+        """Build the IdP authorization URL and the login-flow state to persist.
+
+        Returns ``(auth_url, state_blob)`` where ``state_blob`` is the dict the
+        caller signs into the short-lived :data:`STATE_COOKIE` (``state`` +
+        PKCE ``verifier`` + ``nonce``) and re-checks in the callback.
+        """
+        md = await self.metadata()
+        endpoint = md.get("authorization_endpoint")
+        if not endpoint:
+            raise OIDCError("IdP metadata has no authorization_endpoint")
+        state = generate_token(32)
+        nonce = generate_token(32)
+        verifier = generate_token(64)
+        params = {
+            "response_type": "code",
+            "client_id": self.config.client_id,
+            "redirect_uri": self.config.redirect_uri,
+            "scope": self.config.scopes,
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": create_s256_code_challenge(verifier),
+            "code_challenge_method": "S256",
+        }
+        sep = "&" if "?" in endpoint else "?"
+        return f"{endpoint}{sep}{urlencode(params)}", {
+            "state": state,
+            "verifier": verifier,
+            "nonce": nonce,
+        }
+
+    async def exchange_code(self, code: str, code_verifier: str) -> dict[str, Any]:
+        """Exchange an authorization code for tokens at the token endpoint."""
+        md = await self.metadata()
+        endpoint = md.get("token_endpoint")
+        if not endpoint:
+            raise OIDCError("IdP metadata has no token_endpoint")
+        status, body = await self._http_post_form(
+            endpoint,
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.config.redirect_uri,
+                "client_id": self.config.client_id,
+                "client_secret": self.config.client_secret,
+                "code_verifier": code_verifier,
+            },
+        )
+        if status != 200:
+            # Log the status for diagnosis; never surface the body (may echo the
+            # secret or the code back).
+            log.warning("OIDC token endpoint returned HTTP %s", status)
+            raise OIDCError("token exchange failed")
+        return body
+
+    async def validate_id_token(self, id_token: str, nonce: str) -> dict[str, Any]:
+        """Verify the ID token's signature and claims; return the claims dict.
+
+        Fails **closed**: any error from the JOSE layer (bad signature, unknown
+        ``kid``, expired, wrong issuer) becomes an :class:`OIDCError`. The
+        audience is checked separately to accept the spec-legal list-or-string
+        form, and the ``nonce`` is checked against the one we minted, binding the
+        token to this browser's flow.
+        """
+        md = await self.metadata()
+        issuer = md.get("issuer")
+        if not issuer:
+            raise OIDCError("IdP metadata has no issuer")
+        keyset = await self._key_set()
+        try:
+            claims = jwt.decode(id_token, keyset, algorithms=list(_ID_TOKEN_ALGS)).claims
+            jwt.JWTClaimsRegistry(
+                iss={"essential": True, "value": issuer},
+                exp={"essential": True},
+            ).validate(claims)
+        except Exception as exc:  # joserfc JoseError subclasses, ValueError, …
+            raise OIDCError("ID token validation failed") from exc
+        # Audience may be a string or a list per the OIDC spec; our client_id
+        # must be present. (Validated here rather than via the registry so both
+        # forms are accepted.)
+        aud = claims.get("aud")
+        audiences = aud if isinstance(aud, list) else [aud]
+        if self.config.client_id not in audiences:
+            raise OIDCError("ID token audience mismatch")
+        if claims.get("nonce") != nonce:
+            raise OIDCError("ID token nonce mismatch")
+        return dict(claims)
+
+    @staticmethod
+    def identity(claims: Mapping[str, Any]) -> str:
+        """Human identity to allowlist and log. Prefer email, then
+        ``preferred_username``, then the opaque ``sub``."""
+        for key in ("email", "preferred_username", "sub"):
+            value = claims.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return ""
+
+    def is_allowed(self, identity: str) -> bool:
+        """True iff *identity* matches the configured allowlist glob. Empty
+        identity is never allowed."""
+        return bool(identity) and fnmatch.fnmatch(identity, self.config.allowed_users_glob)
+
+    async def complete_login(self, code: str, code_verifier: str, nonce: str) -> str:
+        """Run the back half of the flow: exchange the code, validate the ID
+        token, enforce the allowlist. Return the authenticated identity.
+
+        Raises :class:`OIDCForbidden` if authenticated-but-not-allowlisted, or
+        :class:`OIDCError` on any protocol/validation failure.
+        """
+        token = await self.exchange_code(code, code_verifier)
+        id_token = token.get("id_token")
+        if not id_token or not isinstance(id_token, str):
+            raise OIDCError("token response has no id_token")
+        claims = await self.validate_id_token(id_token, nonce)
+        identity = self.identity(claims)
+        if not self.is_allowed(identity):
+            raise OIDCForbidden(identity)
+        return identity

--- a/smart_vent/backend/session.py
+++ b/smart_vent/backend/session.py
@@ -32,6 +32,7 @@ import os
 import secrets
 import time
 from hashlib import sha256
+from typing import Any
 
 from aiohttp import web
 
@@ -150,6 +151,58 @@ def verify_token(secret: bytes, token: str, *, now: float | None = None) -> str 
         return None
     sub = payload.get("sub")
     return sub if isinstance(sub, str) and sub else None
+
+
+def issue_signed_blob(
+    secret: bytes, data: dict[str, Any], *, ttl: int, now: float | None = None
+) -> str:
+    """Mint a signed, expiring token carrying an arbitrary JSON-serialisable dict.
+
+    Same ``<b64(payload)>.<b64(hmac)>`` construction as :func:`issue_token`, but
+    the payload is the caller's *data* plus ``iat``/``exp``. Used for the
+    short-lived OIDC login-flow cookie (Issue #464), which must carry three
+    values (CSRF ``state`` + PKCE ``code_verifier`` + ``nonce``) rather than a
+    single ``sub``. Keeps all HMAC signing in this one module and preserves the
+    "nothing in app.db, backup can't forge it" property.
+
+    Callers MUST NOT put a ``sub`` key in *data* if they later verify it with
+    :func:`verify_token` — that function is for the session cookie only; this
+    blob is verified with :func:`verify_signed_blob`.
+    """
+    issued = int(now if now is not None else time.time())
+    payload = {**data, "iat": issued, "exp": issued + int(ttl)}
+    raw = _b64e(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    return f"{raw}.{_sign(secret, raw.encode('ascii'))}"
+
+
+def verify_signed_blob(
+    secret: bytes, token: str, *, now: float | None = None
+) -> dict[str, Any] | None:
+    """Return the decoded payload dict iff *token* is well-formed, correctly
+    signed and unexpired; ``None`` otherwise.
+
+    The signature is checked in constant time *before* the payload is parsed, so
+    a forged token never reaches JSON decoding with attacker-controlled bytes
+    (same discipline as :func:`verify_token`)."""
+    try:
+        raw, sig = token.split(".", 1)
+    except ValueError:
+        return None
+    expected = _sign(secret, raw.encode("ascii"))
+    if not hmac.compare_digest(sig, expected):
+        return None
+    try:
+        payload = json.loads(_b64d(raw))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    exp = payload.get("exp")
+    if not isinstance(exp, (int, float)) or isinstance(exp, bool):
+        return None
+    if (now if now is not None else time.time()) >= exp:
+        return None
+    return payload
 
 
 def session_user(request: web.Request) -> str | None:

--- a/smart_vent/backend/session.py
+++ b/smart_vent/backend/session.py
@@ -1,14 +1,18 @@
 """Signed session cookies for the direct-port web UI (Issue #373).
 
-The browser session is a **stateless, HMAC-signed token** carried in an
-``HttpOnly`` + ``Secure`` + ``SameSite=Strict`` cookie. There is deliberately no
-server-side session table:
+The browser session is a **stateless, HS256 JWT** carried in an ``HttpOnly`` +
+``Secure`` + ``SameSite=Strict`` cookie. The token is minted and verified with
+``joserfc`` — the same maintained JOSE library the OIDC login uses (#464/#476) —
+signed with a per-install secret; there is deliberately no server-side session
+table:
 
 * Nothing session-related is written to ``app.db``, so ``GET /api/backup`` (which
   streams the entire database) cannot exfiltrate live sessions *or* the signing
   key — a concern called out explicitly in #373.
-* Verification is a constant-time HMAC comparison plus an expiry check, with no
-  DB round-trip on the hot path.
+* Verification is a constant-time signature check plus an expiry check (both
+  inside joserfc), with no DB round-trip on the hot path. Decoding pins
+  ``algorithms=["HS256"]`` so a token claiming any other ``alg`` (``none`` or an
+  asymmetric family) is refused — the classic JWT algorithm-confusion guard.
 
 The signing key is a per-install random secret persisted to a file **outside the
 database** (``<data-dir>/.session_secret``, mode ``0600``). Keeping it out of
@@ -18,25 +22,29 @@ directory is not writable we fall back to an ephemeral in-process secret rather
 than crash — sessions then simply don't outlive the process.
 
 This module owns credential *verification and cookie mechanics only*. Credential
-*issuance* (validating a login against the Home Assistant ``/auth`` backend) is
-``main.py``'s login route; this module just mints/verifies the resulting cookie.
+*issuance* (validating a login against the Home Assistant ``/auth`` backend, or
+the OIDC flow) is the caller's job; this module just mints/verifies the cookie.
 """
 
 from __future__ import annotations
 
 import base64
-import hmac
-import json
 import logging
 import os
 import secrets
 import time
-from hashlib import sha256
 from typing import Any
 
 from aiohttp import web
+from joserfc import jwt
+from joserfc.jwk import OctKey
 
 log = logging.getLogger(__name__)
+
+# The session/state cookies are symmetric (HMAC) JWTs. Pinning the algorithm on
+# decode is what keeps an attacker from presenting a token with a different
+# ``alg`` header (``none``, or an asymmetric family) to bypass verification.
+_JWT_ALG = "HS256"
 
 # Cookie the browser presents on every same-origin request once logged in.
 COOKIE_NAME = "plenum_session"
@@ -102,8 +110,42 @@ def load_or_create_secret(data_dir: str) -> bytes:
     return secret
 
 
-def _sign(secret: bytes, payload: bytes) -> str:
-    return _b64e(hmac.new(secret, payload, sha256).digest())
+def issue_signed_blob(
+    secret: bytes, data: dict[str, Any], *, ttl: int, now: float | None = None
+) -> str:
+    """Mint a signed, expiring HS256 JWT carrying an arbitrary claims dict.
+
+    The token's claims are the caller's *data* plus ``iat``/``exp``. Used for the
+    short-lived OIDC login-flow cookie (Issue #464), which carries the CSRF
+    ``state`` + PKCE ``code_verifier`` + ``nonce``; :func:`issue_token` is the
+    session-cookie specialisation (``sub`` only). Signed with *secret* via
+    joserfc, so nothing is written to ``app.db`` and a backup can't forge it.
+    """
+    issued = int(now if now is not None else time.time())
+    claims = {**data, "iat": issued, "exp": issued + int(ttl)}
+    return jwt.encode({"alg": _JWT_ALG}, claims, OctKey.import_key(secret))
+
+
+def verify_signed_blob(
+    secret: bytes, token: str, *, now: float | None = None
+) -> dict[str, Any] | None:
+    """Return the decoded claims dict iff *token* is a well-formed HS256 JWT,
+    correctly signed by *secret*, and unexpired; ``None`` otherwise.
+
+    Fails **closed**: any joserfc error (bad signature, wrong ``alg``, malformed,
+    missing/invalid ``exp``) yields ``None``. ``exp`` is required. Pass *now* to
+    pin the clock in tests.
+    """
+    try:
+        claims = jwt.decode(token, OctKey.import_key(secret), algorithms=[_JWT_ALG]).claims
+        registry = jwt.JWTClaimsRegistry(
+            now=int(now) if now is not None else None,
+            exp={"essential": True},
+        )
+        registry.validate(claims)
+    except Exception:
+        return None
+    return dict(claims)
 
 
 def issue_token(
@@ -113,96 +155,22 @@ def issue_token(
     now: float | None = None,
     ttl: int = SESSION_TTL_SECONDS,
 ) -> str:
-    """Mint a signed, expiring session token for *user_id*.
+    """Mint a signed, expiring session token (HS256 JWT) for *user_id*.
 
-    Format: ``<b64(payload)>.<b64(hmac)>`` where payload is
-    ``{"sub", "iat", "exp"}``. Only the signature — over the exact payload
-    bytes — makes the token trustworthy; a tampered payload fails
-    :func:`verify_token`.
+    The session cookie is just an :func:`issue_signed_blob` with a single ``sub``
+    claim; :func:`verify_token` reads it back.
     """
-    issued = int(now if now is not None else time.time())
-    payload = {"sub": user_id, "iat": issued, "exp": issued + int(ttl)}
-    raw = _b64e(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
-    return f"{raw}.{_sign(secret, raw.encode('ascii'))}"
+    return issue_signed_blob(secret, {"sub": user_id}, ttl=ttl, now=now)
 
 
 def verify_token(secret: bytes, token: str, *, now: float | None = None) -> str | None:
-    """Return the ``sub`` (user id) iff *token* is well-formed, correctly signed
-    and unexpired; ``None`` otherwise.
-
-    The signature is checked in constant time *before* the payload is parsed, so
-    a forged token never reaches JSON decoding with attacker-controlled bytes.
-    """
-    try:
-        raw, sig = token.split(".", 1)
-    except ValueError:
+    """Return the ``sub`` (user id) iff *token* is a valid, unexpired session
+    JWT with a non-empty string ``sub``; ``None`` otherwise."""
+    claims = verify_signed_blob(secret, token, now=now)
+    if claims is None:
         return None
-    expected = _sign(secret, raw.encode("ascii"))
-    if not hmac.compare_digest(sig, expected):
-        return None
-    try:
-        payload = json.loads(_b64d(raw))
-    except (ValueError, json.JSONDecodeError):
-        return None
-    exp = payload.get("exp")
-    if not isinstance(exp, (int, float)) or isinstance(exp, bool):
-        return None
-    if (now if now is not None else time.time()) >= exp:
-        return None
-    sub = payload.get("sub")
+    sub = claims.get("sub")
     return sub if isinstance(sub, str) and sub else None
-
-
-def issue_signed_blob(
-    secret: bytes, data: dict[str, Any], *, ttl: int, now: float | None = None
-) -> str:
-    """Mint a signed, expiring token carrying an arbitrary JSON-serialisable dict.
-
-    Same ``<b64(payload)>.<b64(hmac)>`` construction as :func:`issue_token`, but
-    the payload is the caller's *data* plus ``iat``/``exp``. Used for the
-    short-lived OIDC login-flow cookie (Issue #464), which must carry three
-    values (CSRF ``state`` + PKCE ``code_verifier`` + ``nonce``) rather than a
-    single ``sub``. Keeps all HMAC signing in this one module and preserves the
-    "nothing in app.db, backup can't forge it" property.
-
-    Callers MUST NOT put a ``sub`` key in *data* if they later verify it with
-    :func:`verify_token` — that function is for the session cookie only; this
-    blob is verified with :func:`verify_signed_blob`.
-    """
-    issued = int(now if now is not None else time.time())
-    payload = {**data, "iat": issued, "exp": issued + int(ttl)}
-    raw = _b64e(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
-    return f"{raw}.{_sign(secret, raw.encode('ascii'))}"
-
-
-def verify_signed_blob(
-    secret: bytes, token: str, *, now: float | None = None
-) -> dict[str, Any] | None:
-    """Return the decoded payload dict iff *token* is well-formed, correctly
-    signed and unexpired; ``None`` otherwise.
-
-    The signature is checked in constant time *before* the payload is parsed, so
-    a forged token never reaches JSON decoding with attacker-controlled bytes
-    (same discipline as :func:`verify_token`)."""
-    try:
-        raw, sig = token.split(".", 1)
-    except ValueError:
-        return None
-    expected = _sign(secret, raw.encode("ascii"))
-    if not hmac.compare_digest(sig, expected):
-        return None
-    try:
-        payload = json.loads(_b64d(raw))
-    except (ValueError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    exp = payload.get("exp")
-    if not isinstance(exp, (int, float)) or isinstance(exp, bool):
-        return None
-    if (now if now is not None else time.time()) >= exp:
-        return None
-    return payload
 
 
 def session_user(request: web.Request) -> str | None:

--- a/smart_vent/backend/tests/integration/test_auth_middleware.py
+++ b/smart_vent/backend/tests/integration/test_auth_middleware.py
@@ -182,17 +182,32 @@ async def test_flag_on_healthz_exempt(make_client: Callable) -> None:
     assert (await resp.json())["ok"] is True
 
 
+# OIDC single sign-on (#464) is off in these tests (no provider configured), so
+# auth_status reports the three OIDC fields as disabled/empty.
+_OIDC_OFF = {"oidc_enabled": False, "oidc_provider_name": "", "oidc_login_url": ""}
+
+
 async def test_flag_on_auth_status_public(make_client: Callable) -> None:
     client = await make_client(require_auth=True)
     resp = await client.get("/api/auth/status")
     assert resp.status == 200
-    assert await resp.json() == {"require_auth": True, "authenticated": False, "method": "none"}
+    assert await resp.json() == {
+        "require_auth": True,
+        "authenticated": False,
+        "method": "none",
+        **_OIDC_OFF,
+    }
 
 
 async def test_auth_status_authenticated_via_ingress(make_client: Callable) -> None:
     client = await make_client(require_auth=True, supervisor_ip=LOOPBACK)
     resp = await client.get("/api/auth/status", headers=INGRESS_HDR)
-    assert await resp.json() == {"require_auth": True, "authenticated": True, "method": "ingress"}
+    assert await resp.json() == {
+        "require_auth": True,
+        "authenticated": True,
+        "method": "ingress",
+        **_OIDC_OFF,
+    }
 
 
 async def test_auth_status_authenticated_via_session(make_client: Callable) -> None:
@@ -206,7 +221,12 @@ async def test_auth_status_authenticated_via_session(make_client: Callable) -> N
 async def test_auth_status_reports_off_when_flag_off(client: TestClient) -> None:
     resp = await client.get("/api/auth/status")
     # Auth off ⇒ everyone is effectively authenticated.
-    assert await resp.json() == {"require_auth": False, "authenticated": True, "method": "open"}
+    assert await resp.json() == {
+        "require_auth": False,
+        "authenticated": True,
+        "method": "open",
+        **_OIDC_OFF,
+    }
 
 
 # --------------------------------------------------------------------------

--- a/smart_vent/backend/tests/integration/test_auth_oidc.py
+++ b/smart_vent/backend/tests/integration/test_auth_oidc.py
@@ -1,0 +1,207 @@
+"""Integration tests for the OIDC single sign-on routes (Issue #464).
+
+Drives the real aiohttp app + middleware chain. ``build_app`` picks up an OIDC
+provider by way of a patched ``oidc.load_config``; the provider's flow methods
+(``authorization_url`` / ``complete_login``) are stubbed at the class level so no
+network is touched (the actual token/JWT logic is unit-tested in
+``backend/tests/test_oidc.py``). The state cookie is a real HMAC-signed blob
+minted with the app's own session secret, exactly as the login route mints it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from aiohttp.test_utils import TestClient
+
+from backend import oidc, session
+
+TEST_CONFIG = oidc.OIDCConfig(
+    configuration_url="https://idp.example/.well-known/openid-configuration",
+    client_id="cid",
+    client_secret="sec",
+    external_url="https://plenum.example",
+    provider_name="TestIdP",
+)
+
+
+@pytest.fixture
+def with_oidc(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """Make ``build_app`` construct an OIDC provider, with network-free stubs."""
+    monkeypatch.setattr(oidc, "load_config", lambda env=None: TEST_CONFIG)
+
+    async def fake_auth_url(self: oidc.OIDCProvider) -> tuple[str, dict[str, str]]:
+        return "https://idp.example/authorize?state=S", {
+            "state": "S",
+            "verifier": "V",
+            "nonce": "N",
+        }
+
+    async def fake_complete(self: oidc.OIDCProvider, code: str, verifier: str, nonce: str) -> str:
+        return "alice@corp.com"
+
+    monkeypatch.setattr(oidc.OIDCProvider, "authorization_url", fake_auth_url)
+    monkeypatch.setattr(oidc.OIDCProvider, "complete_login", fake_complete)
+    return monkeypatch
+
+
+def _state_cookie(client: TestClient, *, state: str = "S") -> dict[str, str]:
+    blob = session.issue_signed_blob(
+        client.app["session_secret"],
+        {"state": state, "verifier": "V", "nonce": "N"},
+        ttl=oidc.STATE_TTL_SECONDS,
+    )
+    return {oidc.STATE_COOKIE: blob}
+
+
+# --------------------------------------------------------------------------- #
+# status + password-login interaction
+# --------------------------------------------------------------------------- #
+
+
+async def test_auth_status_reports_oidc(make_client: Callable, with_oidc: object) -> None:
+    client = await make_client(require_auth=True)
+    body = await (await client.get("/api/auth/status")).json()
+    assert body["oidc_enabled"] is True
+    assert body["oidc_provider_name"] == "TestIdP"
+    assert body["oidc_login_url"] == "/api/auth/oidc/login"
+
+
+async def test_auth_status_no_oidc_by_default(make_client: Callable) -> None:
+    client = await make_client(require_auth=True)
+    body = await (await client.get("/api/auth/status")).json()
+    assert body["oidc_enabled"] is False
+    assert body["oidc_provider_name"] == ""
+    assert body["oidc_login_url"] == ""
+
+
+async def test_password_login_disabled_when_oidc(make_client: Callable, with_oidc: object) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.post("/api/auth/login", json={"username": "u", "password": "p"})
+    assert resp.status == 403
+    assert "disabled" in (await resp.json())["error"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# /api/auth/oidc/login
+# --------------------------------------------------------------------------- #
+
+
+async def test_oidc_login_redirects_and_sets_state_cookie(
+    make_client: Callable, with_oidc: object
+) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/login", allow_redirects=False)
+    assert resp.status == 302
+    assert resp.headers["Location"].startswith("https://idp.example/authorize")
+    set_cookie = resp.headers.get("Set-Cookie", "")
+    assert oidc.STATE_COOKIE in set_cookie
+    assert "HttpOnly" in set_cookie
+    # Lax (not Strict) so the browser sends it on the cross-site redirect back.
+    assert "SameSite=Lax" in set_cookie
+
+
+async def test_oidc_login_404_when_not_configured(make_client: Callable) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/login", allow_redirects=False)
+    assert resp.status == 404
+
+
+async def test_oidc_login_502_on_discovery_error(
+    make_client: Callable, with_oidc: pytest.MonkeyPatch
+) -> None:
+    async def boom(self: oidc.OIDCProvider) -> tuple[str, dict[str, str]]:
+        raise RuntimeError("discovery unreachable")
+
+    with_oidc.setattr(oidc.OIDCProvider, "authorization_url", boom)
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/login", allow_redirects=False)
+    assert resp.status == 502
+
+
+# --------------------------------------------------------------------------- #
+# /api/auth/oidc/callback
+# --------------------------------------------------------------------------- #
+
+
+async def test_oidc_callback_success_authenticates(
+    make_client: Callable, with_oidc: object
+) -> None:
+    client = await make_client(require_auth=True)
+    assert (await client.get("/api/rooms")).status == 401  # protected before login
+    resp = await client.get(
+        "/api/auth/oidc/callback?code=good&state=S",
+        cookies=_state_cookie(client),
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    assert resp.headers["Location"] == "https://plenum.example/"
+    assert session.COOKIE_NAME in resp.headers.get("Set-Cookie", "")
+    # The minted session cookie now authenticates a protected request.
+    assert (await client.get("/api/rooms")).status == 200
+
+
+async def test_oidc_callback_state_mismatch(make_client: Callable, with_oidc: object) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get(
+        "/api/auth/oidc/callback?code=good&state=WRONG",
+        cookies=_state_cookie(client, state="S"),
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    assert "login_error=sso_state" in resp.headers["Location"]
+    assert session.COOKIE_NAME not in resp.headers.get("Set-Cookie", "")
+
+
+async def test_oidc_callback_no_state_cookie(make_client: Callable, with_oidc: object) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/callback?code=good&state=S", allow_redirects=False)
+    assert resp.status == 302
+    assert "login_error=sso_state" in resp.headers["Location"]
+
+
+async def test_oidc_callback_idp_error(make_client: Callable, with_oidc: object) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/callback?error=access_denied", allow_redirects=False)
+    assert resp.status == 302
+    assert "login_error=sso_cancelled" in resp.headers["Location"]
+
+
+async def test_oidc_callback_forbidden(
+    make_client: Callable, with_oidc: pytest.MonkeyPatch
+) -> None:
+    async def forbidden(self: oidc.OIDCProvider, code: str, verifier: str, nonce: str) -> str:
+        raise oidc.OIDCForbidden("intruder@evil.com")
+
+    with_oidc.setattr(oidc.OIDCProvider, "complete_login", forbidden)
+    client = await make_client(require_auth=True)
+    resp = await client.get(
+        "/api/auth/oidc/callback?code=good&state=S",
+        cookies=_state_cookie(client),
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    assert "login_error=sso_forbidden" in resp.headers["Location"]
+    assert session.COOKIE_NAME not in resp.headers.get("Set-Cookie", "")
+
+
+async def test_oidc_callback_failure(make_client: Callable, with_oidc: pytest.MonkeyPatch) -> None:
+    async def fail(self: oidc.OIDCProvider, code: str, verifier: str, nonce: str) -> str:
+        raise oidc.OIDCError("token exchange failed")
+
+    with_oidc.setattr(oidc.OIDCProvider, "complete_login", fail)
+    client = await make_client(require_auth=True)
+    resp = await client.get(
+        "/api/auth/oidc/callback?code=good&state=S",
+        cookies=_state_cookie(client),
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    assert "login_error=sso_failed" in resp.headers["Location"]
+
+
+async def test_oidc_callback_404_when_not_configured(make_client: Callable) -> None:
+    client = await make_client(require_auth=True)
+    resp = await client.get("/api/auth/oidc/callback?code=x&state=y", allow_redirects=False)
+    assert resp.status == 404

--- a/smart_vent/backend/tests/test_oidc.py
+++ b/smart_vent/backend/tests/test_oidc.py
@@ -1,0 +1,446 @@
+"""Unit tests for OIDC single sign-on (Issue #464).
+
+Network is isolated behind ``OIDCProvider``'s ``_http_get_json`` /
+``_http_post_form`` seams. Most tests pre-populate the discovery + JWKS caches
+(no network); the seams themselves are covered against a tiny local aiohttp test
+server. ID-token crypto is exercised for real via ``joserfc``: we mint a local
+RSA key, publish its public JWKS, sign tokens, and assert validation accepts good
+tokens and rejects tampered / expired / mis-audienced / wrong-issuer ones.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from joserfc import jwt
+from joserfc.jwk import KeySet, RSAKey
+
+from backend import oidc
+
+ISSUER = "https://idp.example"
+CLIENT_ID = "plenum-client"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def signing_key() -> RSAKey:
+    return RSAKey.generate_key(2048, auto_kid=True)
+
+
+def _config(**over: object) -> oidc.OIDCConfig:
+    base: dict[str, object] = {
+        "configuration_url": "https://idp.example/.well-known/openid-configuration",
+        "client_id": CLIENT_ID,
+        "client_secret": "s3cret",
+        "external_url": "https://plenum.example",
+    }
+    base.update(over)
+    return oidc.OIDCConfig(**base)  # type: ignore[arg-type]
+
+
+def _provider(signing_key: RSAKey, **over: object) -> oidc.OIDCProvider:
+    """A provider whose discovery + JWKS caches are pre-populated from a local
+    key, so no method touches the network."""
+    provider = oidc.OIDCProvider(_config(**over))
+    provider._metadata = {
+        "issuer": ISSUER,
+        "authorization_endpoint": ISSUER + "/authorize",
+        "token_endpoint": ISSUER + "/token",
+        "jwks_uri": ISSUER + "/jwks",
+    }
+    provider._jwks = KeySet.import_key_set({"keys": [signing_key.as_dict(private=False)]})
+    return provider
+
+
+def _id_token(signing_key: RSAKey, **claims: object) -> str:
+    payload: dict[str, object] = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "sub": "user-123",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 600,
+    }
+    payload.update(claims)
+    return jwt.encode({"alg": "RS256", "kid": signing_key.kid}, payload, signing_key)
+
+
+# --------------------------------------------------------------------------- #
+# load_config
+# --------------------------------------------------------------------------- #
+
+
+def test_load_config_empty_is_none() -> None:
+    assert oidc.load_config({}) is None
+
+
+def test_load_config_partial_is_none_and_warns(caplog: pytest.LogCaptureFixture) -> None:
+    cfg = oidc.load_config({"OIDC_CLIENT_ID": "abc"})  # only one of four
+    assert cfg is None
+    assert "partially configured" in caplog.text.lower()
+
+
+def test_load_config_full() -> None:
+    cfg = oidc.load_config(
+        {
+            "OIDC_CONFIGURATION_URL": "https://idp/.well-known/openid-configuration",
+            "OIDC_CLIENT_ID": "cid",
+            "OIDC_CLIENT_SECRET": "sec",
+            "PLENUM_EXTERNAL_URL": "https://plenum.example/",
+        }
+    )
+    assert cfg is not None
+    assert cfg.client_id == "cid"
+    assert cfg.scopes == "openid email profile"  # default
+    assert cfg.allowed_users_glob == "*"  # default
+    assert cfg.provider_name == "SSO"  # default
+    # redirect_uri / app_root strip the trailing slash exactly once.
+    assert cfg.redirect_uri == "https://plenum.example/api/auth/oidc/callback"
+    assert cfg.app_root == "https://plenum.example/"
+
+
+def test_load_config_injects_openid_scope() -> None:
+    cfg = oidc.load_config(
+        {
+            "OIDC_CONFIGURATION_URL": "https://idp/x",
+            "OIDC_CLIENT_ID": "cid",
+            "OIDC_CLIENT_SECRET": "sec",
+            "PLENUM_EXTERNAL_URL": "https://plenum",
+            "OIDC_SCOPES": "email groups",  # missing openid
+        }
+    )
+    assert cfg is not None
+    assert cfg.scopes.split()[0] == "openid"
+    assert "email" in cfg.scopes and "groups" in cfg.scopes
+
+
+def test_load_config_custom_name_and_allowlist() -> None:
+    cfg = oidc.load_config(
+        {
+            "OIDC_CONFIGURATION_URL": "https://idp/x",
+            "OIDC_CLIENT_ID": "cid",
+            "OIDC_CLIENT_SECRET": "sec",
+            "PLENUM_EXTERNAL_URL": "https://plenum",
+            "OIDC_PROVIDER_NAME": "Authelia",
+            "OIDC_ALLOWED_USERS_GLOB": "*@corp.com",
+        }
+    )
+    assert cfg is not None
+    assert cfg.provider_name == "Authelia"
+    assert cfg.allowed_users_glob == "*@corp.com"
+
+
+# --------------------------------------------------------------------------- #
+# identity / allowlist
+# --------------------------------------------------------------------------- #
+
+
+def test_identity_precedence() -> None:
+    ident = oidc.OIDCProvider.identity  # staticmethod — no instance needed
+    assert ident({"email": "e", "preferred_username": "u", "sub": "s"}) == "e"
+    assert ident({"preferred_username": "u", "sub": "s"}) == "u"
+    assert ident({"sub": "s"}) == "s"
+    assert ident({}) == ""
+    assert ident({"email": ""}) == ""  # empty skipped
+
+
+@pytest.mark.parametrize(
+    "glob,identity,allowed",
+    [
+        ("*", "anyone@x.com", True),
+        ("*", "", False),  # empty never allowed
+        ("*@corp.com", "a@corp.com", True),
+        ("*@corp.com", "a@evil.com", False),
+        ("alice@corp.com", "alice@corp.com", True),
+        ("alice@corp.com", "bob@corp.com", False),
+    ],
+)
+def test_is_allowed(signing_key: RSAKey, glob: str, identity: str, allowed: bool) -> None:
+    provider = _provider(signing_key, allowed_users_glob=glob)
+    assert provider.is_allowed(identity) is allowed
+
+
+# --------------------------------------------------------------------------- #
+# authorization_url
+# --------------------------------------------------------------------------- #
+
+
+async def test_authorization_url(signing_key: RSAKey) -> None:
+    import base64
+    import hashlib
+    from urllib.parse import parse_qs, urlparse
+
+    provider = _provider(signing_key)
+    url, blob = await provider.authorization_url()
+    assert url.startswith(ISSUER + "/authorize?")
+    query = parse_qs(urlparse(url).query)
+    assert query["response_type"] == ["code"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["client_id"] == [CLIENT_ID]
+    assert query["redirect_uri"] == [provider.config.redirect_uri]
+    assert set(blob) == {"state", "verifier", "nonce"}
+    # The state/nonce in the blob are what the callback re-checks.
+    assert query["state"] == [blob["state"]]
+    assert query["nonce"] == [blob["nonce"]]
+    # The challenge is the unpadded base64url S256 of the verifier we kept.
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(blob["verifier"].encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert query["code_challenge"] == [expected]
+
+
+async def test_authorization_url_no_endpoint(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    provider._metadata = {"issuer": ISSUER}  # no authorization_endpoint
+    with pytest.raises(oidc.OIDCError):
+        await provider.authorization_url()
+
+
+# --------------------------------------------------------------------------- #
+# validate_id_token
+# --------------------------------------------------------------------------- #
+
+
+async def test_validate_id_token_ok(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    claims = await provider.validate_id_token(
+        _id_token(signing_key, nonce="N", email="a@corp.com"), "N"
+    )
+    assert claims["sub"] == "user-123"
+    assert claims["email"] == "a@corp.com"
+
+
+async def test_validate_id_token_aud_list(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    token = _id_token(signing_key, nonce="N", aud=["someone-else", CLIENT_ID])
+    claims = await provider.validate_id_token(token, "N")
+    assert claims["sub"] == "user-123"
+
+
+async def test_validate_id_token_wrong_audience(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    token = _id_token(signing_key, nonce="N", aud="not-us")
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "N")
+
+
+async def test_validate_id_token_wrong_issuer(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    token = _id_token(signing_key, nonce="N", iss="https://evil")
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "N")
+
+
+async def test_validate_id_token_expired(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    token = _id_token(signing_key, nonce="N", exp=int(time.time()) - 5)
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "N")
+
+
+async def test_validate_id_token_nonce_mismatch(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    token = _id_token(signing_key, nonce="N")
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "DIFFERENT")
+
+
+async def test_validate_id_token_wrong_key(signing_key: RSAKey) -> None:
+    """A token signed by a different key (unknown kid) must be rejected."""
+    provider = _provider(signing_key)
+    attacker = RSAKey.generate_key(2048, auto_kid=True)
+    token = _id_token(attacker, nonce="N")
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "N")
+
+
+async def test_validate_id_token_rejects_symmetric_alg(signing_key: RSAKey) -> None:
+    """An HS256-signed token must be refused: only asymmetric algorithms are in
+    the allow-list, defeating the classic 'sign with the public key as an HMAC
+    secret' confusion attack."""
+    from joserfc.jwk import OctKey
+
+    provider = _provider(signing_key)
+    oct_key = OctKey.import_key("x" * 32)
+    token = jwt.encode(
+        {"alg": "HS256"},
+        {"iss": ISSUER, "aud": CLIENT_ID, "sub": "x", "nonce": "N", "exp": int(time.time()) + 600},
+        oct_key,
+    )
+    with pytest.raises(oidc.OIDCError):
+        await provider.validate_id_token(token, "N")
+
+
+# --------------------------------------------------------------------------- #
+# exchange_code / complete_login (network seam monkeypatched)
+# --------------------------------------------------------------------------- #
+
+
+async def test_exchange_code_ok(signing_key: RSAKey, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider(signing_key)
+
+    async def fake_post(url: str, data: dict) -> tuple[int, dict]:
+        assert data["grant_type"] == "authorization_code"
+        assert data["code"] == "the-code"
+        return 200, {"id_token": "xyz", "access_token": "a"}
+
+    monkeypatch.setattr(provider, "_http_post_form", fake_post)
+    token = await provider.exchange_code("the-code", "verifier")
+    assert token["id_token"] == "xyz"
+
+
+async def test_exchange_code_non_200(signing_key: RSAKey, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider(signing_key)
+
+    async def fake_post(url: str, data: dict) -> tuple[int, dict]:
+        return 401, {"error": "invalid_grant"}
+
+    monkeypatch.setattr(provider, "_http_post_form", fake_post)
+    with pytest.raises(oidc.OIDCError):
+        await provider.exchange_code("bad", "verifier")
+
+
+async def test_exchange_code_no_endpoint(signing_key: RSAKey) -> None:
+    provider = _provider(signing_key)
+    provider._metadata = {"issuer": ISSUER}  # no token_endpoint
+    with pytest.raises(oidc.OIDCError):
+        await provider.exchange_code("c", "v")
+
+
+async def test_complete_login_ok(signing_key: RSAKey, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider(signing_key)
+
+    async def fake_exchange(code: str, verifier: str) -> dict:
+        return {"id_token": _id_token(signing_key, nonce="N", email="a@corp.com")}
+
+    monkeypatch.setattr(provider, "exchange_code", fake_exchange)
+    identity = await provider.complete_login("code", "verifier", "N")
+    assert identity == "a@corp.com"
+
+
+async def test_complete_login_forbidden(
+    signing_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(signing_key, allowed_users_glob="*@corp.com")
+
+    async def fake_exchange(code: str, verifier: str) -> dict:
+        return {"id_token": _id_token(signing_key, nonce="N", email="intruder@evil.com")}
+
+    monkeypatch.setattr(provider, "exchange_code", fake_exchange)
+    with pytest.raises(oidc.OIDCForbidden) as excinfo:
+        await provider.complete_login("code", "verifier", "N")
+    assert excinfo.value.identity == "intruder@evil.com"
+
+
+async def test_complete_login_missing_id_token(
+    signing_key: RSAKey, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = _provider(signing_key)
+
+    async def fake_exchange(code: str, verifier: str) -> dict:
+        return {"access_token": "a"}  # no id_token
+
+    monkeypatch.setattr(provider, "exchange_code", fake_exchange)
+    with pytest.raises(oidc.OIDCError):
+        await provider.complete_login("code", "verifier", "N")
+
+
+# --------------------------------------------------------------------------- #
+# HTTP seams + discovery caching (against a local aiohttp server)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def idp_server(signing_key: RSAKey):
+    """A tiny stand-in IdP serving discovery, JWKS and a token endpoint."""
+    calls = {"discovery": 0, "jwks": 0}
+
+    async def discovery(request: web.Request) -> web.Response:
+        calls["discovery"] += 1
+        base = str(request.url.origin())
+        return web.json_response(
+            {
+                "issuer": base,
+                "authorization_endpoint": base + "/authorize",
+                "token_endpoint": base + "/token",
+                "jwks_uri": base + "/jwks",
+            }
+        )
+
+    async def jwks(request: web.Request) -> web.Response:
+        calls["jwks"] += 1
+        return web.json_response({"keys": [signing_key.as_dict(private=False)]})
+
+    async def token(request: web.Request) -> web.Response:
+        form = await request.post()
+        if form.get("code") == "good":
+            return web.json_response({"id_token": "signed", "access_token": "a"})
+        return web.json_response({"error": "invalid_grant"}, status=400)
+
+    async def notjson(request: web.Request) -> web.Response:
+        return web.Response(text="nope", status=500)
+
+    app = web.Application()
+    app.router.add_get("/.well-known/openid-configuration", discovery)
+    app.router.add_get("/jwks", jwks)
+    app.router.add_post("/token", token)
+    app.router.add_route("*", "/boom", notjson)  # 500 + non-JSON body, any method
+    server = TestServer(app)
+    await server.start_server()
+    server_url = str(server.make_url(""))
+    try:
+        yield server, server_url, calls
+    finally:
+        await server.close()
+
+
+async def test_http_get_json_and_caching(idp_server) -> None:
+    server, base, calls = idp_server
+    provider = oidc.OIDCProvider(
+        _config(configuration_url=base + "/.well-known/openid-configuration")
+    )
+    md1 = await provider.metadata()
+    md2 = await provider.metadata()  # cached — no second fetch
+    assert md1["issuer"] == base.rstrip("/")
+    assert calls["discovery"] == 1
+    assert md2 is md1
+    keyset1 = await provider._key_set()
+    await provider._key_set()  # cached
+    assert calls["jwks"] == 1
+    assert keyset1 is provider._jwks
+
+
+async def test_http_get_json_non_200(idp_server) -> None:
+    server, base, _ = idp_server
+    provider = oidc.OIDCProvider(_config())
+    with pytest.raises(oidc.OIDCError):
+        await provider._http_get_json(base + "/boom")
+
+
+async def test_http_post_form_roundtrip(idp_server) -> None:
+    server, base, _ = idp_server
+    provider = oidc.OIDCProvider(_config())
+    provider._metadata = {"token_endpoint": base + "/token"}
+    provider._jwks = None
+    status, body = await provider._http_post_form(base + "/token", {"code": "good"})
+    assert status == 200
+    assert body["id_token"] == "signed"
+    # non-JSON / error body → still returns the status with an empty dict.
+    status2, body2 = await provider._http_post_form(base + "/boom", {})
+    assert status2 == 500
+    assert body2 == {}
+
+
+async def test_key_set_missing_jwks_uri(signing_key: RSAKey) -> None:
+    provider = oidc.OIDCProvider(_config())
+    provider._metadata = {"issuer": ISSUER}  # no jwks_uri
+    with pytest.raises(oidc.OIDCError):
+        await provider._key_set()

--- a/smart_vent/backend/tests/test_session.py
+++ b/smart_vent/backend/tests/test_session.py
@@ -144,3 +144,45 @@ def test_load_secret_ignores_empty_file(tmp_path):
     secret = session.load_or_create_secret(str(tmp_path))
     assert isinstance(secret, bytes) and len(secret) == 32
     assert path.read_bytes()  # rewritten with content
+
+
+# --------------------------------------------------------------------------- #
+# Signed-blob helpers (used by the OIDC login-flow state cookie, #464)
+# --------------------------------------------------------------------------- #
+
+
+def test_signed_blob_roundtrip():
+    data = {"state": "s", "verifier": "v", "nonce": "n"}
+    tok = session.issue_signed_blob(_secret(), data, ttl=600, now=1000)
+    got = session.verify_signed_blob(_secret(), tok, now=1000)
+    assert got == {**data, "iat": 1000, "exp": 1600}
+
+
+def test_signed_blob_rejects_wrong_secret_and_tamper():
+    tok = session.issue_signed_blob(_secret(), {"state": "s"}, ttl=600, now=1000)
+    assert session.verify_signed_blob(b"1" * 32, tok, now=1000) is None
+    raw, _sig = tok.split(".", 1)
+    forged = f"{raw}.{session._sign(b'1' * 32, raw.encode())}"
+    assert session.verify_signed_blob(_secret(), forged, now=1000) is None
+
+
+def test_signed_blob_rejects_expired():
+    tok = session.issue_signed_blob(_secret(), {"state": "s"}, ttl=100, now=1000)
+    assert session.verify_signed_blob(_secret(), tok, now=1099)["state"] == "s"
+    assert session.verify_signed_blob(_secret(), tok, now=1100) is None  # exp is >= exclusive
+
+
+def test_signed_blob_rejects_malformed_and_bad_exp():
+    assert session.verify_signed_blob(_secret(), "no-dot", now=1000) is None
+    bad_raw = "!!!notb64!!!"
+    sig = session._sign(_secret(), bad_raw.encode())
+    assert session.verify_signed_blob(_secret(), f"{bad_raw}.{sig}", now=1000) is None
+    # Correctly signed but the payload is a JSON list, not a dict.
+    raw = base64.urlsafe_b64encode(json.dumps([1, 2]).encode()).decode().rstrip("=")
+    tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
+    assert session.verify_signed_blob(_secret(), tok, now=1000) is None
+    # Correctly signed dict but exp missing / non-numeric.
+    for payload in ({"state": "s"}, {"state": "s", "exp": "later"}):
+        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
+        assert session.verify_signed_blob(_secret(), tok, now=1000) is None

--- a/smart_vent/backend/tests/test_session.py
+++ b/smart_vent/backend/tests/test_session.py
@@ -1,22 +1,31 @@
-"""Unit tests for the signed session-cookie module (Issue #373, backend/session.py).
+"""Unit tests for the signed session-cookie module (Issue #373/#476,
+backend/session.py — HS256 JWT via joserfc).
 
 Security-critical properties:
-* a tampered payload or signature never verifies,
+* a tampered token or a token signed by the wrong secret never verifies,
 * an expired token never verifies,
+* a token claiming a non-HS256 ``alg`` (algorithm confusion) is refused,
 * the signing secret is persisted outside app.db and reused across boots.
 """
 
 from __future__ import annotations
 
-import base64
-import json
 from types import SimpleNamespace
+
+from joserfc import jwt as _jwt
+from joserfc.jwk import OctKey, RSAKey
 
 from backend import session
 
 
 def _secret() -> bytes:
     return b"0" * 32
+
+
+def _mint(claims: dict, *, secret: bytes | None = None) -> str:
+    """Mint an HS256 JWT with arbitrary *claims* signed by *secret* — for crafting
+    edge-case tokens the public ``issue_*`` helpers won't produce."""
+    return _jwt.encode({"alg": "HS256"}, claims, OctKey.import_key(secret or _secret()))
 
 
 def test_issue_then_verify_roundtrip():
@@ -30,47 +39,51 @@ def test_verify_rejects_wrong_secret():
 
 
 def test_verify_rejects_tampered_payload():
+    # Flipping any byte of the JWT payload segment breaks the signature.
     tok = session.issue_token(_secret(), "user-abc", now=1000)
-    raw, sig = tok.split(".", 1)
-    forged_payload = (
-        base64.urlsafe_b64encode(
-            json.dumps({"sub": "admin", "iat": 1000, "exp": 9999999999}).encode()
-        )
-        .decode()
-        .rstrip("=")
-    )
-    forged = f"{forged_payload}.{sig}"
+    header, payload, sig = tok.split(".")
+    tampered_char = "A" if payload[0] != "A" else "B"
+    forged = f"{header}.{tampered_char}{payload[1:]}.{sig}"
     assert session.verify_token(_secret(), forged, now=1000) is None
+
+
+def test_verify_rejects_wrong_algorithm():
+    """A token claiming a non-HS256 alg (e.g. RS256) is refused — the
+    algorithm-confusion guard restored by pinning algorithms=['HS256']."""
+    rsa = RSAKey.generate_key(2048, auto_kid=True)
+    rs_tok = _jwt.encode({"alg": "RS256", "kid": rsa.kid}, {"sub": "u", "exp": 9999999999}, rsa)
+    assert session.verify_token(_secret(), rs_tok) is None
 
 
 def test_verify_rejects_expired():
     tok = session.issue_token(_secret(), "user-abc", now=1000, ttl=100)
-    # exp = 1100; at now=1100 it is exactly expired (>=).
-    assert session.verify_token(_secret(), tok, now=1100) is None
-    assert session.verify_token(_secret(), tok, now=1099) == "user-abc"
+    # exp = 1100; joserfc treats the token as valid up to and including exp, and
+    # expired strictly after it.
+    assert session.verify_token(_secret(), tok, now=1100) == "user-abc"
+    assert session.verify_token(_secret(), tok, now=1101) is None
 
 
 def test_verify_rejects_malformed_tokens():
     assert session.verify_token(_secret(), "no-dot-here", now=1000) is None
     assert session.verify_token(_secret(), "", now=1000) is None
-    # Correct format but the payload is not valid base64/JSON.
-    bad_raw = "!!!notb64!!!"
-    sig = session._sign(_secret(), bad_raw.encode())
-    assert session.verify_token(_secret(), f"{bad_raw}.{sig}", now=1000) is None
+    assert session.verify_token(_secret(), "a.b.c", now=1000) is None  # not real JWT segments
 
 
 def test_verify_rejects_missing_or_bad_exp():
-    for payload in ({"sub": "u", "iat": 1}, {"sub": "u", "exp": "soon"}, {"sub": "u", "exp": True}):
-        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-        tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
-        assert session.verify_token(_secret(), tok, now=1000) is None
+    # Signed by us, but exp missing / non-numeric — verification still refuses it
+    # (exp is essential, and joserfc rejects a non-numeric exp).
+    for claims in ({"sub": "u", "iat": 1}, {"sub": "u", "exp": "soon"}):
+        assert session.verify_token(_secret(), _mint(claims), now=1000) is None
 
 
 def test_verify_rejects_missing_or_nonstring_sub():
-    for payload in ({"exp": 9999999999}, {"sub": 42, "exp": 9999999999}, {"sub": "", "exp": 9}):
-        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-        tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
-        assert session.verify_token(_secret(), tok, now=1000) is None
+    # All non-expired (exp far in the future) so it's the sub check that rejects.
+    for claims in (
+        {"exp": 9999999999},
+        {"sub": 42, "exp": 9999999999},
+        {"sub": "", "exp": 9999999999},
+    ):
+        assert session.verify_token(_secret(), _mint(claims), now=1000) is None
 
 
 def test_session_user_reads_cookie():
@@ -160,29 +173,22 @@ def test_signed_blob_roundtrip():
 
 def test_signed_blob_rejects_wrong_secret_and_tamper():
     tok = session.issue_signed_blob(_secret(), {"state": "s"}, ttl=600, now=1000)
+    # Signed by us but presented with a different verifying secret → bad signature.
     assert session.verify_signed_blob(b"1" * 32, tok, now=1000) is None
-    raw, _sig = tok.split(".", 1)
-    forged = f"{raw}.{session._sign(b'1' * 32, raw.encode())}"
+    # Or forged with a different secret entirely.
+    forged = _mint({"state": "s", "exp": 9999999999}, secret=b"1" * 32)
     assert session.verify_signed_blob(_secret(), forged, now=1000) is None
 
 
 def test_signed_blob_rejects_expired():
     tok = session.issue_signed_blob(_secret(), {"state": "s"}, ttl=100, now=1000)
-    assert session.verify_signed_blob(_secret(), tok, now=1099)["state"] == "s"
-    assert session.verify_signed_blob(_secret(), tok, now=1100) is None  # exp is >= exclusive
+    assert session.verify_signed_blob(_secret(), tok, now=1100)["state"] == "s"  # valid at exp
+    assert session.verify_signed_blob(_secret(), tok, now=1101) is None  # expired after exp
 
 
 def test_signed_blob_rejects_malformed_and_bad_exp():
     assert session.verify_signed_blob(_secret(), "no-dot", now=1000) is None
-    bad_raw = "!!!notb64!!!"
-    sig = session._sign(_secret(), bad_raw.encode())
-    assert session.verify_signed_blob(_secret(), f"{bad_raw}.{sig}", now=1000) is None
-    # Correctly signed but the payload is a JSON list, not a dict.
-    raw = base64.urlsafe_b64encode(json.dumps([1, 2]).encode()).decode().rstrip("=")
-    tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
-    assert session.verify_signed_blob(_secret(), tok, now=1000) is None
-    # Correctly signed dict but exp missing / non-numeric.
-    for payload in ({"state": "s"}, {"state": "s", "exp": "later"}):
-        raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-        tok = f"{raw}.{session._sign(_secret(), raw.encode())}"
-        assert session.verify_signed_blob(_secret(), tok, now=1000) is None
+    assert session.verify_signed_blob(_secret(), "a.b.c", now=1000) is None
+    # Correctly signed but exp missing / non-numeric → refused (exp is essential).
+    for claims in ({"state": "s"}, {"state": "s", "exp": "later"}):
+        assert session.verify_signed_blob(_secret(), _mint(claims), now=1000) is None

--- a/smart_vent/config.yaml
+++ b/smart_vent/config.yaml
@@ -39,6 +39,29 @@ options:
   #         minted bearer token (default, secure).
   # false = legacy fully-open behavior on the raw ports (pre-#373).
   require_auth: true
+  # OpenID Connect single sign-on for the web UI (#464). OPTIONAL. Leave blank to
+  # keep the default Home Assistant username/password login on published ports.
+  # When oidc_configuration_url + oidc_client_id + oidc_client_secret +
+  # plenum_external_url are ALL set, the web UI shows a "Sign in with <name>"
+  # button and the password login is disabled. This closes the direct-port MFA
+  # gap (your identity provider enforces MFA) and works with no Supervisor
+  # (standalone Docker). MCP is unaffected — it keeps its bearer tokens; front the
+  # MCP port with an OIDC proxy (see docs/mcp.md) if you need SSO there. Home
+  # Assistant ingress is always trusted and never sees any of this.
+  #   oidc_configuration_url: your IdP's .well-known/openid-configuration URL
+  #   oidc_client_id / oidc_client_secret: the OAuth client you register for Plenum
+  #   oidc_scopes: space-separated scopes (must include "openid")
+  #   oidc_allowed_users_glob: glob over email/username allowed in ("*" = anyone)
+  #   oidc_provider_name: label for the button, e.g. "Authelia" or "Google"
+  #   plenum_external_url: public base URL of the web UI; the OIDC redirect URI is
+  #     <plenum_external_url>/api/auth/oidc/callback — register that at your IdP
+  oidc_configuration_url: ""
+  oidc_client_id: ""
+  oidc_client_secret: ""
+  oidc_scopes: "openid email profile"
+  oidc_allowed_users_glob: "*"
+  oidc_provider_name: ""
+  plenum_external_url: ""
 schema:
   ha_url: str
   ha_token: str
@@ -47,6 +70,13 @@ schema:
   timezone: str
   temperature_unit: str
   require_auth: bool
+  oidc_configuration_url: str
+  oidc_client_id: str
+  oidc_client_secret: password
+  oidc_scopes: str
+  oidc_allowed_users_glob: str
+  oidc_provider_name: str
+  plenum_external_url: str
 environment:
   DATA_DIR: /config
 map:

--- a/smart_vent/frontend/src/App.tsx
+++ b/smart_vent/frontend/src/App.tsx
@@ -92,7 +92,14 @@ function AuthGate({ children }: { children: React.ReactNode }) {
     );
   }
   if (phase === "login") {
-    return <Login onSuccess={check} />;
+    return (
+      <Login
+        onSuccess={check}
+        oidcEnabled={!!status?.oidc_enabled}
+        oidcProviderName={status?.oidc_provider_name || "SSO"}
+        oidcLoginUrl={status?.oidc_login_url || "/api/auth/oidc/login"}
+      />
+    );
   }
 
   const method: AuthMethod = status?.method ?? "open";

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -283,6 +283,13 @@ export interface AuthStatus {
   // How: "open" (auth off) | "ingress" (HA sidebar) | "session" (logged in) |
   // "none" (auth on, no credential → show login).
   method: "open" | "ingress" | "session" | "none";
+  // OIDC single sign-on (#464). When oidc_enabled, the login screen shows a
+  // "Sign in with {oidc_provider_name}" button that navigates to oidc_login_url
+  // instead of the HA username/password form (which is disabled server-side in
+  // this mode). Fields are absent when the backend predates this feature.
+  oidc_enabled?: boolean;
+  oidc_provider_name?: string;
+  oidc_login_url?: string;
 }
 
 export interface EventLogEntry {

--- a/smart_vent/frontend/src/pages/Login.test.tsx
+++ b/smart_vent/frontend/src/pages/Login.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import Login from "./Login";
+import { loginErrorMessage } from "./loginError";
 import * as api from "../api";
 
 vi.mock("../api");
@@ -44,5 +45,35 @@ describe("Login", () => {
     expect(btn).toBeDisabled();
     fireEvent.change(screen.getByLabelText(/Password/i), { target: { value: "b" } });
     expect(btn).not.toBeDisabled();
+  });
+
+  describe("OIDC mode (#464)", () => {
+    it("renders a 'Sign in with <provider>' link to the login endpoint, no password form", () => {
+      render(
+        <Login
+          onSuccess={vi.fn()}
+          oidcEnabled
+          oidcProviderName="Authelia"
+          oidcLoginUrl="/api/auth/oidc/login"
+        />
+      );
+      const link = screen.getByRole("link", { name: /Sign in with Authelia/i });
+      expect(link).toHaveAttribute("href", "/api/auth/oidc/login");
+      // The HA username/password form is not rendered in OIDC mode.
+      expect(screen.queryByLabelText(/Username/i)).toBeNull();
+      expect(screen.queryByLabelText(/Password/i)).toBeNull();
+      // OIDC login is a full navigation, so api.login must not be involved.
+      expect(api.login).not.toHaveBeenCalled();
+    });
+
+    it("maps login_error reasons to messages (pure helper)", () => {
+      expect(loginErrorMessage("?login_error=sso_forbidden")).toMatch(/not permitted/i);
+      expect(loginErrorMessage("?login_error=sso_state")).toMatch(/expired/i);
+      expect(loginErrorMessage("?login_error=sso_cancelled")).toMatch(/cancelled/i);
+      expect(loginErrorMessage("?login_error=sso_failed")).toMatch(/failed/i);
+      // Unknown reason → generic; no tag → null.
+      expect(loginErrorMessage("?login_error=weird")).toMatch(/Sign-in failed/i);
+      expect(loginErrorMessage("")).toBeNull();
+    });
   });
 });

--- a/smart_vent/frontend/src/pages/Login.tsx
+++ b/smart_vent/frontend/src/pages/Login.tsx
@@ -1,18 +1,40 @@
 import React, { useState } from "react";
 import { login as apiLogin } from "../api";
+import { loginErrorMessage } from "./loginError";
 
 /**
- * Direct-port login screen (#373). Shown by the App-level auth gate only when
- * `require_auth` is on AND the caller is not already authenticated (i.e. reached
- * a published port directly, not through the Home Assistant sidebar). Validates
- * against the user's Home Assistant account via the backend `/api/auth/login`
- * → Supervisor `/auth` flow; on success the backend sets an HttpOnly session
- * cookie and the gate re-checks and renders the app.
+ * Direct-port login screen (#373, #464). Shown by the App-level auth gate only
+ * when `require_auth` is on AND the caller is not already authenticated (i.e.
+ * reached a published port directly, not through the Home Assistant sidebar).
+ *
+ * Two modes, driven by the `/api/auth/status` probe:
+ *  - **OIDC single sign-on** (`oidcEnabled`, #464): renders a "Sign in with
+ *    {provider}" button that navigates to the backend `/api/auth/oidc/login`
+ *    endpoint, which redirects to the identity provider. The HA username/password
+ *    form is not shown (and is disabled server-side in this mode).
+ *  - **HA account** (default, #373): username + password validated against the
+ *    Supervisor `/auth` backend via `/api/auth/login`; on success the backend
+ *    sets an HttpOnly session cookie and the gate re-checks and renders the app.
  */
-export default function Login({ onSuccess }: { onSuccess: () => void }) {
+
+function initialLoginError(): string | null {
+  return typeof window === "undefined" ? null : loginErrorMessage(window.location.search);
+}
+
+export default function Login({
+  onSuccess,
+  oidcEnabled = false,
+  oidcProviderName = "SSO",
+  oidcLoginUrl = "/api/auth/oidc/login",
+}: {
+  onSuccess: () => void;
+  oidcEnabled?: boolean;
+  oidcProviderName?: string;
+  oidcLoginUrl?: string;
+}) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(initialLoginError);
   const [submitting, setSubmitting] = useState(false);
 
   const submit = async (e: React.FormEvent) => {
@@ -29,6 +51,33 @@ export default function Login({ onSuccess }: { onSuccess: () => void }) {
       setSubmitting(false);
     }
   };
+
+  if (oidcEnabled) {
+    return (
+      <div className="login-screen">
+        <div className="card login-card">
+          <div className="login-brand">
+            <span className="nav-icon">🌡</span> Plenum
+          </div>
+          <div className="card-title">Sign in</div>
+          <p className="form-hint login-intro">
+            Sign in with your organization account. Opening Plenum from the Home Assistant sidebar
+            signs you in automatically — this is only for accessing a directly-published port.
+          </p>
+          {error && (
+            <div className="badge badge-red login-error" role="alert">
+              {error}
+            </div>
+          )}
+          {/* A real navigation (not a fetch): the backend 302s to the IdP. Using
+              an anchor keeps it accessible (right-clickable) and testable. */}
+          <a className="btn btn-primary login-submit" href={oidcLoginUrl}>
+            Sign in with {oidcProviderName}
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="login-screen">

--- a/smart_vent/frontend/src/pages/loginError.ts
+++ b/smart_vent/frontend/src/pages/loginError.ts
@@ -1,0 +1,18 @@
+// Friendly copy for the `?login_error=<reason>` tag the OIDC callback (#464) adds
+// to the redirect URL when a single-sign-on round-trip fails. Reasons are fixed
+// backend constants (backend/api/routes.py). Kept in its own module so Login.tsx
+// stays a component-only file (React Fast Refresh / react-refresh lint rule).
+const LOGIN_ERROR_MESSAGES: Record<string, string> = {
+  sso_cancelled: "Sign-in was cancelled at the identity provider.",
+  sso_state: "Your sign-in session expired. Please try again.",
+  sso_forbidden: "Your account is not permitted to access Plenum.",
+  sso_failed: "Single sign-on failed. Please try again.",
+};
+
+/** Map a URL query string's `login_error` tag to a user message. Unknown reasons
+ * collapse to a generic message; no tag → null. */
+export function loginErrorMessage(search: string): string | null {
+  const reason = new URLSearchParams(search).get("login_error");
+  if (!reason) return null;
+  return LOGIN_ERROR_MESSAGES[reason] ?? "Sign-in failed. Please try again.";
+}

--- a/smart_vent/pyproject.toml
+++ b/smart_vent/pyproject.toml
@@ -22,6 +22,12 @@ dependencies = [
     "marshmallow>=4.3.0,<5.0",
     "marshmallow-dataclass>=8.7.1",
     "certifi",
+    # OIDC single sign-on for the web UI (#464). Authlib supplies the OAuth
+    # primitives (CSPRNG state/nonce/PKCE verifier + S256 challenge); joserfc —
+    # the maintained successor to the deprecated authlib.jose submodule — does the
+    # ID-token (JWT/JWKS) signature + claims validation. See backend/oidc.py.
+    "authlib>=1.3.0",
+    "joserfc>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -29,7 +35,6 @@ dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=4.1.0",
-    "aioresponses>=0.7.9",
     "ruff>=0.15.20",
     "mypy>=2.2.0",
     "types-python-dateutil",
@@ -60,6 +65,8 @@ module = [
   "marshmallow_dataclass.*",
   "apispec.*",
   "swagger_ui_bundle.*",
+  "authlib.*",
+  "joserfc.*",
 ]
 ignore_missing_imports = true
 

--- a/smart_vent/run.sh
+++ b/smart_vent/run.sh
@@ -46,6 +46,18 @@ TEMPERATURE_UNIT=$(get_config 'temperature_unit' '')
 # Require auth on directly-exposed ports + MCP (#373). Default 'true' (secure);
 # HA ingress is always trusted regardless. Empty add-on option → 'true'.
 REQUIRE_AUTH=$(get_config 'require_auth' 'true')
+# OIDC single sign-on for the web UI (#464). All OPTIONAL — blank means the
+# default HA username/password login is used on direct ports. Each add-on option
+# key uppercases to the exact env var the backend reads, and get_config falls
+# back to that env var when there is no Supervisor, so standalone-Docker operators
+# set OIDC_* / PLENUM_EXTERNAL_URL directly. MCP is unaffected.
+OIDC_CONFIGURATION_URL=$(get_config 'oidc_configuration_url' '')
+OIDC_CLIENT_ID=$(get_config 'oidc_client_id' '')
+OIDC_CLIENT_SECRET=$(get_config 'oidc_client_secret' '')
+OIDC_SCOPES=$(get_config 'oidc_scopes' 'openid email profile')
+OIDC_ALLOWED_USERS_GLOB=$(get_config 'oidc_allowed_users_glob' '*')
+OIDC_PROVIDER_NAME=$(get_config 'oidc_provider_name' '')
+PLENUM_EXTERNAL_URL=$(get_config 'plenum_external_url' '')
 
 
 # ---------------------------------------------------------------------------
@@ -87,8 +99,21 @@ export PORT="${PORT:-8099}"
 export MCP_PORT="${MCP_PORT:-9099}"
 export TEMPERATURE_UNIT="${TEMPERATURE_UNIT}"
 export REQUIRE_AUTH="${REQUIRE_AUTH}"
+export OIDC_CONFIGURATION_URL="${OIDC_CONFIGURATION_URL}"
+export OIDC_CLIENT_ID="${OIDC_CLIENT_ID}"
+export OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET}"
+export OIDC_SCOPES="${OIDC_SCOPES}"
+export OIDC_ALLOWED_USERS_GLOB="${OIDC_ALLOWED_USERS_GLOB}"
+export OIDC_PROVIDER_NAME="${OIDC_PROVIDER_NAME}"
+export PLENUM_EXTERNAL_URL="${PLENUM_EXTERNAL_URL}"
 
 bashio::log.info "HA_URL=${HA_URL} USE_WSS=${HA_USE_WSS} SSL_VERIFY=${HA_SSL_VERIFY} TZ=${TZ} TEMPERATURE_UNIT=${TEMPERATURE_UNIT:-auto} REQUIRE_AUTH=${REQUIRE_AUTH}"
+# Log OIDC status WITHOUT the client secret (never log secrets).
+if [ -n "${OIDC_CONFIGURATION_URL}" ]; then
+    bashio::log.info "OIDC: configured (provider='${OIDC_PROVIDER_NAME:-SSO}', external_url='${PLENUM_EXTERNAL_URL:-<unset>}', allowlist='${OIDC_ALLOWED_USERS_GLOB}')"
+else
+    bashio::log.info "OIDC: not configured (using HA username/password login on direct ports)"
+fi
 
 mkdir -p "${DATA_DIR}"
 

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.31.0-beta.24 — building toward v0.31.0
+## 0.31.0-beta.25 — building toward v0.31.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -17,3 +17,4 @@
 - Dedicated Settings page: MCP server + tokens + Backup/Restore, fix cramped MCP modal (#471) ([#472](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/472))
 - chore(Increment Beta Version) ([#473](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/473))
 - Document OIDC/OAuth2 auth-proxy option for cloud MCP connectors ([#474](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/474))
+- Add OIDC single sign-on for the web UI (#464) ([#475](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/475))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -40,6 +40,29 @@ options:
   #         minted bearer token (default, secure).
   # false = legacy fully-open behavior on the raw ports (pre-#373).
   require_auth: true
+  # OpenID Connect single sign-on for the web UI (#464). OPTIONAL. Leave blank to
+  # keep the default Home Assistant username/password login on published ports.
+  # When oidc_configuration_url + oidc_client_id + oidc_client_secret +
+  # plenum_external_url are ALL set, the web UI shows a "Sign in with <name>"
+  # button and the password login is disabled. This closes the direct-port MFA
+  # gap (your identity provider enforces MFA) and works with no Supervisor
+  # (standalone Docker). MCP is unaffected — it keeps its bearer tokens; front the
+  # MCP port with an OIDC proxy (see docs/mcp.md) if you need SSO there. Home
+  # Assistant ingress is always trusted and never sees any of this.
+  #   oidc_configuration_url: your IdP's .well-known/openid-configuration URL
+  #   oidc_client_id / oidc_client_secret: the OAuth client you register for Plenum
+  #   oidc_scopes: space-separated scopes (must include "openid")
+  #   oidc_allowed_users_glob: glob over email/username allowed in ("*" = anyone)
+  #   oidc_provider_name: label for the button, e.g. "Authelia" or "Google"
+  #   plenum_external_url: public base URL of the web UI; the OIDC redirect URI is
+  #     <plenum_external_url>/api/auth/oidc/callback — register that at your IdP
+  oidc_configuration_url: ""
+  oidc_client_id: ""
+  oidc_client_secret: ""
+  oidc_scopes: "openid email profile"
+  oidc_allowed_users_glob: "*"
+  oidc_provider_name: ""
+  plenum_external_url: ""
 schema:
   ha_url: str
   ha_token: str
@@ -48,6 +71,13 @@ schema:
   timezone: str
   temperature_unit: str
   require_auth: bool
+  oidc_configuration_url: str
+  oidc_client_id: str
+  oidc_client_secret: password
+  oidc_scopes: str
+  oidc_allowed_users_glob: str
+  oidc_provider_name: str
+  plenum_external_url: str
 environment:
   DATA_DIR: /config
 map:

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.31.0-beta.24"
+version: "0.31.0-beta.25"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
Closes #464, closes #476.

Closes the two direct-port login gaps from #373/#463 (tracked in #464):

- **Gap 1 — no MFA.** The HA username/password login validates against the Supervisor `/auth` backend, which only checks the first factor.
- **Gap 2 — no standalone login.** That path needs a Supervisor, so plain-Docker installs with `require_auth=true` were locked out (login `503`s).

Both close by pointing Plenum at an external **OpenID Connect** provider: the direct-port UI shows a **"Sign in with &lt;provider&gt;"** button, the IdP enforces MFA, and no Supervisor is required. **Ingress stays always-trusted; MCP is unchanged** (keeps its bearer tokens — front the MCP port with an OIDC proxy per `docs/mcp.md` if you want SSO there).

Per the discussion on #464: OIDC is configured **entirely outside the Plenum UI** (add-on options / container env), it **replaces** the HA-password login (which is then disabled server-side), and the button label is operator-set.

## What changed

**Backend — OIDC**
- `backend/oidc.py` — Authorization Code + PKCE flow. **Authlib** for the OAuth primitives (state/nonce/PKCE challenge); **joserfc** for ID-token signature + claims validation. Only asymmetric algorithms are accepted (`alg:none` and symmetric `HS*` refused → defeats key-confusion). All network calls sit behind small async seams so tests need no HTTP-mocking library.
- Routes `GET /api/auth/oidc/login` and `/callback`. The login-flow state (CSRF `state` + PKCE `verifier` + `nonce`) rides in a short-lived signed `SameSite=Lax` cookie; on success the callback mints the **existing** session cookie. Access is gated by a glob over email/username (default `*`).
- When OIDC is configured, `POST /api/auth/login` (HA password) returns **403** — the weaker path can't be reached even by hitting the endpoint directly.
- `/api/auth/status` now reports `oidc_enabled` / provider name / login URL.

**Frontend**
- Login screen renders "Sign in with &lt;provider&gt;" (a real anchor navigation) in OIDC mode and hides the password form; `?login_error` redirects map to friendly messages via a small pure helper.

**Config** (`config.yaml` stable + beta, `run.sh`)
- `oidc_configuration_url`, `oidc_client_id`, `oidc_client_secret` (masked `password` type), `oidc_scopes`, `oidc_allowed_users_glob`, `oidc_provider_name`, `plenum_external_url`. Each option key uppercases to the exact env var the backend reads, so standalone Docker sets them directly.

**Bespoke-auth cleanup (Closes #476)**
- A repo-wide audit of the auth code across #373/#463/#464 found `session.py`'s hand-rolled `<b64>.<b64hmac>` token was the only remaining bespoke crypto (correct, but the one candidate for delegation). It now uses **joserfc** (already pulled in for OIDC) as an **HS256 JWT** — so joserfc is the single JOSE library for the whole codebase, **with no new dependency**. Decoding pins `algorithms=["HS256"]` (restores the algorithm-confusion protection the headerless format had). Public API unchanged, so the rest of the auth code is untouched. **One-time logout** of existing direct-port sessions, since the cookie format changed.
- Dropped the unused, aiohttp-3.14-incompatible `aioresponses` dev dependency.

**Docs** — `docs/auth.md` gains an OIDC section; the MFA and standalone-Docker known-limitation bullets now point to OIDC as the remediation; session/state cookies described as HS256 JWTs.

## Test plan

- **Backend:** `pytest` **1268 passed, coverage 94.71%** (gate 93.9). New `test_oidc.py` (unit — real joserfc crypto with locally-minted keys: config/allowlist/PKCE/validation incl. wrong-key, wrong-issuer, wrong-audience, expired, nonce-mismatch, HS256-only) and `test_auth_oidc.py` (route integration: redirect+state cookie, success round-trip authenticates, state-mismatch/no-cookie/IdP-error/forbidden/failure, password-login-403, status fields). `test_session.py` reworked for the JWT format (mint/tamper via joserfc, non-HS256-alg rejection). `ruff` + `mypy` clean.
- **Frontend:** `vitest` green, coverage thresholds met; `eslint` + `prettier` clean. New Login OIDC-mode tests.
- **Config:** both `config.yaml` files validate as YAML; add-on↔`run.sh` and stable↔beta parity tests pass.
- **Not exercised end-to-end against a live IdP** (CI has no external OpenID provider — same constraint as the live Supervisor); covered by unit + integration tests with a stubbed provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)