### PR TITLE
Reopen a served room's vent when it drifts past its deadband mid-cycle

### DIFF
--- a/smart_vent/backend/engine/cycle_engine.py
+++ b/smart_vent/backend/engine/cycle_engine.py
@@ -1459,6 +1459,30 @@ class CycleEngine:
             effective_avg = avg + ar.room.temp_offset
             at_target = _is_at_target(effective_avg, rcs.target_temp, hvac_mode)
 
+            if rcs.vent_closed_at is not None:
+                # Room already served this cycle (its vent is closed). #86: a
+                # served room's small re-crossing of the target is hysteresis
+                # noise and must NOT block termination — otherwise the cycle
+                # never ends. But while a SLOWER co-active room keeps the cycle
+                # running, a served room can heat-/cool-soak far past its
+                # target with its vent shut and nothing reopens it until the
+                # cycle timeout. #423 already re-engages a drifted served room
+                # — but only inside the minimum-runtime hold (which is reached
+                # only once every room is satisfied). Generalize it here: once
+                # a served room drifts more than a FULL deadband past its
+                # (possibly eco-relaxed) target it has live demand again —
+                # reopen its vent and resume serving it in this cycle. The
+                # deadband is the hysteresis (it must climb a full band past
+                # target to re-engage, then return to target to re-close), so
+                # this cannot flap; within-band drift stays "served" per #86.
+                # The pure-target close decision (#70) is untouched.
+                band = _effective_deadband(ar.room, tc.deadband)
+                if _drifted_past_deadband(effective_avg, rcs.target_temp, hvac_mode, band):
+                    await self._reopen_drifted_room(conn, room_id, ar, rcs, avg, band)
+                    all_at_target = False
+                    blocked_only_by_floor = False
+                continue
+
             if at_target and rcs.vent_closed_at is None:
                 # Try to close the vent.
                 # Bug 6: if this is the last room whose vent still needs to close and
@@ -1571,6 +1595,71 @@ class CycleEngine:
             # HVAC at target is strictly protective. The floor is never
             # violated — the deferred closes simply never happen.
             await self._terminate_cycle(conn)
+
+    async def _reopen_drifted_room(
+        self,
+        conn: aiosqlite.Connection,
+        room_id: str,
+        ar: ActiveRoom,
+        rcs: RoomCycleState,
+        avg: float,
+        band: float,
+    ) -> None:
+        """Reopen a served room's vent after it drifted past its deadband.
+
+        Clears ``vent_closed_at`` so the room is served again in the current
+        cycle; the per-room monitor then keeps the vent open until the room
+        re-reaches target, at which point the normal close path re-closes it.
+        Opening a vent only adds airflow, so it can never breach the airflow
+        floor, and the setpoint already accounts for this room's target (it
+        never left ``_active_rooms``). ``reached_at`` is left intact so the
+        room's original time-to-target is preserved for metrics.
+        """
+        vents = self._room_vents.get(room_id, [])
+        if vents:
+            await self._vent.open_room_vents(vents)
+        rcs.vent_closed_at = None
+        rcs.temp_at_end = None
+        await db.upsert_room_cycle_state(conn, rcs)
+        drift = abs(avg + ar.room.temp_offset - rcs.target_temp)
+        log.info(
+            "Room %s drifted %.1f°F past target %.1f°F (deadband %.1f°F) — "
+            "vent reopened to resume serving",
+            ar.room.name,
+            drift,
+            rcs.target_temp,
+            band,
+        )
+        if self._cycle_log:
+            ts = datetime.now(UTC)
+            for v in vents:
+                try:
+                    await db.insert_cycle_vent_event(
+                        conn,
+                        self._cycle_log.id,
+                        ts,
+                        v.entity_id,
+                        room_id,
+                        "reopened_drift",
+                        f"avg={avg:.1f} target={rcs.target_temp} band={band}",
+                    )
+                except Exception as exc:
+                    log.debug("Failed to record reopened_drift event: %s", exc)
+        if self._logger:
+            await self._logger.log(
+                "info",
+                "engine",
+                f"Room {ar.room.name} drifted {drift:.1f}°F past its "
+                f"{rcs.target_temp}°F target (deadband {band}°F) — vent reopened "
+                "to resume serving",
+                {
+                    "room_id": room_id,
+                    "room_name": ar.room.name,
+                    "target_temp": rcs.target_temp,
+                    "avg_temp": avg,
+                    "deadband": band,
+                },
+            )
 
     async def _repair_missing_room_state(
         self, conn: aiosqlite.Connection, ar: ActiveRoom
@@ -3890,7 +3979,8 @@ class CycleEngine:
         premise no longer holds. The deadband is the hysteresis — drift within
         it never releases the hold, so the hold cannot flap at the target
         boundary. Rooms without a reading cannot vote (mirrors
-        ``_all_active_rooms_satisfied``).
+        ``_all_active_rooms_satisfied``). Uses the same ``_drifted_past_deadband``
+        predicate as the served-room reopen check in ``_monitor_rooms``.
         """
         drifted: list[str] = []
         for room_id, ar in self._active_rooms.items():
@@ -3902,12 +3992,7 @@ class CycleEngine:
                 continue
             effective = avg + ar.room.temp_offset
             band = _effective_deadband(ar.room, tc.deadband)
-            if (
-                hvac_mode == "cooling"
-                and effective > rcs.target_temp + band
-                or hvac_mode == "heating"
-                and effective < rcs.target_temp - band
-            ):
+            if _drifted_past_deadband(effective, rcs.target_temp, hvac_mode, band):
                 drifted.append(ar.room.name)
         return drifted
 
@@ -4317,4 +4402,24 @@ def _is_at_target(avg_temp: float, target_temp: float, hvac_mode: str) -> bool:
     # Unexpected mode — return False (not at target) so vents stay open
     # rather than closing prematurely.  (Issue #48 Bug 6)
     log.warning("_is_at_target called with unexpected mode %r — returning False", hvac_mode)
+    return False
+
+
+def _drifted_past_deadband(
+    effective_avg: float, target_temp: float, hvac_mode: str, band: float
+) -> bool:
+    """True if a served room has drifted MORE than *band* past its target.
+
+    This is renewed live demand — not the fraction-of-a-degree re-crossing of
+    the target that #86 deliberately treats as "served" (which would otherwise
+    block termination forever). The deadband is the hysteresis, so re-engaging
+    on this predicate cannot flap at the target boundary. Shared by the
+    min-runtime-hold release check (#423) and the served-room reopen check in
+    ``_monitor_rooms`` so the two can never diverge. Unexpected modes never
+    count as drifted.
+    """
+    if hvac_mode == "cooling":
+        return effective_avg > target_temp + band
+    if hvac_mode == "heating":
+        return effective_avg < target_temp - band
     return False

--- a/smart_vent/backend/tests/integration/test_served_room_drift_reopen.py
+++ b/smart_vent/backend/tests/integration/test_served_room_drift_reopen.py
@@ -1,0 +1,217 @@
+"""A served room that drifts past its deadband mid-cycle gets its vent reopened.
+
+Regression: ``_monitor_rooms`` only ever acted on rooms whose vent was still
+open (``vent_closed_at is None``). A room that reached target early had its vent
+closed and was then ignored for the rest of the cycle. While a *slower*
+co-active room kept the cycle running, the served room could heat-/cool-soak far
+past its target with its vent shut and nothing reopened it until the cycle
+timeout (observed in production: an office at 73.9 °F against a 70.6 °F cooling
+target, vent closed, for 30+ minutes).
+
+#423 already re-engaged a drifted served room — but only inside the
+minimum-runtime hold, which is reached only once *every* room is satisfied. This
+generalizes it to normal monitoring: past a full deadband the room has live
+demand again, so its vent reopens and the cycle keeps serving it.
+
+Pinned here:
+  - a served room drifting MORE than a deadband past target reopens its vent and
+    the cycle keeps running until it is back at target (cooling and heating);
+  - drift WITHIN the deadband keeps the vent closed — hysteresis, so the #86
+    "served rooms don't block termination" guarantee is preserved and the vent
+    cannot thrash at the target boundary;
+  - the boundary (exactly target ± deadband) does not reopen; a touch past does;
+  - the reopen is recorded as a ``reopened_drift`` vent event for the operator.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+THERMO = "climate.test_thermostat"
+A_SENSOR = "sensor.room_a"
+A_VENT = "cover.room_a_vent"
+B_SENSOR = "sensor.room_b"
+B_VENT = "cover.room_b_vent"
+
+_ATTRS = {"unit_of_measurement": "°F"}
+
+
+def _engine(client):
+    return client.app["scheduler"]._engines[THERMO]
+
+
+async def _make_room(client, name: str, sensor: str, vent: str) -> str:
+    resp = await client.post("/api/rooms", json={"name": name, "thermostat_entity_id": THERMO})
+    room_id: str = (await resp.json())["id"]
+    await client.post(f"/api/rooms/{room_id}/sensors", json={"entity_id": sensor})
+    await client.post(
+        f"/api/rooms/{room_id}/vents",
+        json={"entity_id": vent, "control_method": "open_close"},
+    )
+    return room_id
+
+
+async def _add_all_day_schedule(client, room_id: str, target_temp: float) -> None:
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    end = (now + timedelta(hours=1)).time().replace(second=0, microsecond=0)
+    await client.post(
+        f"/api/rooms/{room_id}/schedules",
+        json={
+            "days_of_week": list(range(7)),
+            "start_time": start.isoformat(timespec="minutes"),
+            "end_time": end.isoformat(timespec="minutes"),
+            "target_temp": target_temp,
+        },
+    )
+
+
+async def _start_two_room_cycle(
+    client,
+    fake_ha,
+    tick,
+    *,
+    mode: str,
+    thermo_ambient: float,
+    a_temp: float,
+    b_temp: float,
+    target: float,
+):
+    """Start a cycle with two rooms that both need conditioning.
+
+    Room B never reaches target, so the cycle keeps running the whole test —
+    exactly the state that used to strand a served Room A out of band. Minimum
+    runtime is disabled so the min-runtime hold (whose own #423 path already
+    handles drift) never engages and the normal-monitoring path is exercised.
+    """
+    hvac_action = "cooling" if mode == "cool" else "heating"
+    fake_ha.seed_state(
+        THERMO,
+        mode,
+        {"current_temperature": thermo_ambient, "temperature": target, "hvac_action": hvac_action},
+    )
+    fake_ha.seed_state(A_SENSOR, str(a_temp), _ATTRS)
+    fake_ha.seed_state(A_VENT, "open", {})
+    fake_ha.seed_state(B_SENSOR, str(b_temp), _ATTRS)
+    fake_ha.seed_state(B_VENT, "open", {})
+
+    room_a = await _make_room(client, "RoomA", A_SENSOR, A_VENT)
+    room_b = await _make_room(client, "RoomB", B_SENSOR, B_VENT)
+    await _add_all_day_schedule(client, room_a, target)
+    await _add_all_day_schedule(client, room_b, target)
+    await client.put(
+        f"/api/thermostats/{THERMO}",
+        json={"min_cycle_runtime_min": 0, "min_cycle_offtime_min": 0, "deadband": 1.0},
+    )
+
+    await tick()  # cycle starts
+    eng = _engine(client)
+    assert eng.cycle_state.value == "running"
+    return eng, room_a, room_b
+
+
+@pytest.mark.asyncio
+async def test_served_room_reopens_on_drift_past_deadband_cooling(client, fake_ha, tick) -> None:
+    eng, _room_a, _room_b = await _start_two_room_cycle(
+        client,
+        fake_ha,
+        tick,
+        mode="cool",
+        thermo_ambient=80.0,
+        a_temp=74.0,
+        b_temp=80.0,
+        target=72.0,
+    )
+
+    # RoomA reaches its 72°F target → vent closes. RoomB (80°F) keeps running.
+    await fake_ha.set_entity_state(A_SENSOR, "72.0", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "closed"
+    assert fake_ha.get_state(B_VENT)["state"] == "open"
+    assert eng.cycle_state.value == "running"
+
+    # RoomA heat-soaks 1.5°F past its 72°F target (deadband 1.0) with its vent
+    # shut — genuine renewed demand. The served-room reopen must fire.
+    await fake_ha.set_entity_state(A_SENSOR, "73.5", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "open", (
+        "a served room past its deadband must have its vent reopened"
+    )
+    assert eng.cycle_state.value == "running"
+
+    # And it is visible to the operator as a distinct vent event.
+    cycle_id = eng._cycle_log.id
+    detail = await (await client.get(f"/api/logs/{cycle_id}/detail")).json()
+    a_actions = {e["action"] for e in detail["vent_events"] if e["entity_id"] == A_VENT}
+    assert "reopened_drift" in a_actions
+
+    # Cooled back to target → the normal close path re-closes it.
+    await fake_ha.set_entity_state(A_SENSOR, "72.0", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "closed"
+    assert eng.cycle_state.value == "running"
+
+
+@pytest.mark.asyncio
+async def test_served_room_stays_closed_within_deadband(client, fake_ha, tick) -> None:
+    """Hysteresis / #86: within-band drift must NOT reopen the vent, or the
+    vent would thrash every time the served room re-crossed its target."""
+    eng, _room_a, _room_b = await _start_two_room_cycle(
+        client,
+        fake_ha,
+        tick,
+        mode="cool",
+        thermo_ambient=80.0,
+        a_temp=74.0,
+        b_temp=80.0,
+        target=72.0,
+    )
+
+    await fake_ha.set_entity_state(A_SENSOR, "72.0", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "closed"
+
+    # 73.0 is exactly target + deadband — NOT past it (strict >) → stays closed.
+    await fake_ha.set_entity_state(A_SENSOR, "73.0", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "closed", (
+        "boundary drift (exactly target + deadband) must not reopen"
+    )
+    assert eng.cycle_state.value == "running"
+
+    # A touch past the band → reopens.
+    await fake_ha.set_entity_state(A_SENSOR, "73.2", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_served_room_reopens_on_drift_past_deadband_heating(client, fake_ha, tick) -> None:
+    """Mirror image for heating: a served room cooling past target - deadband
+    reopens."""
+    eng, _room_a, _room_b = await _start_two_room_cycle(
+        client,
+        fake_ha,
+        tick,
+        mode="heat",
+        thermo_ambient=60.0,
+        a_temp=68.0,
+        b_temp=60.0,
+        target=72.0,
+    )
+
+    # RoomA warms to its 72°F target → vent closes. RoomB (60°F) keeps running.
+    await fake_ha.set_entity_state(A_SENSOR, "72.0", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "closed"
+    assert eng.cycle_state.value == "running"
+
+    # RoomA cools 1.5°F below its 72°F target (deadband 1.0) → vent reopens.
+    await fake_ha.set_entity_state(A_SENSOR, "70.5", _ATTRS)
+    await tick()
+    assert fake_ha.get_state(A_VENT)["state"] == "open", (
+        "a served room past its deadband must reopen in heating too"
+    )
+    assert eng.cycle_state.value == "running"

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,18 +1,11 @@
 # Plenum Beta — Changelog
 
-## 0.32.0-beta.8 — building toward v0.32.0
+## 0.33.0-beta.1 — building toward v0.33.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
-> heading for the next stable release (v0.32.0).
+> heading for the next stable release (v0.33.0).
 
-**Landed on beta since v0.31.0:**
+**Landed on beta since v0.32.0:**
 
-- Remove redundant Validate Release CI workflow ([#478](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/478))
-- Document REQUIRE_AUTH for standalone Docker installs ([#488](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/488))
-- ci: skip lint/container/beta pipelines on docs-only changes ([#489](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/489))
-- chore(deps): consolidate open Dependabot bumps ([#490](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/490))
-- Allow changing an existing MCP token's scope without rotating it ([#492](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/492))
-- Replace window.confirm with an in-app modal for all delete confirmations ([#494](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/494))
-- Test-suite hardening: real exceptions for HA protocol failures, new coverage, ratcheted gates ([#496](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/496))
-- Eco Suspend: temporarily disable Eco Mode per thermostat until a chosen date/time (#500) ([#501](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/501))
+- Reopen a served room's vent when it drifts past its deadband mid-cycle ([#503](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/503))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.32.0-beta.8"
+version: "0.33.0-beta.1"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## What & why

A room that reaches its target early has its vent closed and is then treated as **served** for the rest of the cycle. The per-room monitor loop in `_monitor_rooms` only ever acts on rooms whose vent is still open (`vent_closed_at is None`), so once a room is served it is neither re-checked nor reopened.

That is correct when the cycle terminates promptly. But when a **slower co-active room** keeps the cycle running, a served room can heat-/cool-soak far past its target with its vent shut — and nothing reopens it until the cycle timeout.

Observed on a production install: a cooling cycle where an upstairs office reached its target seconds after cycle start (it began just under the eco-relaxed target, so its vent closed almost immediately), while another room never reached target and kept the cycle alive. The office then heat-soaked to **~3.3 °F above its ~70.6 °F target and sat there for 30+ minutes with the vent still closed** — well past even the deadband around the (correct) eco-relaxed target. No log line was emitted; the engine silently considered the room done.

`#423` already handles a served room drifting back out of band, but **only inside the minimum-runtime hold**, which is reached only once *every* active room is satisfied. This generalizes that check to normal monitoring.

## Change

- New pure helper `_drifted_past_deadband(effective_avg, target, mode, band)`, **shared** by the min-runtime-hold release check (`_rooms_drifted_past_deadband`, #423) and the new served-room reopen path so the two can never diverge.
- New branch in `_monitor_rooms`: a room whose `vent_closed_at` is set that has drifted **more than a full deadband** past its (possibly eco-relaxed) target has live demand again → `_reopen_drifted_room` reopens its vent, clears `vent_closed_at`, and the cycle resumes serving it until it re-reaches target (where the normal pure-target close re-closes it).
- The reopen is recorded as a `reopened_drift` vent event so it is visible in the Logs cycle detail — the original incident produced no log at all.

## Safety / prior-art alignment

- **#86** (a served room's drift must not block termination): **preserved.** Within-band drift still counts as "served"; only drift *past a full deadband* re-engages. The deadband is the hysteresis (a room must climb a full band past target to reopen, then return to target to re-close), so the vent cannot flap.
- **#70** (`_is_at_target` is a pure target comparison, no deadband on completion): **untouched.** Rooms still close at pure target; the deadband gates only the *re-engage*, consistent with "deadband gates start/join".
- **#423**: this is a strict generalization of its already-accepted principle from the hold to normal running. The hold path and its tests are unchanged — a held room keeps `vent_closed_at is None`, so the new branch never fires for it.
- Reopening a vent only *adds* airflow, so it can't breach the airflow floor (#210/#213); the setpoint already accounts for the room's target (the room never left the active set).
- Related context: **#410** is the upstream reason a room ends up served-then-drifting (a room in the gap between the requested and eco-relaxed target starts a cycle already "at target"); this PR fixes the downstream consequence.

## Test plan

- `backend/tests/integration/test_served_room_drift_reopen.py` (new):
  - past-band drift reopens the served room's vent while a co-active room keeps the cycle running — **cooling and heating**;
  - within-band drift keeps the vent closed (hysteresis / #86);
  - the exact `target ± deadband` boundary does not reopen, a touch past does;
  - the reopen surfaces as a `reopened_drift` vent event.
- Existing #423 hold tests (`test_min_runtime_hold_resume.py`) unchanged and green.
- Full backend suite green (1384 passed) at the coverage ratchet (96.79% ≥ 96.7%); `ruff format` / `ruff check` / `mypy` clean.