### PR TITLE
Allow changing an existing MCP token's scope without rotating it

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -179,6 +179,9 @@ token). Tokens are minted in the UI (Settings page → **MCP access tokens**).
   dispatcher threads the granted scope, and the auth middleware rejects a call
   whose required scope exceeds it (`403`). Guarding only the 9099 layer would be
   bypassable; the REST-side check is the one that counts.
+- **Re-scoping.** `PATCH /api/mcp/tokens/{id}` changes a token's scope in place
+  without rotating its secret. Like minting and revoking, this is itself
+  destructive-scoped.
 
 ## Threat model matrix
 

--- a/smart_vent/backend/api/routes.py
+++ b/smart_vent/backend/api/routes.py
@@ -726,6 +726,34 @@ async def mcp_tokens_delete(request: web.Request) -> web.Response:
     return json_response({"deleted": True})
 
 
+@docs(tags=["mcp"], summary="Update an existing MCP bearer token's scope")
+@request_schema(schemas.McpTokenUpdateSchema)
+@response_schema(schemas.McpTokenSchema)
+@routes.patch("/api/mcp/tokens/{token_id}")
+async def mcp_tokens_update(request: web.Request) -> web.Response:
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return error("Invalid JSON body")
+    scope = body.get("scope")
+    if scope not in scopes.VALID_SCOPES:
+        return error(f"scope must be one of {', '.join(scopes.VALID_SCOPES)}")
+    token_id = request.match_info["token_id"]
+    conn = await get_conn(request)
+    updated = await db.update_mcp_token_scope(conn, token_id, scope)
+    if not updated:
+        return error("Token not found", status=404)
+    await emit(
+        request,
+        "info",
+        "auth",
+        "MCP token scope updated",
+        {"id": token_id, "scope": scope},
+    )
+    token = await db.get_mcp_token(conn, token_id)
+    return json_response(token)
+
+
 # ---------------------------------------------------------------------------
 # Rooms
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/api/schemas.py
+++ b/smart_vent/backend/api/schemas.py
@@ -251,6 +251,12 @@ class McpTokenCreateSchema(Schema):
     scope = fields.Str(required=True, metadata={"description": "read | write | destructive"})
 
 
+class McpTokenUpdateSchema(Schema):
+    """PATCH /api/mcp/tokens/{token_id} body."""
+
+    scope = fields.Str(required=True, metadata={"description": "read | write | destructive"})
+
+
 class McpTokenCreatedSchema(McpTokenSchema):
     """The mint response — carries the raw secret ONCE (never stored, never
     returned again)."""

--- a/smart_vent/backend/db.py
+++ b/smart_vent/backend/db.py
@@ -3127,6 +3127,23 @@ async def delete_mcp_token(conn: aiosqlite.Connection, token_id: str) -> bool:
     return cur.rowcount > 0
 
 
+async def get_mcp_token(conn: aiosqlite.Connection, token_id: str) -> dict | None:
+    """A single token's metadata by id (id, label, scope, timestamps) — NEVER the hash."""
+    async with conn.execute(
+        "SELECT id, label, scope, created_at, last_used_at FROM mcp_tokens WHERE id=?",
+        (token_id,),
+    ) as cur:
+        row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def update_mcp_token_scope(conn: aiosqlite.Connection, token_id: str, scope: str) -> bool:
+    """Change a token's scope in place. Returns True if a row was updated."""
+    cur = await conn.execute("UPDATE mcp_tokens SET scope=? WHERE id=?", (scope, token_id))
+    await conn.commit()
+    return cur.rowcount > 0
+
+
 # ---------------------------------------------------------------------------
 # Event log
 # ---------------------------------------------------------------------------

--- a/smart_vent/backend/tests/integration/test_mcp_tokens.py
+++ b/smart_vent/backend/tests/integration/test_mcp_tokens.py
@@ -67,6 +67,45 @@ async def test_revoke_missing_is_404(client: TestClient) -> None:
     assert (await client.delete("/api/mcp/tokens/nope")).status == 404
 
 
+async def test_update_scope(client: TestClient) -> None:
+    """Scope can be changed in place without rotating the secret."""
+    from backend.main import validate_mcp_bearer
+
+    minted = await (
+        await client.post("/api/mcp/tokens", json={"label": "t", "scope": "read"})
+    ).json()
+    token_id = minted["id"]
+    raw = minted["token"]
+
+    resp = await client.patch(f"/api/mcp/tokens/{token_id}", json={"scope": "write"})
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["scope"] == "write"
+    assert body["id"] == token_id
+    assert "token" not in body
+    assert "token_hash" not in body
+
+    tokens = await (await client.get("/api/mcp/tokens")).json()
+    assert tokens[0]["scope"] == "write"
+
+    # The original secret still validates — and resolves to the NEW scope,
+    # proving the hash was never rotated.
+    scheduler = client.app["scheduler"]
+    assert await validate_mcp_bearer(scheduler, raw) == "write"
+
+
+async def test_update_scope_validation(client: TestClient) -> None:
+    minted = await (
+        await client.post("/api/mcp/tokens", json={"label": "t", "scope": "read"})
+    ).json()
+    resp = await client.patch(f"/api/mcp/tokens/{minted['id']}", json={"scope": "admin"})
+    assert resp.status == 400
+
+
+async def test_update_missing_is_404(client: TestClient) -> None:
+    assert (await client.patch("/api/mcp/tokens/nope", json={"scope": "write"})).status == 404
+
+
 async def test_validate_mcp_bearer(client: TestClient) -> None:
     """The 9099-layer validator: a minted token's raw secret resolves to its
     scope and records last-used; an unknown token resolves to None."""
@@ -161,6 +200,35 @@ async def test_token_management_needs_destructive_scope(make_client: Callable) -
     assert (
         await client.get("/api/mcp/tokens", headers=_loopback(client, "destructive"))
     ).status == 200
+
+
+async def test_update_scope_needs_destructive_scope(make_client: Callable) -> None:
+    client = await make_client(require_auth=True)
+    # Minting itself needs destructive scope.
+    minted = await (
+        await client.post(
+            "/api/mcp/tokens",
+            json={"label": "t", "scope": "read"},
+            headers=_loopback(client, "destructive"),
+        )
+    ).json()
+    token_id = minted["id"]
+
+    # A write-scoped caller cannot update a token's scope…
+    resp = await client.patch(
+        f"/api/mcp/tokens/{token_id}",
+        json={"scope": "write"},
+        headers=_loopback(client, "write"),
+    )
+    assert resp.status == 403
+
+    # …only destructive scope can.
+    resp = await client.patch(
+        f"/api/mcp/tokens/{token_id}",
+        json={"scope": "write"},
+        headers=_loopback(client, "destructive"),
+    )
+    assert resp.status == 200
 
 
 # --------------------------------------------------------------------------

--- a/smart_vent/frontend/src/api.test.ts
+++ b/smart_vent/frontend/src/api.test.ts
@@ -520,6 +520,25 @@ describe("API Client", () => {
     );
   });
 
+  it("updateMcpTokenScope PATCHes the new scope", async () => {
+    mockJsonResponse({
+      id: "abc",
+      label: "t",
+      scope: "write",
+      created_at: "x",
+      last_used_at: null,
+    });
+    const updated = await api.updateMcpTokenScope("abc", "write");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/mcp/tokens/abc",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ scope: "write" }),
+      })
+    );
+    expect(updated.scope).toBe("write");
+  });
+
   it("removeVent sends a DELETE request", async () => {
     mockJsonResponse({});
     await api.removeVent("r1", "v1");

--- a/smart_vent/frontend/src/api.ts
+++ b/smart_vent/frontend/src/api.ts
@@ -558,6 +558,11 @@ export const mintMcpToken = (label: string, scope: McpScope) =>
   });
 export const revokeMcpToken = (id: string) =>
   api<{ deleted: boolean }>(`/api/mcp/tokens/${id}`, { method: "DELETE" });
+export const updateMcpTokenScope = (id: string, scope: McpScope) =>
+  api<McpToken>(`/api/mcp/tokens/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ scope }),
+  });
 
 export const setSystemEnabled = (enabled: boolean) =>
   api<SystemStatus>("/api/system/enabled", { method: "POST", body: JSON.stringify({ enabled }) });

--- a/smart_vent/frontend/src/components/McpTokensCard.test.tsx
+++ b/smart_vent/frontend/src/components/McpTokensCard.test.tsx
@@ -69,4 +69,57 @@ describe("McpTokensCard", () => {
     fireEvent.click(screen.getByRole("button", { name: /Mint token/i }));
     expect(await screen.findByText(/scope must be one of/i)).toBeInTheDocument();
   });
+
+  it("edits a token's scope", async () => {
+    vi.mocked(api.listMcpTokens).mockResolvedValue([
+      { id: "t1", label: "Old", scope: "read", created_at: "x", last_used_at: null },
+    ]);
+    vi.mocked(api.updateMcpTokenScope).mockResolvedValue({
+      id: "t1",
+      label: "Old",
+      scope: "write",
+      created_at: "x",
+      last_used_at: null,
+    });
+    render(<McpTokensCard />);
+    fireEvent.click(await screen.findByRole("button", { name: /Edit/i }));
+
+    const select = screen.getByLabelText(/Scope for Old/i) as HTMLSelectElement;
+    expect(select.value).toBe("read");
+    fireEvent.change(select, { target: { value: "write" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(api.updateMcpTokenScope).toHaveBeenCalledWith("t1", "write"));
+    await waitFor(() => expect(api.listMcpTokens).toHaveBeenCalledTimes(2));
+  });
+
+  it("cancels an in-progress scope edit without saving", async () => {
+    vi.mocked(api.listMcpTokens).mockResolvedValue([
+      { id: "t1", label: "Old", scope: "read", created_at: "x", last_used_at: null },
+    ]);
+    render(<McpTokensCard />);
+    fireEvent.click(await screen.findByRole("button", { name: /Edit/i }));
+
+    const select = screen.getByLabelText(/Scope for Old/i);
+    fireEvent.change(select, { target: { value: "write" } });
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+
+    expect(api.updateMcpTokenScope).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Scope for Old/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Save/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Cancel/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Revoke/i })).toBeInTheDocument();
+  });
+
+  it("shows an error when updating scope fails", async () => {
+    vi.mocked(api.listMcpTokens).mockResolvedValue([
+      { id: "t1", label: "Old", scope: "read", created_at: "x", last_used_at: null },
+    ]);
+    vi.mocked(api.updateMcpTokenScope).mockRejectedValue(new Error("scope must be one of ..."));
+    render(<McpTokensCard />);
+    fireEvent.click(await screen.findByRole("button", { name: /Edit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+    expect(await screen.findByText(/scope must be one of/i)).toBeInTheDocument();
+  });
 });

--- a/smart_vent/frontend/src/components/McpTokensCard.tsx
+++ b/smart_vent/frontend/src/components/McpTokensCard.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { listMcpTokens, mintMcpToken, revokeMcpToken, type McpToken, type McpScope } from "../api";
+import {
+  listMcpTokens,
+  mintMcpToken,
+  revokeMcpToken,
+  updateMcpTokenScope,
+  type McpToken,
+  type McpScope,
+} from "../api";
 
 const SCOPE_HELP: Record<McpScope, string> = {
   read: "Read-only: list and inspect rooms, schedules, metrics, logs.",
@@ -19,6 +26,9 @@ export default function McpTokensCard() {
   const [minting, setMinting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [freshSecret, setFreshSecret] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editScope, setEditScope] = useState<McpScope>("read");
+  const [scopeError, setScopeError] = useState<string | null>(null);
 
   const load = () => {
     listMcpTokens()
@@ -50,6 +60,28 @@ export default function McpTokensCard() {
       load();
     } catch {
       // ignore — the list will simply not change
+    }
+  };
+
+  const startEdit = (t: McpToken) => {
+    setEditingId(t.id);
+    setEditScope(t.scope);
+    setScopeError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setScopeError(null);
+  };
+
+  const saveScope = async (id: string) => {
+    try {
+      await updateMcpTokenScope(id, editScope);
+      setEditingId(null);
+      setScopeError(null);
+      load();
+    } catch (err) {
+      setScopeError(err instanceof Error ? err.message : "Failed to update scope");
     }
   };
 
@@ -121,14 +153,49 @@ export default function McpTokensCard() {
             <li key={t.id} className="mcp-token-item">
               <div>
                 <span className="mcp-token-item-label">{t.label}</span>{" "}
-                <span className={`badge badge-blue`}>{t.scope}</span>
+                {editingId === t.id ? (
+                  <div className="form-group">
+                    <select
+                      className="form-control"
+                      aria-label={`Scope for ${t.label}`}
+                      value={editScope}
+                      onChange={(e) => setEditScope(e.target.value as McpScope)}
+                    >
+                      <option value="read">read</option>
+                      <option value="write">write</option>
+                      <option value="destructive">destructive</option>
+                    </select>
+                    <div className="form-hint">{SCOPE_HELP[editScope]}</div>
+                  </div>
+                ) : (
+                  <span className={`badge badge-blue`}>{t.scope}</span>
+                )}
                 <div className="text-sm text-muted">
                   Last used: {t.last_used_at ? t.last_used_at : "never"}
                 </div>
+                {editingId === t.id && scopeError && (
+                  <span className="text-danger">{scopeError}</span>
+                )}
               </div>
-              <button className="btn btn-danger btn-sm" onClick={() => void revoke(t.id)}>
-                Revoke
-              </button>
+              {editingId === t.id ? (
+                <div>
+                  <button className="btn btn-primary btn-sm" onClick={() => void saveScope(t.id)}>
+                    Save
+                  </button>{" "}
+                  <button className="btn btn-secondary btn-sm" onClick={cancelEdit}>
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <div>
+                  <button className="btn btn-secondary btn-sm" onClick={() => startEdit(t)}>
+                    Edit
+                  </button>{" "}
+                  <button className="btn btn-danger btn-sm" onClick={() => void revoke(t.id)}>
+                    Revoke
+                  </button>
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.32.0-beta.4 — building toward v0.32.0
+## 0.32.0-beta.5 — building toward v0.32.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -12,3 +12,4 @@
 - Document REQUIRE_AUTH for standalone Docker installs ([#488](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/488))
 - ci: skip lint/container/beta pipelines on docs-only changes ([#489](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/489))
 - chore(deps): consolidate open Dependabot bumps ([#490](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/490))
+- Allow changing an existing MCP token's scope without rotating it ([#492](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/492))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.32.0-beta.4"
+version: "0.32.0-beta.5"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## Summary

Closes #491.

Adds `PATCH /api/mcp/tokens/{token_id}` to change an existing MCP bearer token's scope (`read` / `write` / `destructive`) in place, without rotating its secret. Previously the only lifecycle operations were mint (`POST`) and revoke (`DELETE`), so changing a token's permission level meant revoking it and minting a new one — forcing every MCP client using it (Claude Desktop, etc.) to be reconfigured with a new secret, since the raw secret is shown exactly once at mint time and never again.

## Changes

**Backend**
- `backend/db.py` — `get_mcp_token()` (single-token metadata lookup by id) and `update_mcp_token_scope()` (updates the `scope` column only; `token_hash`/`created_at`/`id` are untouched).
- `backend/api/schemas.py` — `McpTokenUpdateSchema` for the PATCH body.
- `backend/api/routes.py` — `PATCH /api/mcp/tokens/{token_id}` handler, following the same validation/`emit()` conventions as the existing mint/revoke handlers. This path already falls under `scopes.py`'s `_DESTRUCTIVE_PREFIXES = ("/api/mcp/tokens",)`, so updating a token's scope is itself `destructive`-scoped — a lesser-privileged token cannot re-scope itself or any other token, same as mint/revoke/list today.
- `backend/tests/integration/test_mcp_tokens.py` — new tests: valid scope update (including proof, via `validate_mcp_bearer`, that the token's secret still resolves correctly after the update — i.e. no rotation occurred), invalid scope (400), unknown token id (404), and scope-enforcement (a `write`-scoped token gets 403, a `destructive`-scoped token gets 200).

**Frontend**
- `frontend/src/api.ts` — `updateMcpTokenScope(id, scope)`.
- `frontend/src/components/McpTokensCard.tsx` — each listed token gets an "Edit" button that reveals an inline scope `<select>` (with the same help text as the mint form) plus Save/Cancel, next to the existing "Revoke" button.
- Matching test coverage in `McpTokensCard.test.tsx` and `api.test.ts`.

**Docs**
- `docs/auth.md` — one-line addition under "MCP bearer tokens" documenting the new re-scoping endpoint.

## Test plan

- [x] `python -m pytest backend/tests/ -q` — 1272 passed, 94.70% coverage (gate: 93.9%)
- [x] `ruff format --check backend/` / `ruff check backend/` — clean
- [x] `mypy backend/ --ignore-missing-imports` — no issues
- [x] `npx vitest run --coverage` (frontend) — 389 passed; statements 89.47%, branches 76.31%, functions 87.48%, lines 91.82% (all above thresholds)
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Manual diff review confirms the update path never touches `token_hash`, and that scope enforcement is verified against the real auth middleware (not just asserted)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KB36VfMCQ12KSJgVXZgzaB)_