### PR TITLE
Retry GitHub Release notes sync + add a manual repair path

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,11 +9,28 @@ name: Create Release PR
 #   5. Prepends a new section to CHANGELOG.md
 #   6. Bumps version in smart_vent/config.yaml
 #   7. Opens a PR "Release vX.Y.Z" → main for review
+#   8. Populates the GitHub Release notes for the tag (retried on failure)
+#
+# Can also be run manually (workflow_dispatch) with a `tag` input to resync
+# just step 8 for an existing release, in case it failed after the release PR
+# already merged (this happened for v0.32.0: a transient GitHub API 5xx on
+# `gh release edit` left the release page blank even though PR #502 had the
+# real notes). The resync path skips changelog/version-bump/branch/PR
+# generation entirely and reuses the body of the already-merged
+# "Release vX.Y.Z" PR verbatim.
 
 on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing release tag to resync GitHub Release notes for (e.g.
+          v0.32.0). Only touches the GitHub Release object — does not
+          regenerate CHANGELOG.md, bump versions, or reopen the release PR.
+        required: true
 
 permissions:
   contents: write
@@ -33,11 +50,22 @@ jobs:
 
       - name: Derive version and previous tag
         id: versions
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
         run: |
-          TAG="${GITHUB_REF_NAME}"                      # e.g. v0.4.0
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${DISPATCH_TAG}"                       # e.g. v0.32.0, resync-only
+          else
+            TAG="${GITHUB_REF_NAME}"                    # e.g. v0.4.0
+          fi
           VERSION="${TAG#v}"                            # e.g. 0.4.0
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "workflow_dispatch resync for ${TAG} — skipping changelog/PR generation"
+            exit 0
+          fi
 
           # Find the most recent tag that is strictly older than this one
           PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -1)
@@ -52,6 +80,7 @@ jobs:
           echo "Version: ${VERSION}, Previous boundary: ${PREV_TAG}"
 
       - name: Generate changelog entries
+        if: github.event_name == 'push'
         id: changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -144,6 +173,7 @@ jobs:
           echo "contributors_file=/tmp/contributors.txt" >> "$GITHUB_OUTPUT"
 
       - name: Update CHANGELOG.md
+        if: github.event_name == 'push'
         env:
           VERSION: ${{ steps.versions.outputs.version }}
         run: |
@@ -162,6 +192,7 @@ jobs:
           mv /tmp/CHANGELOG_new.md smart_vent/CHANGELOG.md
 
       - name: Bump version in config.yaml, pyproject.toml, and package.json
+        if: github.event_name == 'push'
         env:
           VERSION: ${{ steps.versions.outputs.version }}
         run: |
@@ -171,6 +202,7 @@ jobs:
           npm install --package-lock-only --prefix smart_vent/frontend
 
       - name: Create release branch, commit, and push
+        if: github.event_name == 'push'
         env:
           TAG: ${{ steps.versions.outputs.tag }}
           VERSION: ${{ steps.versions.outputs.version }}
@@ -185,6 +217,7 @@ jobs:
           git push origin "$BRANCH" --force
 
       - name: Open Pull Request
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.versions.outputs.tag }}
@@ -214,14 +247,40 @@ jobs:
             --head "$BRANCH" \
             --base main
 
+      - name: Fetch existing release PR body (resync path)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.versions.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          BODY=$(gh pr list --repo "$REPO" --state all --head "release/${TAG}" \
+            --json body --jq '.[0].body // empty')
+          if [ -z "$BODY" ]; then
+            echo "::error::No 'release/${TAG}' PR found to resync notes from."
+            exit 1
+          fi
+          printf '%s' "$BODY" > /tmp/pr_body.md
+
       - name: Populate GitHub Release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.versions.outputs.tag }}
-          VERSION: ${{ steps.versions.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
-          gh release edit "${TAG}" \
-            --repo "$REPO" \
-            --title "Plenum ${TAG}" \
-            --notes-file /tmp/pr_body.md
+          # gh release edit occasionally hits a transient GitHub API 5xx
+          # (this is exactly what left v0.32.0's release page blank even
+          # though its release PR had the real notes). Retry with backoff
+          # instead of failing the whole job on one hiccup.
+          for attempt in 1 2 3 4 5; do
+            if gh release edit "${TAG}" \
+              --repo "$REPO" \
+              --title "Plenum ${TAG}" \
+              --notes-file /tmp/pr_body.md; then
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed to update release notes for ${TAG}; retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "::error::Failed to populate GitHub Release notes for ${TAG} after 5 attempts."
+          exit 1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ The workflow will:
 - Bump the version in `config.yaml`, `pyproject.toml`, and `frontend/package.json`
 - Prepend a section to `CHANGELOG.md` (filtered to real feature PRs, not housekeeping)
 - Open a Release PR titled "Release vX.Y.Z"
-- Populate the GitHub Release page with the same notes
+- Populate the GitHub Release page with the same notes (retried on transient failure — see below)
 
 ## Merging the release PR
 
@@ -65,11 +65,30 @@ Never push directly to `main`, even under pressure. It bypasses CI and creates t
    ```
 4. The old broken image tag will remain in GHCR but `latest` will not point to it once the new release pushes
 
+## If the GitHub Release page is missing its title/notes
+
+The last step of `release-pr.yml` (`gh release edit`) writes the same notes
+onto the GitHub Release object. It's a single API call with no fallback if it
+merged after the release PR was already opened — a transient GitHub API 5xx
+there (as happened for v0.32.0) leaves the release page showing the bare tag
+name instead of "Plenum vX.Y.Z" and no notes, even though the release PR body
+is correct. It's now retried automatically (5 attempts, backoff) on the
+normal tag-push path, but if it still comes up blank:
+
+1. Go to **Actions → Create Release PR → Run workflow**
+2. Set **tag** to the affected release (e.g. `v0.32.0`) and run it against `main`
+3. This resync path only edits the GitHub Release notes — it does not
+   regenerate `CHANGELOG.md`, bump versions, or reopen the release PR. It
+   copies the body of the already-merged "Release vX.Y.Z" PR verbatim, so the
+   release PR must already exist (it always does by the time you'd notice
+   this — the release-notes step runs after the PR is opened).
+
 ## What triggers what
 
 | Action | Workflow | Result |
 |--------|----------|--------|
-| Push `v*.*.*` tag | `release-pr.yml` | Creates release branch, opens PR, populates GitHub Release notes |
+| Push `v*.*.*` tag | `release-pr.yml` | Creates release branch, opens PR, populates GitHub Release notes (retried on transient failure) |
+| Manual `workflow_dispatch` on `release-pr.yml` (`tag` input) | `release-pr.yml` | Resync-only repair path: re-populates GitHub Release notes for an already-tagged/PR'd release from its merged release PR body — see "If the GitHub Release page is missing its title/notes" above |
 | Open PR → main (non-release) | `container-ci.yml` → `Build (PR validation)` | Single multi-arch build, pushed as throwaway `ci-<sha>` tag; reused by smoke test + °F/°C E2E legs (#333). Skipped for docs-only diffs (see note below). |
 | Open release PR (`release/v*`) | `container-ci.yml` → `Build (PR validation)` | Build pushed as the real `:version` + `:latest`, then Trivy image scan; smoke test + °F/°C round-trip reuse that real image. A second, throwaway, single-arch image is also built with `version: CI` pinned and handed off via artifact — the visual-regression legs use *that* one, since only a `CI`-pinned build freezes volatile UI (`isCI`, `frontend/src/ci.tsx`) enough to match committed goldens. (A release PR always bumps `config.yaml`/`pyproject.toml`, so it never classifies as docs-only.) |
 | Any PR or push to main | `lint.yml` | Ruff, pytest, mypy, frontend lint+tests, Trivy source scan. Skipped for docs-only diffs (see note below). |

--- a/smart_vent_beta/CHANGELOG.md
+++ b/smart_vent_beta/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Plenum Beta — Changelog
 
-## 0.33.0-beta.1 — building toward v0.33.0
+## 0.33.0-beta.2 — building toward v0.33.0
 
 > ⚠️ **Beta channel.** Tracks the tip of `main` and may be unstable. For a
 > production install, use the **Plenum** (stable) add-on. Everything below is
@@ -9,3 +9,4 @@
 **Landed on beta since v0.32.0:**
 
 - Reopen a served room's vent when it drifts past its deadband mid-cycle ([#503](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/503))
+- Retry GitHub Release notes sync + add a manual repair path ([#504](https://github.com/dhruvb14/smart-thermostat-with-vents/pull/504))

--- a/smart_vent_beta/config.yaml
+++ b/smart_vent_beta/config.yaml
@@ -1,6 +1,6 @@
 name: "Plenum (Beta)"
 description: "BETA channel — tracks the tip of main and may be unstable. Runs fully isolated from stable Plenum (its own database and its own host ports). Currently exercising the auth refactor (#373)."
-version: "0.33.0-beta.1"
+version: "0.33.0-beta.2"
 slug: "plenum_beta"
 image: "ghcr.io/dhruvb14/plenum-beta"
 url: "https://github.com/dhruvb14/smart-thermostat-with-vents"


### PR DESCRIPTION
## What changed

`release-pr.yml`'s last step, "Populate GitHub Release notes" (`gh release edit`), had no retry. For `v0.32.0` this single API call hit a transient GitHub 503 *after* the release PR (#502) was already opened with the full changelog — so the job failed on its last step, and the release page was left showing the bare tag name with no notes even though #502 has the correct "What's new in 0.32.0" body.

Two changes:

1. **Retry the release-notes call.** Up to 5 attempts with backoff (5s, 10s, 15s, 20s) instead of failing the whole job on one API hiccup.
2. **Add a `workflow_dispatch` repair path** (`tag` input) for cases the retry still doesn't cover. It re-populates just the GitHub Release notes for an existing tag by reusing the body of its already-merged "Release vX.Y.Z" PR verbatim — it does not touch `CHANGELOG.md`, version bumps, or the release branch/PR (those already merged). The normal tag-push steps are guarded to only run on the `push` trigger; the resync path fetches the PR body via `gh pr list --head release/<tag>` instead.

`RELEASE.md` documents the new repair path ("If the GitHub Release page is missing its title/notes") and the trigger table gets a row for the new `workflow_dispatch` input.

## Why

Root-caused from the live `v0.32.0` release: the tag-push run (`Create Release PR`, run #81) completed 8 of 9 steps successfully — changelog generated, `CHANGELOG.md` updated, versions bumped, PR #502 opened with the correct body — and only the final `gh release edit` call failed, with the job logs showing `HTTP 503: No server is currently available to service your request.` This failure is invisible from the release PR itself (the workflow is `push: tags:`-triggered, not `pull_request:`-triggered, so it produces no check on the PR), which is how it went unnoticed until merge.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-pr.yml'))"` — YAML parses
- [ ] CI (lint + container-ci) green on this PR
- [ ] After merge: manually dispatch `Create Release PR` with `tag=v0.32.0` to backfill the live release notes, and confirm the release page shows title "Plenum v0.32.0" and the full changelog
- [ ] Next real `vX.Y.Z` tag push still produces a correctly-titled/populated release (regression check on the normal path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NscRRWmxbev7DCivtAoQdu)_