### PR TITLE
Document REQUIRE_AUTH for standalone Docker installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ docker run -d \
   -e HA_URL=https://your-ha-instance.com \
   -e HA_TOKEN=your_long_lived_token \
   -e TIMEZONE=America/New_York \
+  -e REQUIRE_AUTH=false \
   ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
 ```
 
@@ -149,36 +150,13 @@ docker run -d \
 
 > **Important:** the `-v /path/to/data:/data` volume mount is required. Without it, `app.db` is written inside the ephemeral container layer and **all configuration is lost when the container restarts**.
 
-Open `http://localhost:8099` in your browser.
-
-#### Authentication outside Home Assistant
-
-Plenum's login screen (`require_auth`, default **on**) authenticates users against the Home Assistant Supervisor's `/auth` backend. **A standalone Docker container has no Supervisor** — so with the command above as-is, `require_auth` is on, nothing is classifiable as Home Assistant ingress, and the login screen has no backend to validate credentials against, making the UI unreachable. You have two options:
-
-**Option 1 (recommended) — set up OIDC single sign-on.** Point Plenum at your own identity provider (Authelia, Authentik, Keycloak, Google, Microsoft Entra ID, …) and it handles login — including MFA — without needing a Supervisor at all. This keeps authentication enabled. See [`docs/auth.md`](docs/auth.md#oidc-single-sign-on-optional-closes-the-two-direct-port-gaps) for the required `OIDC_*` environment variables and setup steps.
-
-**Option 2 — disable authentication.** Set `REQUIRE_AUTH=false` to run without any login:
-
-```bash
-docker run -d \
-  --name smart-vent \
-  -p 8099:8099 \
-  -v /path/to/data:/data \
-  -e DATA_DIR=/data \
-  -e HA_URL=https://your-ha-instance.com \
-  -e HA_TOKEN=your_long_lived_token \
-  -e TIMEZONE=America/New_York \
-  -e REQUIRE_AUTH=false \
-  ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
-```
-
-> **You are running Plenum without authentication.** `REQUIRE_AUTH=false` disables all login checks on both the direct web UI (`8099`) and MCP (`9099`) ports — anyone who can reach those ports on your network has full read/write control of your HVAC, no credentials required. This is the pre-#373 legacy behavior, intended for local/trusted-network testing only.
+> **You are running Plenum without authentication.** `REQUIRE_AUTH=false` is set above because Plenum's default login (`require_auth`, on by default) authenticates against the Home Assistant Supervisor's `/auth` backend — which doesn't exist in a standalone container, so without this flag the UI would be unreachable off HAOS. With it set, **anyone who can reach `8099`/`9099` on your network has full read/write control of your HVAC, no credentials required.** This is the pre-#373 legacy behavior, intended for local/trusted-network testing only.
 >
 > - **Never** publish `8099`/`9099` to the public internet while `REQUIRE_AUTH=false` is set.
-> - If you need to expose these ports beyond a trusted LAN, use **Option 1 (OIDC)** above instead, or put an authenticating reverse proxy (oauth2-proxy, Authelia, …) in front.
+> - To keep authentication enabled instead, drop the `REQUIRE_AUTH` line and configure **OIDC single sign-on** — it works without a Supervisor and supports MFA. See [`docs/auth.md`](docs/auth.md#oidc-single-sign-on-optional-closes-the-two-direct-port-gaps) for the required `OIDC_*` environment variables.
 > - This flag has no effect on Home Assistant ingress access, which is always separately trusted regardless of `REQUIRE_AUTH`.
 
-See [`docs/auth.md`](docs/auth.md) for the full trust model, including how ingress requests are told apart from direct-port ones.
+Open `http://localhost:8099` in your browser. See [`docs/auth.md`](docs/auth.md) for the full trust model, including how ingress requests are told apart from direct-port ones.
 
 ### Option C — Local development
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,35 @@ docker run -d \
 
 Open `http://localhost:8099` in your browser.
 
+#### Authentication outside Home Assistant
+
+Plenum's login screen (`require_auth`, default **on**) authenticates users against the Home Assistant Supervisor's `/auth` backend. **A standalone Docker container has no Supervisor** — so with the command above as-is, `require_auth` is on, nothing is classifiable as Home Assistant ingress, and the login screen has no backend to validate credentials against, making the UI unreachable. You have two options:
+
+**Option 1 (recommended) — set up OIDC single sign-on.** Point Plenum at your own identity provider (Authelia, Authentik, Keycloak, Google, Microsoft Entra ID, …) and it handles login — including MFA — without needing a Supervisor at all. This keeps authentication enabled. See [`docs/auth.md`](docs/auth.md#oidc-single-sign-on-optional-closes-the-two-direct-port-gaps) for the required `OIDC_*` environment variables and setup steps.
+
+**Option 2 — disable authentication.** Set `REQUIRE_AUTH=false` to run without any login:
+
+```bash
+docker run -d \
+  --name smart-vent \
+  -p 8099:8099 \
+  -v /path/to/data:/data \
+  -e DATA_DIR=/data \
+  -e HA_URL=https://your-ha-instance.com \
+  -e HA_TOKEN=your_long_lived_token \
+  -e TIMEZONE=America/New_York \
+  -e REQUIRE_AUTH=false \
+  ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
+```
+
+> **You are running Plenum without authentication.** `REQUIRE_AUTH=false` disables all login checks on both the direct web UI (`8099`) and MCP (`9099`) ports — anyone who can reach those ports on your network has full read/write control of your HVAC, no credentials required. This is the pre-#373 legacy behavior, intended for local/trusted-network testing only.
+>
+> - **Never** publish `8099`/`9099` to the public internet while `REQUIRE_AUTH=false` is set.
+> - If you need to expose these ports beyond a trusted LAN, use **Option 1 (OIDC)** above instead, or put an authenticating reverse proxy (oauth2-proxy, Authelia, …) in front.
+> - This flag has no effect on Home Assistant ingress access, which is always separately trusted regardless of `REQUIRE_AUTH`.
+
+See [`docs/auth.md`](docs/auth.md) for the full trust model, including how ingress requests are told apart from direct-port ones.
+
 ### Option C — Local development
 
 1. **Clone the repository**

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -118,6 +118,32 @@ env var of the same name, so standalone Docker sets the env var directly:
 OIDC is treated as configured only when the four required values are all set; a
 partial configuration logs a warning and leaves the HA-password login in place.
 
+**Standalone Docker example.** This is the same base command as the README's
+Option B, with the OIDC variables added instead of `REQUIRE_AUTH=false` —
+`require_auth` stays at its default `true`, so authentication is never
+disabled:
+
+```bash
+docker run -d \
+  --name smart-vent \
+  -p 8099:8099 \
+  -v /path/to/data:/data \
+  -e DATA_DIR=/data \
+  -e HA_URL=https://your-ha-instance.com \
+  -e HA_TOKEN=your_long_lived_token \
+  -e TIMEZONE=America/New_York \
+  -e OIDC_CONFIGURATION_URL=https://your-idp.example.com/.well-known/openid-configuration \
+  -e OIDC_CLIENT_ID=plenum \
+  -e OIDC_CLIENT_SECRET=your_client_secret \
+  -e PLENUM_EXTERNAL_URL=https://plenum.example.com \
+  ghcr.io/dhruvb14/smart-thermostat-with-vents:latest
+```
+
+Register `https://plenum.example.com/api/auth/oidc/callback` as the redirect
+URI at your IdP — it must exactly match `PLENUM_EXTERNAL_URL` above. Add
+`-e OIDC_ALLOWED_USERS_GLOB=...` to narrow who can sign in beyond "anyone your
+IdP authenticates".
+
 - **Flow.** Standard OAuth 2.1 **Authorization Code + PKCE**. The IdP validates
   the login (and MFA); Plenum validates the returned ID token's signature and
   claims (`joserfc`), checks the allowlist, then issues the **same** signed

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.32.0-beta.1 — building toward v0.32.0
+## 0.32.0-beta.2 — building toward v0.32.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -9,3 +9,4 @@
 **Landed on beta since v0.31.0:**
 
 - Remove redundant Validate Release CI workflow ([#478](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/478))
+- Document REQUIRE_AUTH for standalone Docker installs ([#488](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/488))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.32.0-beta.1"
+version: "0.32.0-beta.2"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## Summary

The README's **Option B — Docker (standalone / testing)** section was never updated after auth landed (#373). `require_auth` defaults to `true`, but the direct-port login authenticates against the Home Assistant Supervisor's `/auth` backend — which doesn't exist in a standalone container. Following the README's `docker run` example as written left the UI unreachable (no Supervisor to validate credentials against, and nothing classifiable as HA ingress).

**README (`Option B`)** — updated the single `docker run` command in place (no duplicate second command):
- Adds `-e REQUIRE_AUTH=false` inline, since that's required for the UI to be reachable at all off HAOS with the default config.
- Adds one prominent callout, right after the existing "Important" notes, explaining *why* the flag is there, warning that it disables all login checks on both the web UI (`8099`) and MCP (`9099`) ports, and telling readers never to publish those ports publicly while it's set.
- Points to OIDC single sign-on (`docs/auth.md`) inline as the alternative that keeps auth enabled — works without a Supervisor, supports MFA.

**`docs/auth.md`** — the OIDC section documented every `OIDC_*` env var in a table but never showed a runnable command (unlike the HA-password path). Added a "Standalone Docker example" right after the table: the same base `docker run` command as README's Option B, with the OIDC variables in place of `REQUIRE_AUTH=false`, plus a note on registering the redirect URI and narrowing sign-in with `OIDC_ALLOWED_USERS_GLOB`.

No code changes — docs only.

## Test plan

- [x] Verified `REQUIRE_AUTH` / `require_auth` env var name and default (`true`) against `smart_vent/config.yaml` and `smart_vent/run.sh`.
- [x] Verified every `OIDC_*` env var name against the existing table in `docs/auth.md`.
- [x] Verified the OIDC section anchor link from README against the heading in `docs/auth.md`.
- [x] Confirmed this is a docs-only change (no `TEMPERATURE_FIELDS`, `config.yaml` options, or API surface touched), so no parity tests apply.
- [x] `ruff check` / `ruff format --check` / frontend lint + coverage all pass unaffected (pre-commit hook ran clean on this change).
